### PR TITLE
fix: update useForm type definition for improved type safety

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ function HomeImpl({ searchParams }: { searchParams: URLSearchParams }) {
   const providerErrorShown = useRef(false);
   const failedProviders = useRef<Set<string>>(new Set());
 
-  const formMethods = useForm<FormData>({
+  const formMethods = useForm<FormData, any, undefined>({
     mode: "onChange",
     defaultValues: {
       token: "USDC",


### PR DESCRIPTION
### Description

This pull request includes a minor update to the `useForm` initialization in the `HomeImpl` function. The change explicitly specifies the generic type parameters for `useForm`, adding `any` and `undefined` for the second and third parameters, respectively.

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L60-R60): Updated the `useForm` call in the `HomeImpl` function to include explicit generic type parameters: `<FormData, any, undefined>`.

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).