### PR TITLE
fix: remove character limit on numeric input fields

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -110,7 +110,7 @@ export const TransactionForm = ({
           Number((Number(amountReceived) / rate).toFixed(4)),
         );
       } else {
-        setValue("amountReceived", Number((rate * amountSent).toFixed(4)));
+        setValue("amountReceived", Number((rate * amountSent).toFixed(2)));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -211,12 +211,12 @@ export const TransactionForm = ({
 
                   const value = Number(inputValue);
                   if (isNaN(value) || value < 0) return;
-                  if (
-                    inputValue.includes(".") &&
-                    inputValue.split(".")[1]?.length > 4
-                  )
-                    return;
-                  if (value > 10000) return;
+
+                  // Only limit decimal places, allow any whole number
+                  if (inputValue.includes(".")) {
+                    const decimals = inputValue.split(".")[1];
+                    if (decimals?.length > 4) return;
+                  }
 
                   formMethods.setValue("amountSent", value, {
                     shouldValidate: true,
@@ -275,7 +275,7 @@ export const TransactionForm = ({
               <input
                 id="amount-received"
                 type="number"
-                step="0.0001"
+                step="0.01"
                 onChange={(e) => {
                   let inputValue = e.target.value;
 
@@ -288,12 +288,12 @@ export const TransactionForm = ({
 
                   const value = Number(inputValue);
                   if (isNaN(value) || value < 0) return;
-                  if (
-                    inputValue.includes(".") &&
-                    inputValue.split(".")[1]?.length > 4
-                  )
-                    return;
-                  if (value > 10000) return;
+
+                  // Only limit decimal places to 2 for receive amount
+                  if (inputValue.includes(".")) {
+                    const decimals = inputValue.split(".")[1];
+                    if (decimals?.length > 2) return;
+                  }
 
                   formMethods.setValue("amountReceived", value, {
                     shouldValidate: true,


### PR DESCRIPTION
Also limited fiat (receive) amount to 2 decimal places to match standard currency format

### Description

## Primary Fix
- Fixed input field bug that prevented entering numbers longer than 4 digits
- Users can now enter any length of whole numbers (only limited by max value of 10,000)
- Previous implementation incorrectly limited the length of the whole number part

## Additional Improvement
- Limited fiat (receive) amount to 2 decimal places to match standard currency format
- Kept crypto (send) amount at 4 decimal places


## Testing
- Verified numbers like 12345 can now be entered (though invalid if >10000)
- Confirmed decimal place limits work correctly:
  - Send amount: up to 4 decimal places (e.g. 1234.5678)
  - Receive amount: up to 2 decimal places (e.g. 1234.56)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
