### PR TITLE
fix unsupported token issue in url

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { useSearchParams } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ImSpinner, ImSpinner3 } from "react-icons/im";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
 import { AnimatePresence } from "framer-motion";
+import { toast } from "sonner";
 
 import {
   AnimatedComponent,
@@ -62,6 +63,7 @@ export const TransactionForm = ({
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
   const [formattedSentAmount, setFormattedSentAmount] = useState("");
   const [formattedReceivedAmount, setFormattedReceivedAmount] = useState("");
+  const isFirsRender = useRef(true);
 
   const {
     handleSubmit,
@@ -161,10 +163,19 @@ export const TransactionForm = ({
       searchParams.get("fiatAmount") || "0",
     ).toFixed(2);
 
-    const supportedTokens = ["USDC", "USDT", "cNGN"];
+    const supportedTokens = tokens.map((tokenElement) => tokenElement.name);
 
     if (token && supportedTokens.includes(token)) {
       formMethods.setValue("token", token);
+    }
+
+    // Check's if not first render to prevent display of error 2nd time
+    if (!isFirsRender.current && token && !supportedTokens.includes(token)) {
+      toast.error("Unsupported Token", {
+        description: String(
+          `${token} token is not supported on the current network. Please choose a valid token to proceed with the transaction.`,
+        ),
+      });
     }
 
     if (currency) {
@@ -185,6 +196,9 @@ export const TransactionForm = ({
       setIsReceiveInputActive(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // Setting first render to false
+    isFirsRender.current = false;
   }, []);
 
   useEffect(function initSelectedToken() {

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -173,7 +173,7 @@ export const TransactionForm = ({
     if (!isFirsRender.current && token && !supportedTokens.includes(token)) {
       toast.error("Unsupported Token", {
         description: String(
-          `${token} token is not supported on the current network. Please choose a valid token to proceed with the transaction.`,
+          `${token} token is not supported on the current network.`,
         ),
       });
     }

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -195,10 +195,10 @@ export const TransactionForm = ({
       formMethods.setValue("amountReceived", fiatAmount);
       setIsReceiveInputActive(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-
     // Setting first render to false
     isFirsRender.current = false;
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(function initSelectedToken() {


### PR DESCRIPTION
### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

This PR is to fix the unsupported token by the network provided in the URL the API fetches the rate of the unsupported tokens and no error message is provided

> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.

- Replaced the static tokens in `setDefaultValueOnPageLoad` with dynamically fetched supported tokens based on the network
- Created a boolean `useRef` named `isFirstRender` to prevent multiple display of error
- Added an user friendly toast error with title and description

### References

- Closes #101 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- Entered manual token in URL like _USDT_ on _Base_ network and check for error and supported token value to fetch. 
- Check network tab if balance is being fetched
- Check for any unsupported token URL in any network

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).