### PR TITLE
fix: show PausedNetworkNotice only when authenticated

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -504,8 +504,6 @@ export const TransactionForm = ({
     selectedNetwork.chain.name,
   );
 
-  console.log("isPausedNetwork", isPausedNetwork);
-
   return (
     <div className="mx-auto max-w-[27.3125rem]">
       <form
@@ -762,7 +760,7 @@ export const TransactionForm = ({
             >
               {buttonText}
             </button>
-            {isPausedNetwork && <PausedNetworkNotice />}
+            {isPausedNetwork && authenticated && <PausedNetworkNotice />}
           </>
         )}
 


### PR DESCRIPTION
### Description

This pull request includes two changes to the `TransactionForm` component in `app/pages/TransactionForm.tsx`. These changes improve the code by removing unnecessary debugging output and refining the logic for displaying the `PausedNetworkNotice` component.

Code cleanup:

* Removed a `console.log` statement that logged the `isPausedNetwork` variable, as it was unnecessary for production code.

Logic refinement:

* Updated the condition for rendering the `PausedNetworkNotice` component to include a check for the `authenticated` variable, ensuring it only displays when the user is authenticated.


### Testing

- Visit the transaction/swap form unauthenticated
- Verify the paused network notice doesn't show up unless you're authenticated and you're on an affected network 

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).