### PR TITLE
fix: wrap useSearchParams in Suspense to resolve build error

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useForm } from "react-hook-form";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, Suspense, JSX } from "react";
 import { AnimatePresence } from "framer-motion";
 import Cookies from "js-cookie";
 import { useSearchParams } from "next/navigation";
@@ -32,11 +32,10 @@ import { useNetwork } from "./context/NetworksContext";
  * Represents the Home component.
  * This component handles the logic and rendering of the home page.
  */
-export default function Home() {
+function HomeImpl({ searchParams }: { searchParams: URLSearchParams }) {
   const { authenticated } = usePrivy();
   const { currentStep, setCurrentStep } = useStep();
   const { selectedNetwork } = useNetwork();
-  const searchParams = useSearchParams();
 
   const [isPageLoading, setIsPageLoading] = useState(true);
   const [isFetchingRate, setIsFetchingRate] = useState(false);
@@ -308,5 +307,22 @@ export default function Home() {
         <AnimatedPage componentKey={currentStep}>{renderStep()}</AnimatedPage>
       </AnimatePresence>
     </>
+  );
+}
+
+function SearchParamsWrapper(props: {
+  children: (sp: URLSearchParams) => JSX.Element;
+}) {
+  const searchParams = useSearchParams();
+  return props.children(searchParams);
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SearchParamsWrapper>
+        {(sp) => <HomeImpl searchParams={sp} />}
+      </SearchParamsWrapper>
+    </Suspense>
   );
 }


### PR DESCRIPTION
### Description

This PR fixes the recent build error by wrapping the page’s `useSearchParams` call in a Suspense boundary to prevent client-side forced rendering and resolve the missing Suspense boundary build issue.

This pull request includes changes to the `app/page.tsx` file to enhance the component structure and improve the handling of search parameters. The most important changes include the addition of new imports, the refactoring of the `Home` component, and the introduction of a new `SearchParamsWrapper` component.

Component structure improvements:

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L3-R3): Added `Suspense` and `JSX` to the import statement to support asynchronous rendering and JSX elements.
* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L35-L39): Refactored the `Home` component to `HomeImpl` and updated the function signature to accept `searchParams` as a prop.
* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R312-R328): Introduced a new `SearchParamsWrapper` component to encapsulate the logic for retrieving search parameters and passing them to child components.
* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R312-R328): Created a new `Page` component that uses `Suspense` to wrap the `SearchParamsWrapper` and render the `HomeImpl` component with the retrieved search parameters.


### Testing

1. Install all dependencies by running:
   `npm ci`

2. Then run the build command:
   `npm run build`

3. Verify the build completes without errors.

4. Finally, launch your application locally (e.g., npm run start) and ensure the page functions correctly without remaining blank.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
