### PR TITLE
fix(faq): prevent horizontal overflow on small screens

### DIFF
--- a/app/components/FAQs.tsx
+++ b/app/components/FAQs.tsx
@@ -103,7 +103,7 @@ export default function FAQs() {
   return (
     <section className="mx-auto mb-[5.3125rem] flex w-full max-w-[999px] flex-col gap-6 px-5 lg:mb-[17.75rem] lg:grid lg:grid-cols-[1fr_2fr]">
       <h2
-        className={`${crimsonPro.className} flex gap-1 text-center text-[2rem] font-semibold italic sm:gap-2 sm:text-[2.95rem] md:text-6xl lg:max-w-[294px] lg:flex-col lg:items-start lg:gap-5 lg:text-left lg:leading-[0.9]`}
+        className={`${crimsonPro.className} flex flex-wrap gap-1 text-center text-[2rem] font-semibold italic sm:gap-2 sm:text-[2.95rem] md:text-6xl lg:max-w-[294px] lg:flex-col lg:items-start lg:gap-5 lg:text-left lg:leading-[0.9]`}
       >
         <span>Frequently </span>
         <span>Asked </span>


### PR DESCRIPTION
allow the header for "Frequently Asked Questions" to wrap

### Description

This PR fixes a UI bug that causes horizontal overflow on very small mobile devices (<350px width). The overflow is caused by the "Frequently Asked Questions" section header.

The fix is applied to the app/components/FAQs.tsx file.
`flex-wrap` : Allows the flex items (`<span>`` tags) to wrap onto the next line when they run out of space.


### References

Closes #173 


### Testing

I have manually tested this on smaller viewports and ensured that this does not change anything on the larger viewports
<img width="822" height="602" alt="image" src="https://github.com/user-attachments/assets/c3da1724-2adf-4d59-b1ce-0944482980df" />

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).