### PR TITLE
fix: update Kenya mobile money code for SAFARICOM (MPESA) to correct value

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -313,7 +313,7 @@ export function getGatewayContractAddress(network = ""): string | undefined {
 export const kenyaMobileMoneyOptions: InstitutionProps[] = [
   {
     name: "SAFARICOM (MPESA)",
-    code: "MPESA",
+    code: "SAFAKEPC",
     type: "mobile_money",
   },
   {


### PR DESCRIPTION
### Description

This pull request includes a change to the `kenyaMobileMoneyOptions` array in the `app/utils.ts` file. The change updates the code for the "SAFARICOM (MPESA)" institution from "MPESA" to "SAFAKEPC".

* [`app/utils.ts`](diffhunk://#diff-9ba22a4ee607f76b338e5793ffbb2eae933b1b432aba0fbcd3a3fd14c9efbb1bL316-R316): Updated the `code` for "SAFARICOM (MPESA)" from "MPESA" to "SAFAKEPC".

![image](https://github.com/user-attachments/assets/18e6c1ff-42be-45e9-801d-fefcd517e027)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
