### PR TITLE
fix: update selected token when selected network is changed to another

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -187,6 +187,12 @@ export const TransactionForm = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(function initSelectedToken() {
+    if (!fetchedTokens.find(t => t.symbol === token) && fetchedTokens.length > 0) {
+      setValue('token', fetchedTokens[0].symbol);
+    }
+  }, [selectedNetwork.chain.name]);
+
   useEffect(
     function checkKycStatus() {
       const walletAddressToCheck = isInjectedWallet


### PR DESCRIPTION
### Description

This pull request includes change of `TransactoinForm.tsx` and it is related with issue #102. Implemented feature is like below.
1. When User select token and change the network.
2. If the selected token is not supported 
3. Set the selected token as the first token of supported tokens.

### References

>
> [BUG] Incorrect token display when switching networks #102 
> Closes #102 

###Impacts
> Implemented one useEffect hook in `TransactionForm.tsx`
> If `selctedNetwork.chain.name` is changed run `initSelectedToken`

### Testing

1. Go to the swap page on the Arbitrum network.
2. Select USDT as the token.
3. Switch the network to Base.
4. Observe that the displayed selected token is changed USDC(first token of Base).


### Checklist

- [x ] I have added documentation and tests for new/changed functionality in this PR
- [x ] All active GitHub checks for tests, formatting, and security are passing
- [x ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).