### PR TITLE
fix: replace loading fallback with Preloader component in Suspense

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -319,7 +319,7 @@ function SearchParamsWrapper(props: {
 
 export default function Page() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<Preloader isLoading={true} />}>
       <SearchParamsWrapper>
         {(sp) => <HomeImpl searchParams={sp} />}
       </SearchParamsWrapper>


### PR DESCRIPTION
### Description

This pull request includes a change to the `app/page.tsx` file to improve the user experience by updating the fallback component in the `Suspense` wrapper.

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L322-R322): Replaced the fallback component in the `Suspense` wrapper from a simple `<div>Loading...</div>` to a more informative `<Preloader isLoading={true} />` component.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
