### PR TITLE
feat: add support for Ugandan Shilling (UGX) and Tanzanian Shilling

### DIFF
--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -15,6 +15,14 @@ export const acceptedCurrencies = [
     disabled: true,
   },
   {
+    name: "UGX",
+    label: "Ugandan Shilling (UGX)",
+  },
+  {
+    name: "TZS",
+    label: "Tanzanian Shilling (TZS)",
+  },
+  {
     name: "BRL",
     label: "Brazilian Real (BRL)",
     disabled: true,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -663,6 +663,8 @@ export const currencyToCountryCode = (currency: string) => {
   const currencyOverrides: Record<string, string> = {
     XAF: "cm", // Central African CFA Franc (Cameroon)
     XOF: "sn", // West African CFA Franc (Senegal)
+    UGX: "ug", // Uganda
+    TZS: "tz", // Tanzania
     XCD: "ag", // East Caribbean Dollar (Antigua & Barbuda)
     XPF: "nc", // CFP Franc (New Caledonia)
     XDR: "", // No country (IMF Special Drawing Rights)

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -663,8 +663,6 @@ export const currencyToCountryCode = (currency: string) => {
   const currencyOverrides: Record<string, string> = {
     XAF: "cm", // Central African CFA Franc (Cameroon)
     XOF: "sn", // West African CFA Franc (Senegal)
-    UGX: "ug", // Uganda
-    TZS: "tz", // Tanzania
     XCD: "ag", // East Caribbean Dollar (Antigua & Barbuda)
     XPF: "nc", // CFP Franc (New Caledonia)
     XDR: "", // No country (IMF Special Drawing Rights)


### PR DESCRIPTION
This pull request adds support for two new currencies, the Ugandan Shilling (UGX) and Tanzanian Shilling (TZS), by updating mock data and mapping logic in the codebase.

### Currency support updates:

* [`app/mocks.ts`](diffhunk://#diff-5cef9b68abafa52ec52595fa36fc23b188891a59f1e0df39f92559ebec5ac0eaR17-R24): Added entries for UGX and TZS to the `acceptedCurrencies` list, including their names and labels.
* [`app/utils.ts`](diffhunk://#diff-9ba22a4ee607f76b338e5793ffbb2eae933b1b432aba0fbcd3a3fd14c9efbb1bR666-R667): Updated the `currencyToCountryCode` function to include mappings for UGX (Uganda) and TZS (Tanzania).

![Screenshot from 2025-06-10 18-56-37](https://github.com/user-attachments/assets/1cdb2aef-55ca-4b9b-bd7b-3a4efcc8ce67)

## References

- Closes #136 