### PR TITLE
style: update tx status layout

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -207,6 +207,7 @@ export const TransactionForm = ({
         setValue("token", fetchedTokens[0].symbol);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedNetwork.chain.name],
   );
 
@@ -358,7 +359,7 @@ export const TransactionForm = ({
 
       registerFormFields();
     },
-    [token, currency, formMethods],
+    [token, currency, formMethods, currencies],
   );
 
   const { isEnabled, buttonText, buttonAction } = useSwapButton({

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -449,7 +449,7 @@ export function TransactionStatus({
           </div>
         </div>
 
-        <div className="flex max-w-xs flex-col items-start gap-4">
+        <div className="flex flex-col items-start gap-4 sm:max-w-xs">
           <StatusIndicator />
 
           <AnimatedComponent
@@ -516,7 +516,7 @@ export function TransactionStatus({
                 <AnimatedComponent
                   variant={slideInOut}
                   delay={0.5}
-                  className="flex w-full flex-wrap gap-3 max-sm:hidden"
+                  className="flex w-full flex-wrap gap-3 max-sm:*:flex-1"
                 >
                   {["validated", "settled"].includes(transactionStatus) && (
                     <button
@@ -539,6 +539,7 @@ export function TransactionStatus({
                       : "New payment"}
                   </button>
                 </AnimatedComponent>
+
                 {["validated", "settled"].includes(transactionStatus) && (
                   <div className="flex gap-2">
                     <Checkbox
@@ -554,7 +555,7 @@ export function TransactionStatus({
                         <title>
                           {addToBeneficiaries
                             ? "Remove from beneficiaries"
-                            : "Add to beneficiaries"}
+                            : "Add to your beneficiaries"}
                         </title>
                         <path
                           d="M3 8L6 11L11 3.5"
@@ -601,7 +602,7 @@ export function TransactionStatus({
                 className="flex w-full flex-col gap-4 text-gray-500 dark:text-white/50"
               >
                 <div className="flex items-center justify-between gap-1">
-                  <p className="flex-1">Status</p>
+                  <p className="flex-1">Transaction status</p>
                   <div className="flex flex-1 items-center gap-1">
                     <p
                       className={classNames(
@@ -693,46 +694,6 @@ export function TransactionStatus({
                   </a>
                 </div>
               </AnimatedComponent>
-            )}
-          </AnimatePresence>
-
-          <AnimatePresence>
-            {["validated", "settled", "refunded"].includes(
-              transactionStatus,
-            ) && (
-              <>
-                <AnimatedComponent
-                  variant={slideInOut}
-                  delay={0.5}
-                  className="mt-10 w-full space-y-4 sm:hidden"
-                >
-                  <div className="flex w-full flex-col gap-3">
-                    {["validated", "settled"].includes(transactionStatus) && (
-                      <button
-                        type="button"
-                        onClick={handleGetReceipt}
-                        className={classNames(
-                          secondaryBtnClasses,
-                          "w-full flex-1",
-                        )}
-                        disabled={isGettingReceipt}
-                      >
-                        {isGettingReceipt ? "Generating..." : "Get receipt"}
-                      </button>
-                    )}
-
-                    <button
-                      type="button"
-                      onClick={handleBackButtonClick}
-                      className={classNames(primaryBtnClasses, "w-full flex-1")}
-                    >
-                      {transactionStatus === "refunded"
-                        ? "Retry transaction"
-                        : "New payment"}
-                    </button>
-                  </div>
-                </AnimatedComponent>
-              </>
             )}
           </AnimatePresence>
         </div>


### PR DESCRIPTION
### Description

This PR updates the transaction status component to update the layout, text and component arrangement to match the updated design. Below is a comparison of the before and after look of the component.

| Before | After (Successful tx) | After (Failed tx) |
|--------|--------|--------|
| ![Screenshot 2025-03-27 at 23-53-58 Noblocks](https://github.com/user-attachments/assets/62485355-87a1-40d7-ad22-40f95c68f845) | ![Screenshot 2025-03-28 at 01-16-24 Noblocks](https://github.com/user-attachments/assets/8fc7a62b-2659-43af-9aed-f75d46a821d5) | ![Screenshot 2025-03-28 at 01-15-46 Noblocks](https://github.com/user-attachments/assets/ab7f6f89-a893-4a07-aa9e-4e79f730d39f) | 

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).