### PR TITLE
fix: reset recipient name and account number on institution change

### DIFF
--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -186,8 +186,9 @@ export const RecipientDetailsForm = ({
   useEffect(() => {
     if (selectedInstitution) {
       register("institution", { value: selectedInstitution.code });
-      // Reset recipient name when bank changes
+      // Reset recipient name and account number when bank changes
       setValue("recipientName", "");
+      setValue("accountIdentifier", "");
       setRecipientNameError("");
     }
   }, [selectedInstitution, register, setValue]);


### PR DESCRIPTION
This pull request includes a small update to the `RecipientDetailsForm` component in the `app/components/recipient/RecipientDetailsForm.tsx` file. The change ensures that both the recipient name and account number are reset when the selected bank changes.

* [`app/components/recipient/RecipientDetailsForm.tsx`](diffhunk://#diff-f55d357dcca48e1e9293ccf2650c905b319905f7a6f077bb88259f45ca905dd3L189-R191): Updated the `useEffect` hook to reset the `accountIdentifier` field in addition to the `recipientName` field when the selected bank (`selectedInstitution`) changes.