### PR TITLE
feat: Disconnect external wallets on sign-out

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -162,11 +162,8 @@ export const MobileDropdown = ({
     setIsLoggingOut(true);
     try {
       // Disconnect external wallet if connected
-      if (isInjectedWallet) {
-        await disconnectWallet();
-      }
-
       await logout();
+      await disconnectWallet();
       onClose();
     } catch (error) {
       console.error("Error during logout:", error);

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -163,7 +163,9 @@ export const MobileDropdown = ({
     try {
       // Disconnect external wallet if connected
       await logout();
-      await disconnectWallet();
+      if (window.ethereum) {
+        await disconnectWallet();
+      }
       onClose();
     } catch (error) {
       console.error("Error during logout:", error);

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -19,6 +19,9 @@ import {
 import { toast } from "sonner";
 import config from "@/app/lib/config";
 import { useInjectedWallet } from "../context";
+import { createWalletClient, custom } from 'viem'
+import { trackEvent } from '../hooks/analytics'
+import { useWalletDisconnect } from '../hooks/useWalletDisconnect';
 
 export const SettingsDropdown = () => {
   const { user, exportWallet, updateEmail } = usePrivy();
@@ -62,9 +65,22 @@ export const SettingsDropdown = () => {
     },
   });
 
-  const handleLogout = () => {
+  const { disconnectWallet } = useWalletDisconnect();
+
+  const handleLogout = async () => {
     setIsLoggingOut(true);
-    logout();
+    try {
+      // Disconnect external wallet if connected
+      if (isInjectedWallet) {
+        await disconnectWallet();
+      }
+      
+      await logout();
+    } catch (error) {
+      console.error("Error during logout:", error);
+      // Still proceed with logout even if wallet disconnection fails
+      await logout();
+    }
   };
 
   return (

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -70,12 +70,8 @@ export const SettingsDropdown = () => {
   const handleLogout = async () => {
     setIsLoggingOut(true);
     try {
-      // Disconnect external wallet if connected
-      if (isInjectedWallet) {
-        await disconnectWallet();
-      }
-      
       await logout();
+      await disconnectWallet();
     } catch (error) {
       console.error("Error during logout:", error);
       // Still proceed with logout even if wallet disconnection fails

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -71,7 +71,9 @@ export const SettingsDropdown = () => {
     setIsLoggingOut(true);
     try {
       await logout();
-      await disconnectWallet();
+      if (window.ethereum) {
+        await disconnectWallet();
+      }
     } catch (error) {
       console.error("Error during logout:", error);
       // Still proceed with logout even if wallet disconnection fails

--- a/app/hooks/useWalletDisconnect.ts
+++ b/app/hooks/useWalletDisconnect.ts
@@ -1,0 +1,38 @@
+import { createWalletClient, custom } from 'viem';
+import { trackEvent } from './analytics';
+import { toast } from 'sonner';
+
+export const useWalletDisconnect = () => {
+  const disconnectWallet = async () => {
+    try {
+      if (window.ethereum) {
+        const walletClient = createWalletClient({
+          transport: custom(window.ethereum)
+        });
+
+        // Clear any active connections
+        walletClient.request({
+          method: "wallet_revokePermissions",
+          params: [{ eth_accounts: {} }],
+        });
+
+
+        trackEvent("Wallet disconnected", {
+          "Wallet type": "External wallet",
+          "Disconnect reason": "User sign out",
+        });
+
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error("Error disconnecting wallet:", error);
+      toast.error("Failed to disconnect wallet", {
+        description: "Please disconnect your wallet manually"
+      });
+      return false;
+    }
+  };
+
+  return { disconnectWallet };
+}; 


### PR DESCRIPTION
### Description
This pull request introduces the `useWalletDisconnect` hook, which facilitates the disconnection of a user's wallet from the application. The hook leverages the createWalletClient function to interact with the Ethereum provider, allowing for the revocation of wallet permissions

### References

- Cloess #91 

### Testing


### Checklist

- [X] I have added documentation and tests for new/changed functionality in this PR
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).