### PR TITLE
fix: enable form validation when setting max balance amount

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -96,7 +96,7 @@ export const TransactionForm = ({
 
   const handleBalanceMaxClick = () => {
     if (balance > 0) {
-      setValue("amountSent", balance);
+      setValue("amountSent", balance, { shouldValidate: true });
       setIsReceiveInputActive(false);
     }
   };


### PR DESCRIPTION
### Description

This pull request enhances the swap functionality by enabling form validation when the user clicks the "Max" button. This ensures that the form inputs are validated, improving the overall user experience.


### References



### Testing



- [] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
