### PR TITLE
feat: implement user ID tracking on wallet connection and funding events

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -9,6 +9,7 @@ import { WalletDetails } from "./WalletDetails";
 import { NetworksDropdown } from "./NetworksDropdown";
 import { SettingsDropdown } from "./SettingsDropdown";
 import { trackEvent } from "../hooks/analytics";
+import mixpanel from "mixpanel-browser";
 
 export const Navbar = () => {
   const [mounted, setMounted] = useState(false);
@@ -18,8 +19,18 @@ export const Navbar = () => {
   const { ready, authenticated } = usePrivy();
 
   const { login } = useLogin({
-    onComplete: () => {
+    onComplete: ({ user, isNewUser, loginMethod }) => {
       trackEvent("wallet_connected");
+
+      mixpanel.identify(user.wallet?.address);
+
+      mixpanel.people.set({
+        login_method: loginMethod,
+        $last_login: new Date(),
+        $signup_date: user.createdAt,
+        $email: user.email,
+        isNewUser,
+      });
     },
   });
 

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -20,12 +20,20 @@ export const WalletDetails = () => {
   const [isTransferModalOpen, setIsTransferModalOpen] =
     useState<boolean>(false);
 
+  const { selectedNetwork } = useNetwork();
   const { smartWalletBalance, allBalances, refreshBalance } = useBalance();
 
   const { user } = usePrivy();
   const { fundWallet } = useFundWallet({
-    onUserExited: () => {
+    onUserExited: ({ fundingMethod, balance, chain, address }) => {
       refreshBalance();
+      trackEvent("funding_completed", {
+        wallet: "smart_wallet",
+        address,
+        network: chain.name,
+        fundingType: fundingMethod,
+        amount: balance,
+      });
     },
   });
   const handleFundWallet = async (address: string) => await fundWallet(address);
@@ -44,8 +52,6 @@ export const WalletDetails = () => {
     ref: dropdownRef,
     handler: () => setIsOpen(false),
   });
-
-  const { selectedNetwork } = useNetwork();
 
   const tokens: { name: string; imageUrl: string | undefined }[] = [];
   const fetchedTokens: Token[] =
@@ -137,6 +143,9 @@ export const WalletDetails = () => {
                         onClick={() => {
                           handleFundWallet(smartWallet?.address ?? "");
                           setIsOpen(false);
+                          trackEvent("fund_wallet", {
+                            wallet: "smart_wallet",
+                          });
                         }}
                         className="font-medium text-lavender-500"
                       >


### PR DESCRIPTION
This pull request introduces functionality for tracking user interactions and events using Mixpanel in the `Navbar` and `WalletDetails` components. The most important changes include importing the Mixpanel library, identifying users, and tracking various events such as wallet connections and funding completions.

### Tracking user interactions with Mixpanel:

* [`app/components/Navbar.tsx`](diffhunk://#diff-9bdebf4ad9f663cb4edcaad6eb7093480dea11a66830384e2d11c399002fd8faR13): Imported the Mixpanel library and added user identification and event tracking in the `onComplete` callback of the `useLogin` hook. This includes setting user properties such as id (wallet address), login method, last login date, signup date, email, and whether the user is new. [[1]](diffhunk://#diff-9bdebf4ad9f663cb4edcaad6eb7093480dea11a66830384e2d11c399002fd8faR13) [[2]](diffhunk://#diff-9bdebf4ad9f663cb4edcaad6eb7093480dea11a66830384e2d11c399002fd8faL21-R33)

* [`app/components/WalletDetails.tsx`](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R23-R36): Added event tracking for wallet funding completion in the `onUserExited` callback of the `useFundWallet` hook, capturing details like wallet type, address, network, funding method, and amount.

* [`app/components/WalletDetails.tsx`](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0L43-L44): Removed redundant declaration of `selectedNetwork` and added event tracking for the `fund_wallet` action when the user clicks to fund their wallet. [[1]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0L43-L44) [[2]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R141-R143)

### Test Results from Mixpanel

![image](https://github.com/user-attachments/assets/6d4e3dee-a89f-4bb4-a2e1-7d7881cf1657)

#### every event tracked includes the user ID:

![image](https://github.com/user-attachments/assets/5db629c1-8c23-45ff-a1f0-970567fcc4a0)

#### data sent back after funding account

![image](https://github.com/user-attachments/assets/14d0016f-a4e3-4fb4-97bf-9a7159bc8b35)
