### PR TITLE
fix(rates): show 'No available quote' and toast on rate fetch error

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -70,6 +70,7 @@ export const TransactionForm = ({
   const [formattedSentAmount, setFormattedSentAmount] = useState("");
   const [formattedReceivedAmount, setFormattedReceivedAmount] = useState("");
   const isFirstRender = useRef(true);
+  const [rateError, setRateError] = useState<string | null>(null);
 
   const currencies = useMemo(
     () =>
@@ -316,11 +317,14 @@ export const TransactionForm = ({
               Number(rate.data) > 0
             ) {
               maxAmountSentValue = 10000 * Number(rate.data);
-              // Set minimum value to the NGN equivalent of 0.5 USD
               minAmountSentValue = 0.5 * Number(rate.data);
+              setRateError(null); // Clear error on success
             }
-          } catch (error) {
-            console.error("Error fetching rate for cNGN amount limits:", error);
+          } catch (error: any) {
+            setRateError(error?.message || "Unknown error");
+            toast.error("No available quote", {
+              description: error?.message || "Unknown error",
+            });
           }
         }
 
@@ -812,20 +816,20 @@ export const TransactionForm = ({
         )}
 
         <AnimatePresence>
-          {rate > 0 && (
+          {currency && (
             <AnimatedComponent
               variant={slideInOut}
               className="flex w-full flex-col justify-between gap-2 py-3 text-xs text-text-disabled transition-all dark:text-white/30 xsm:flex-row xsm:items-center"
             >
-              {currency && (
-                <div className="min-w-fit">
-                  1 {token} ~{" "}
-                  {isFetchingRate
-                    ? "..."
-                    : formatNumberWithCommasForDisplay(rate)}{" "}
-                  {currency}
-                </div>
-              )}
+              <div className="min-w-fit">
+                {rateError ? (
+                  <>No available quote</>
+                ) : rate > 0 ? (
+                  <>
+                    1 {token} ~ {isFetchingRate ? "..." : formatNumberWithCommasForDisplay(rate)} {currency}
+                  </>
+                ) : null}
+              </div>
               <div className="ml-auto flex w-full flex-col justify-end gap-2 xsm:flex-row xsm:items-center">
                 <div className="h-px w-1/2 flex-shrink bg-gradient-to-tr from-white to-gray-300 dark:bg-gradient-to-tr dark:from-neutral-900 dark:to-neutral-700 sm:w-full" />
                 <p className="min-w-fit">Swap usually completes in 30s</p>


### PR DESCRIPTION
### Description

This PR improves error handling for rate fetching in the transaction form.  
If fetching the rate fails (e.g., network error, no provider, etc.):
- The UI now displays **'No available quote'** instead of the rate (e.g., "1 USDT ~ 1,525 NGN").
- The actual error message is shown in a toast notification for user feedback.
- The rate display is only shown if there is no error and a valid rate is available.

No business logic or min/max calculation was changed in this commit—only error handling and user feedback for rate fetching.

### References

N/A

### Testing

To test:
1. Simulate a rate fetch failure (e.g., disconnect network, use unsupported pair, or force an error in the API).
2. The UI should show **'No available quote'** in place of the rate.
3. A toast notification should appear with the actual error message.
4. If the rate fetch succeeds, the normal rate display should be shown.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
