### PR TITLE
feat: add provider-specific rate fetching via LP URL param

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -15,14 +15,15 @@ const AGGREGATOR_URL = process.env.NEXT_PUBLIC_AGGREGATOR_URL;
 
 export const fetchRate = async ({
   token,
-  amount,
+  amount = 1,
   currency,
+  providerId,
 }: RatePayload): Promise<RateResponse> => {
   try {
-    const response = await axios.get(
-      `${AGGREGATOR_URL}/rates/${token}/${amount}/${currency}`,
-    );
-    return response.data;
+    const endpoint = `${AGGREGATOR_URL}/rates/${token}/${amount}/${currency}${providerId ? `?provider_id=${providerId}` : ""}`;
+    const response = await fetch(endpoint);
+    const data = await response.json();
+    return data;
   } catch (error) {
     console.error("Error fetching rate:", error);
     throw error;
@@ -73,7 +74,9 @@ export const fetchOrderDetails = async (
   orderId: string,
 ): Promise<OrderDetailsResponse> => {
   try {
-    const response = await axios.get(`${AGGREGATOR_URL}/orders/${chainId}/${orderId}`);
+    const response = await axios.get(
+      `${AGGREGATOR_URL}/orders/${chainId}/${orderId}`,
+    );
     return response.data;
   } catch (error) {
     console.error("Error fetching order details:", error);

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -20,11 +20,23 @@ export const fetchRate = async ({
   providerId,
 }: RatePayload): Promise<RateResponse> => {
   try {
-    const endpoint = `${AGGREGATOR_URL}/rates/${token}/${amount}/${currency}${providerId ? `?provider_id=${providerId}` : ""}`;
-    const response = await fetch(endpoint);
-    const data = await response.json();
+    const endpoint = `${AGGREGATOR_URL}/rates/${token}/${amount}/${currency}`;
+    const params = providerId ? { provider_id: providerId } : undefined;
+
+    const response = await axios.get(endpoint, { params });
+    const { data } = response;
+
+    // Check the API response status first
+    if (data.status === "error") {
+      throw new Error(data.message || "Provider not found");
+    }
+
     return data;
   } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message || error.message;
+      throw new Error(message);
+    }
     console.error("Error fetching rate:", error);
     throw error;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import Cookies from "js-cookie";
+import { useSearchParams } from "next/navigation";
 
 import {
   AnimatedPage,
@@ -34,6 +35,7 @@ export default function Home() {
   const { authenticated } = usePrivy();
   const { currentStep, setCurrentStep } = useStep();
   const { selectedNetwork } = useNetwork();
+  const searchParams = useSearchParams();
 
   const [isPageLoading, setIsPageLoading] = useState(true);
   const [isFetchingRate, setIsFetchingRate] = useState(false);
@@ -150,10 +152,12 @@ export default function Home() {
 
     const getRate = async () => {
       setIsFetchingRate(true);
+      const providerId = searchParams.get("LP");
       const rate = await fetchRate({
         token,
         amount: amountSent || 1,
         currency,
+        providerId: providerId || undefined,
       });
       setRate(rate.data);
       setIsFetchingRate(false);
@@ -169,7 +173,7 @@ export default function Home() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [amountSent, currency, token]);
+  }, [amountSent, currency, token, searchParams]);
 
   const handleFormSubmit = (data: FormData) => {
     setFormValues(data);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -191,9 +191,7 @@ export default function Home() {
             lpParam &&
             !failedProviders.current.has(lpParam)
           ) {
-            toast.error(error.message, {
-              description: "Using public queue",
-            });
+            toast.error(`${error.message} - defaulting to public rate`);
 
             // Track failed provider
             if (lpParam) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -113,6 +113,7 @@ export type RatePayload = {
   token: string;
   amount?: number;
   currency: string;
+  providerId?: string;
 };
 
 export type RateResponse = {


### PR DESCRIPTION
### Description

This PR adds support for fetching rates from specific liquidity providers by adding a new URL parameter `LP`. This allows users to get quotes from their preferred providers and enables direct deep linking to specific provider rates.

Key changes:
- Added `providerId` optional parameter to rate fetching
- Modified rate API endpoint to support provider filtering
- Updated types to include provider ID in rate payloads
- Added URL parameter extraction and handling
- Added failed providers tracking to prevent repeated failed requests
- Improved error handling with automatic fallback to public queue

Example usage:

```
https://noblocks.xyz/?LP=sampleID             // Gets rates only from sampleID provider
https://noblocks.xyz/                         // Gets rates from all providers (default behavior)
```

Error handling improvements:
- Track failed providers in a Set to prevent repeated failed requests
- Show error toast only once per provider
- Automatically skip failed providers in subsequent requests
- Fallback to public queue when provider fails
- Reset error tracking only for new providers
- Track provider errors in analytics for monitoring

No breaking changes were introduced. The system gracefully handles:
- With provider ID: Returns rates from specific provider
- Without provider ID: Returns rates from all providers
- Failed provider: Automatically falls back to public queue
- Subsequent requests: Skips known failed providers
### Network Requests
Here are the network requests showing the endpoint behavior:

#### Without the LP parameter

![image](https://github.com/user-attachments/assets/76880935-289f-4645-ba15-a2af38316618)

#### With the LP parameter

![image](https://github.com/user-attachments/assets/2794d1f2-b5c7-4c40-8639-0ecf6cd718aa)

#### With the wrong provider ID

- the user gets a toast that the ID is invalid, defaults to public rate

![image](https://github.com/user-attachments/assets/0a022141-de2d-4d5c-a8c6-8d73dfd462c7)

### References

Closes #25

### Testing

#### Test Cases
1. Visit app with ?LP=sampleID
   - Verify only etoMCRIY provider rates are returned
   - Check rate updates work correctly

2. Visit app without LP parameter  
   - Verify all provider rates are returned 
   - Check rate updates work as before

3. Test with invalid provider ID
   - Verify appropriate error handling
   - Check automatic fallback to public queue
   - Verify error toast shows only once
   - Confirm subsequent requests skip failed provider

Manual testing steps:
1. Start app locally
2. Test both URL variants
3. Verify rate fetching in network tab
4. Check error cases

- [x] This change adds test coverage for new/changed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used (`main`)