### PR TITLE
fix:  Swap button disabling issue for values with more than 4 decimal places

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -103,7 +103,8 @@ export const TransactionForm = ({
 
   const handleBalanceMaxClick = () => {
     if (balance > 0) {
-      setValue("amountSent", balance, { shouldValidate: true });
+      const maxAmount = balance.toFixed(4);
+      setValue("amountSent", parseFloat(maxAmount), { shouldValidate: true });
       setIsReceiveInputActive(false);
     }
   };

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -123,9 +123,10 @@ export const TransactionForm = ({
     // Add commas to the integer part
     const integerPart = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
-    // Preserve the decimal part if it exists
+    // Preserve the decimal part if it exists, ensuring max 4 decimal places
     if (parts.length > 1) {
-      return `${integerPart}.${parts[1]}`;
+      const decimalPart = parts[1].slice(0, 4); // Limit to 4 decimal places
+      return `${integerPart}.${decimalPart}`;
     }
 
     return integerPart;


### PR DESCRIPTION
### Description

This pull request enhance swap functionality by converting balance to 4 decimal place when user click for 'Max' button



### References
https://github.com/paycrest/noblocks/issues/83


### Testing



- [] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
