### PR TITLE
feat: add MFA management option to settings

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
-import { usePrivy } from "@privy-io/react-auth";
+import { usePrivy, useMfaEnrollment } from "@privy-io/react-auth";
 import {
   Cancel01Icon,
   ArrowRight01Icon,
@@ -16,6 +16,7 @@ import {
   ArrowLeft02Icon,
   ArrowDown01Icon,
   CustomerService01Icon,
+  Key01Icon,
 } from "hugeicons-react";
 
 import { useNetwork } from "../context/NetworksContext";
@@ -41,9 +42,9 @@ import { FundWalletModal } from "./FundWalletModal";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import config from "@/app/lib/config";
 import { useInjectedWallet } from "../context";
-import { createWalletClient, custom } from 'viem'
-import { trackEvent } from '../hooks/analytics'
-import { useWalletDisconnect } from '../hooks/useWalletDisconnect';
+import { createWalletClient, custom } from "viem";
+import { trackEvent } from "../hooks/analytics";
+import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 
 type View = "wallet" | "settings";
 
@@ -80,6 +81,8 @@ export const MobileDropdown = ({
   const { currentStep } = useStep();
 
   const { disconnectWallet } = useWalletDisconnect();
+
+  const { showMfaEnrollmentModal } = useMfaEnrollment();
 
   const handleCopyAddress = () => {
     navigator.clipboard.writeText(smartWallet?.address ?? "");
@@ -446,6 +449,19 @@ export const MobileDropdown = ({
                           </div>
 
                           <div className="space-y-2 *:min-h-11">
+                            <button
+                              type="button"
+                              onClick={showMfaEnrollmentModal}
+                              className="flex w-full items-center gap-2.5"
+                            >
+                              <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
+                              <p className="text-left">
+                                {user?.mfaMethods?.length
+                                  ? "Manage MFA"
+                                  : "Enable MFA"}
+                              </p>
+                            </button>
+
                             {!isInjectedWallet && user?.email ? (
                               <button
                                 type="button"

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -455,7 +455,7 @@ export const MobileDropdown = ({
                               className="flex w-full items-center gap-2.5"
                             >
                               <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
-                              <p className="text-left">
+                              <p className="text-left text-text-body dark:text-white/80">
                                 {user?.mfaMethods?.length
                                   ? "Manage MFA"
                                   : "Enable MFA"}

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { AnimatePresence, motion } from "framer-motion";
 import { useRef, useState } from "react";
-import { useLinkAccount, useLogout, usePrivy } from "@privy-io/react-auth";
+import {
+  useLinkAccount,
+  useLogout,
+  usePrivy,
+  useMfaEnrollment,
+} from "@privy-io/react-auth";
 import { ImSpinner } from "react-icons/im";
 import { PiCheck } from "react-icons/pi";
 import { useOutsideClick } from "../hooks";
@@ -15,16 +20,18 @@ import {
   Mail01Icon,
   Setting07Icon,
   Wallet01Icon,
+  Key01Icon,
 } from "hugeicons-react";
 import { toast } from "sonner";
 import config from "@/app/lib/config";
 import { useInjectedWallet } from "../context";
-import { createWalletClient, custom } from 'viem'
-import { trackEvent } from '../hooks/analytics'
-import { useWalletDisconnect } from '../hooks/useWalletDisconnect';
+import { createWalletClient, custom } from "viem";
+import { trackEvent } from "../hooks/analytics";
+import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 
 export const SettingsDropdown = () => {
   const { user, exportWallet, updateEmail } = usePrivy();
+  const { showMfaEnrollmentModal } = useMfaEnrollment();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
 
@@ -142,6 +149,25 @@ export const SettingsDropdown = () => {
                   )}
                 </button>
               </li>
+
+              <li
+                role="menuitem"
+                className="flex cursor-pointer items-center justify-between gap-2 rounded-lg transition-all duration-300 hover:bg-accent-gray dark:hover:bg-neutral-700"
+              >
+                <button
+                  type="button"
+                  className="group flex w-full items-center justify-between gap-4"
+                  onClick={showMfaEnrollmentModal}
+                >
+                  <div className="flex items-center gap-2.5">
+                    <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
+                    <p>
+                      {user?.mfaMethods?.length ? "Manage MFA" : "Enable MFA"}
+                    </p>
+                  </div>
+                </button>
+              </li>
+
               {!isInjectedWallet &&
                 (user?.email ? (
                   <li


### PR DESCRIPTION


### Description

This pull request introduces several changes to the `MobileDropdown` and `SettingsDropdown` components to support multi-factor authentication (MFA) functionality. The most important changes include importing necessary hooks and icons, adding a button to trigger the MFA enrollment modal, and ensuring consistent code formatting.

Enhancements for MFA support:

* [`app/components/MobileDropdown.tsx`](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109L6-R6): Added `useMfaEnrollment` hook and `Key01Icon` import to support MFA functionality. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109L6-R6) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R19)
* [`app/components/MobileDropdown.tsx`](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R85-R86): Added a button to trigger the MFA enrollment modal and display appropriate text based on the user's MFA status. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R85-R86) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R452-R464)

Consistent code formatting:

* [`app/components/MobileDropdown.tsx`](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109L44-R47): Updated import statements to use double quotes for consistency.

Enhancements for MFA support:

* [`app/components/SettingsDropdown.tsx`](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeL4-R9): Added `useMfaEnrollment` hook and `Key01Icon` import to support MFA functionality. [[1]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeL4-R9) [[2]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR23-R34)
* [`app/components/SettingsDropdown.tsx`](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR152-R170): Added a button to trigger the MFA enrollment modal and display appropriate text based on the user's MFA status.

### Screenshots

![image](https://github.com/user-attachments/assets/c1d80758-4ac7-4a3c-97d9-919830f53942)

![image](https://github.com/user-attachments/assets/34a232ac-e849-4c55-b125-60a468fe3f4d)

### Testing

#### Environment Information
- React/Next.js application
- Tested with Node.js v20+
- Tested in Zen 1.10.3b
- Desktop and Mobile viewport testing required

#### Manual Testing Steps

1. Desktop Testing:
   - Open the application in desktop view
   - Click the settings gear icon (⚙️) in the top navigation
   - Verify "Enable MFA" appears in the dropdown menu with key icon
   - Click "Enable MFA" and verify Privy MFA modal opens
   - Complete MFA setup
   - Verify button text changes to "Manage MFA"
   - Click "Manage MFA" to verify management modal opens

2. Mobile Testing:
   - Open the application in mobile view (viewport <768px)
   - Click the Menu button
   - Tap the settings gear icon (⚙️) in the mobile wallet view
   - Find "Enable MFA" in the settings list
   - Tap it and verify Privy MFA modal opens
   - Complete MFA setup
   - Verify text updates to "Manage MFA"
   - Tap "Manage MFA" to verify management modal opens

3. Visual Verification:
   - Verify key icon appears correctly in both desktop and mobile views
   - Check dark/light theme compatibility
   - Verify hover states work on desktop
   - Confirm touch targets are appropriately sized on mobile
   - Verify text alignment matches other menu items


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).