### PR TITLE
feat: improve URL handling with useSearchParams hook

### DIFF
--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -10,14 +10,15 @@ import { networks } from "../mocks";
 import { useNetwork } from "../context/NetworksContext";
 import { AnimatedModal } from "./AnimatedComponents";
 import { shouldUseInjectedWallet, handleNetworkSwitch } from "../utils";
+import { useSearchParams } from "next/navigation";
 
 export const NetworkSelectionModal = () => {
+  const searchParams = useSearchParams();
   const [isOpen, setIsOpen] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const [hasCheckedStorage, setHasCheckedStorage] = useState(false);
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { authenticated, user } = usePrivy();
-  const searchParams = new URLSearchParams(window.location.search);
   const useInjectedWallet = shouldUseInjectedWallet(searchParams);
 
   useEffect(() => {

--- a/app/components/NetworksDropdown.tsx
+++ b/app/components/NetworksDropdown.tsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { toast } from "sonner";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 import { networks } from "../mocks";
 import {
@@ -20,8 +21,8 @@ interface NetworksDropdownProps {
 export const NetworksDropdown = ({
   iconOnly = false,
 }: NetworksDropdownProps) => {
+  const searchParams = useSearchParams();
   const { isFormStep } = useStep();
-  const searchParams = new URLSearchParams(window.location.search);
   const useInjectedWallet = shouldUseInjectedWallet(searchParams);
 
   iconOnly = !isFormStep;

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useState,
   useEffect,
+  Suspense,
 } from "react";
 import { createWalletClient, custom } from "viem";
 import { toast } from "sonner";
@@ -25,11 +26,7 @@ const InjectedWalletContext = createContext<InjectedWalletContextType>({
   injectedReady: false,
 });
 
-export const InjectedWalletProvider = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
+function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
   const [isInjectedWallet, setIsInjectedWallet] = useState(false);
   const [injectedAddress, setInjectedAddress] = useState<string | null>(null);
@@ -99,6 +96,18 @@ export const InjectedWalletProvider = ({
     >
       {children}
     </InjectedWalletContext.Provider>
+  );
+}
+
+export const InjectedWalletProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  return (
+    <Suspense fallback={null}>
+      <InjectedWalletProviderContent>{children}</InjectedWalletProviderContent>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
### Description

This pull request includes several changes to improve the handling of search parameters and the structure of the `InjectedWalletProvider` component. The most important changes include refactoring the use of `searchParams` to use `next/navigation`, and restructuring the `InjectedWalletProvider` to include a `Suspense` fallback.

Improvements to search parameter handling:

* [`app/components/NetworkSelectionModal.tsx`](diffhunk://#diff-003f8681a0a763f0ca123183e908e9519a7afed953763acc146200146eb04eabR13-L20): Replaced the usage of `URLSearchParams` with `useSearchParams` from `next/navigation` for better integration with Next.js.
* [`app/components/NetworksDropdown.tsx`](diffhunk://#diff-241e6c4fddddee25f9d81714380c6763a22f43ba9f80710835e9b61eb6524665R5): Similar to `NetworkSelectionModal`, replaced `URLSearchParams` with `useSearchParams` from `next/navigation`. [[1]](diffhunk://#diff-241e6c4fddddee25f9d81714380c6763a22f43ba9f80710835e9b61eb6524665R5) [[2]](diffhunk://#diff-241e6c4fddddee25f9d81714380c6763a22f43ba9f80710835e9b61eb6524665R24-L24)

Restructuring of `InjectedWalletProvider`:

* [`app/context/InjectedWalletContext.tsx`](diffhunk://#diff-258a107366df5d4449fca355184070dd7e4327cec06e7daa152d0f7a46756a4eL28-R29): Split the `InjectedWalletProvider` into two components, `InjectedWalletProviderContent` and `InjectedWalletProvider`, with the latter wrapping the former in a `Suspense` component. This change improves the handling of asynchronous operations within the provider. [[1]](diffhunk://#diff-258a107366df5d4449fca355184070dd7e4327cec06e7daa152d0f7a46756a4eL28-R29) [[2]](diffhunk://#diff-258a107366df5d4449fca355184070dd7e4327cec06e7daa152d0f7a46756a4eR100-R111)

Additional minor changes:

* [`app/context/InjectedWalletContext.tsx`](diffhunk://#diff-258a107366df5d4449fca355184070dd7e4327cec06e7daa152d0f7a46756a4eR8): Added `Suspense` import to support the new provider structure.
