### PR TITLE
fix: conditionally render MFA enrollment button for non-injected wallets

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -449,18 +449,20 @@ export const MobileDropdown = ({
                           </div>
 
                           <div className="space-y-2 *:min-h-11">
-                            <button
-                              type="button"
-                              onClick={showMfaEnrollmentModal}
-                              className="flex w-full items-center gap-2.5"
-                            >
-                              <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
-                              <p className="text-left text-text-body dark:text-white/80">
-                                {user?.mfaMethods?.length
-                                  ? "Manage MFA"
-                                  : "Enable MFA"}
-                              </p>
-                            </button>
+                            {!isInjectedWallet && (
+                              <button
+                                type="button"
+                                onClick={showMfaEnrollmentModal}
+                                className="flex w-full items-center gap-2.5"
+                              >
+                                <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
+                                <p className="text-left text-text-body dark:text-white/80">
+                                  {user?.mfaMethods?.length
+                                    ? "Manage MFA"
+                                    : "Enable MFA"}
+                                </p>
+                              </button>
+                            )}
 
                             {!isInjectedWallet && user?.email ? (
                               <button

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -150,23 +150,25 @@ export const SettingsDropdown = () => {
                 </button>
               </li>
 
-              <li
-                role="menuitem"
-                className="flex cursor-pointer items-center justify-between gap-2 rounded-lg transition-all duration-300 hover:bg-accent-gray dark:hover:bg-neutral-700"
-              >
-                <button
-                  type="button"
-                  className="group flex w-full items-center justify-between gap-4"
-                  onClick={showMfaEnrollmentModal}
+              {!isInjectedWallet && (
+                <li
+                  role="menuitem"
+                  className="flex cursor-pointer items-center justify-between gap-2 rounded-lg transition-all duration-300 hover:bg-accent-gray dark:hover:bg-neutral-700"
                 >
-                  <div className="flex items-center gap-2.5">
-                    <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
-                    <p>
-                      {user?.mfaMethods?.length ? "Manage MFA" : "Enable MFA"}
-                    </p>
-                  </div>
-                </button>
-              </li>
+                  <button
+                    type="button"
+                    className="group flex w-full items-center justify-between gap-4"
+                    onClick={showMfaEnrollmentModal}
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <Key01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
+                      <p>
+                        {user?.mfaMethods?.length ? "Manage MFA" : "Enable MFA"}
+                      </p>
+                    </div>
+                  </button>
+                </li>
+              )}
 
               {!isInjectedWallet &&
                 (user?.email ? (


### PR DESCRIPTION
### Description

This pull request introduces conditional rendering to both the `MobileDropdown` and `SettingsDropdown` components to ensure that certain buttons or elements are only displayed when `isInjectedWallet` is false. This improves the user interface by hiding irrelevant options for users with injected wallets.

### Conditional rendering updates:

* **`MobileDropdown` component (`app/components/MobileDropdown.tsx`)**:
  - Wrapped the MFA enrollment button in a conditional block to render it only when `isInjectedWallet` is false. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R452) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R465)

* **`SettingsDropdown` component (`app/components/SettingsDropdown.tsx`)**:
  - Added a conditional block to ensure a specific list item is only rendered when `isInjectedWallet` is false. [[1]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR153) [[2]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR171)

### Testing

- Switch to an injected wallet (add `?injected=true`)
- Check if the "Enable MFA" setting isn't in the settings list

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).