### PR TITLE
fix: convert USDbC to USDC for accurate rate fetching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -168,8 +168,11 @@ function HomeImpl({ searchParams }: { searchParams: URLSearchParams }) {
               ? lpParam
               : undefined;
 
+          // Convert USDbC to USDC for rate fetching
+          const rateToken = token === "USDbC" ? "USDC" : token;
+
           const rate = await fetchRate({
-            token,
+            token: rateToken,
             amount: amountSent || 1,
             currency,
             providerId,


### PR DESCRIPTION
### Description

Updated the rate fetching logic to convert `USDbC` to `USDC` before making the API call. This ensures that the correct token is used for fetching rates, improving compatibility with rate-fetching logic.

#### Screenshot showing successful rate fetch

![image](https://github.com/user-attachments/assets/4ab26a06-9400-4875-89b6-1c5f2926531f)

* **Token conversion for rate fetching**:
  - Added logic to convert `USDbC` to `USDC` before passing the token to the `fetchRate` function, ensuring consistent handling of token identifiers. (`[app/page.tsxR171-R175](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R171-R175)`)

### References

> #115 

### Testing

- On the beta version of noblocks:
  - Switch to base network
  - Select the `USDbC` token
  - Select a currency
  - Verify rate is properly fetched without errors

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).