### PR TITLE
fix: restore transfer and fund buttons to mobile dropdown

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -285,6 +285,25 @@ export const MobileDropdown = ({
                                 ))
                               )}
                             </div>
+
+                            {!isInjectedWallet && !isLoading && (
+                              <div className="grid grid-cols-2 gap-4">
+                                <button
+                                  type="button"
+                                  onClick={() => setIsTransferModalOpen(true)}
+                                  className="min-h-11 w-full rounded-xl bg-accent-gray py-2 text-sm font-medium text-gray-900 dark:bg-white/5 dark:text-white"
+                                >
+                                  Transfer
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => setIsFundModalOpen(true)}
+                                  className="min-h-11 w-full rounded-xl bg-accent-gray py-2 text-sm font-medium text-gray-900 dark:bg-white/5 dark:text-white"
+                                >
+                                  Fund
+                                </button>
+                              </div>
+                            )}
                           </div>
 
                           {/* Wallet Address Container */}


### PR DESCRIPTION
### Description

This pull request adds new functionality to the `MobileDropdown` component, specifically introducing buttons for "Transfer" and "Fund" actions when certain conditions are met.

### Enhancements to `MobileDropdown` component:

* Added a conditional block to render "Transfer" and "Fund" buttons when `isInjectedWallet` is false and `isLoading` is false. These buttons trigger the `setIsTransferModalOpen` and `setIsFundModalOpen` functions respectively. (`app/components/MobileDropdown.tsx`, [app/components/MobileDropdown.tsxR288-R306](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R288-R306))

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).