### PR TITLE
feat: Add CopyAddressWarningModal component and integrate it across relevant components

### DIFF
--- a/app/components/CopyAddressWarningModal.tsx
+++ b/app/components/CopyAddressWarningModal.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { AnimatePresence, motion } from "framer-motion";
+import {  Copy01Icon, InformationSquareIcon, Wallet01Icon, WalletDone01Icon } from "hugeicons-react";
+import { useNetwork } from "../context/NetworksContext";
+import { networks } from "../mocks";
+import { useActualTheme } from "../hooks/useActualTheme";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { getNetworkImageUrl } from "../utils";
+import { toast } from "sonner";
+import { trackEvent } from "../hooks/analytics/useMixpanel";
+import { PiCheck } from "react-icons/pi";
+
+interface CopyAddressWarningModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  address: string;
+}
+
+export const CopyAddressWarningModal: React.FC<CopyAddressWarningModalProps> = ({
+  isOpen,
+  onClose,
+  address,
+}) => {
+  const { selectedNetwork } = useNetwork();
+  const isDark = useActualTheme();
+  const [isAddressCopied, setIsAddressCopied] = useState(false);
+
+  // Track modal view when opened
+  useEffect(() => {
+    if (isOpen) {
+      trackEvent("copy_address_modal_viewed", {
+        network: selectedNetwork.chain.name,
+        chain_id: selectedNetwork.chain.id,
+      });
+    }
+  }, [isOpen, selectedNetwork, trackEvent]);
+
+  const handleAcknowledge = () => {
+    trackEvent("copy_address_modal_acknowledged", {
+      network: selectedNetwork.chain.name,
+      chain_id: selectedNetwork.chain.id,
+    });
+    onClose();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen]);
+
+    // Copy wallet address to clipboard with feedback
+    const handleCopyAddress = () => {
+      navigator.clipboard.writeText(address ?? "");
+      setIsAddressCopied(true);
+      setTimeout(() => setIsAddressCopied(false), 2000);
+      toast.success("Address copied to clipboard");
+    };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <Dialog
+          open={isOpen}
+          onClose={onClose}
+          className="relative z-[80]"
+          role="dialog"
+          aria-labelledby="copy-address-warning-title"
+          aria-describedby="copy-address-warning-description"
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/25 dark:bg-black/40 backdrop-blur-sm"
+          />
+
+          <div className="fixed inset-0 flex items-center justify-center p-4">
+            <DialogPanel
+              as={motion.div}
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 10 }}
+              className="relative w-full max-w-[412px] min-h-[530px] h-fit bg-white dark:bg-[#202020] p-5 rounded-[20px] "
+            >
+              {/* Header with warning icon */}
+              <div className="flex flex-col items-start gap-4 mb-4">
+                  <WalletDone01Icon
+                    size={20}
+                    className="text-gray-600 dark:text-gray-400"
+                  />
+                <div className="flex-1">
+                  <h3 
+                    id="copy-address-warning-title"
+                    className="text-[18px] font-semibold text-gray-900 dark:text-white mb-2"
+                  >
+                   You just copied your wallet address!
+                  </h3>
+                  <p 
+                    id="copy-address-warning-description"
+                    className="text-[14px] font-light text-gray-900 dark:text-gray-300"
+                  >
+                    If you are depositing funds to it, ensure you are depositing on only the supported networks
+                  </p>
+                </div>
+              </div>
+
+                {/* copied address */}
+              <div className="flex flex-col items-start mb-2 rounded-lg bg-[#F3F4F6] dark:bg-[#141414] h-[110px] px-3 py-3 relative w-full border-[1px] border-gray-200 dark:border-white/10">
+                <Wallet01Icon className="text-gray-600 dark:text-gray-400 w-[16px] h-[16px]" />
+                <p className="text-[14px] text-gray-600 dark:text-gray-400 text-wrap break-all mt-2 max-w-2/3">
+                  {address || "No address available"}
+                </p>
+                 {isAddressCopied ? (
+                                    <PiCheck className="size-4 text-green-900 dark:text-green-500 absolute bottom-4 right-4" />
+                                  ) : (
+                                    <Copy01Icon
+                                        onClick={handleCopyAddress}
+                                      className="size-4 cursor-pointer text-icon-outline-secondary absolute bottom-4 right-4 transition-all group-hover:text-lavender-500 dark:text-white/50 dark:hover:text-white"
+                                      strokeWidth={2}
+                                    />
+                                  )}
+                {/* <Copy01Icon className="text-gray-600 dark:text-gray-400  h-[24px] w-[24px]" /> */}
+              </div>
+
+              {/* Supported networks list */}
+                <div className="flex flex-col gap-2 items-start mb-2 rounded-lg bg-transparent h-fit px-3 py-3 relative w-full border-[1px] border-gray-200 dark:border-white/10">
+                <h4 className="text-[12px] font-medium text-gray-900/50 dark:text-white/50 mb-2">
+                  Supported Networks
+                </h4>
+                <div className=" flex flex-wrap gap-2 w-full h-full ">
+                  {networks.map((network) => (
+                    <div 
+                      key={network.chain.id}
+                      className="flex items-center gap-3 p-2 rounded-lg bg-gray-50 dark:bg-white/10 w-fit h-[24px] rounded-full"
+                    >
+                      <div className="w-[16px] h-[16px]">
+                        <Image
+                          src={getNetworkImageUrl(network, isDark)}
+                          alt={`${network.chain.name} logo`}
+                          width={24}
+                          height={24}
+                          className=" w-full h-full object-contain"
+                        />
+                      </div>
+                      <span className="text-[12px] font-medium text-gray-900 dark:text-white/80">
+                        {network.chain.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Warning note */}
+              <div className="h-[48px] w-full bg-[#FFECC214] px-3 py-2 rounded-lg mb-4 flex items-start gap-4">
+                <InformationSquareIcon className="text-[#F2C71C] w-[24px] h-[24px] mr-2" />
+                <p className="text-[11px] font-light text-[#F2C71C] leading-tight">
+                  Only send funds to the supported networks, sending to an unlisted network will lead to lost of funds
+                </p>
+              </div>
+
+              {/* Action button */}
+              <button
+                onClick={handleAcknowledge}
+                className="w-full text-[14px] bg-[#8B85F4] hover:bg-[#8B85F4] text-white font-medium py-3 px-4 rounded-lg transition-colors focus:outline-none"
+              >
+                Got it
+              </button>
+            </DialogPanel>
+          </div>
+        </Dialog>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -21,6 +21,7 @@ import { Network, Token, TransactionHistory } from "../types";
 import { WalletView, HistoryView, SettingsView } from "./wallet-mobile-modal";
 import { slideUpAnimation } from "./AnimatedComponents";
 import { FundWalletForm, TransferForm } from "./index";
+import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 
 export const MobileDropdown = ({
   isOpen,
@@ -34,6 +35,7 @@ export const MobileDropdown = ({
   >("wallet");
   const [isNetworkListOpen, setIsNetworkListOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
 
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { user, linkEmail, updateEmail } = usePrivy();
@@ -65,6 +67,7 @@ export const MobileDropdown = ({
   const handleCopyAddress = () => {
     navigator.clipboard.writeText(smartWallet?.address ?? "");
     toast.success("Address copied to clipboard");
+    setIsWarningModalOpen(true);
   };
 
   const tokens: { name: string; imageUrl: string | undefined }[] = [];
@@ -285,6 +288,12 @@ export const MobileDropdown = ({
           </Dialog>
         )}
       </AnimatePresence>
+
+      <CopyAddressWarningModal 
+        isOpen={isWarningModalOpen}
+        onClose={() => setIsWarningModalOpen(false)}
+        address={smartWallet?.address ?? ""}
+      />
     </>
   );
 };

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -26,6 +26,7 @@ import { toast } from "sonner";
 import config from "@/app/lib/config";
 import { useInjectedWallet } from "../context";
 import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
+import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 
 export const SettingsDropdown = () => {
   const { user, updateEmail } = usePrivy();
@@ -35,6 +36,7 @@ export const SettingsDropdown = () => {
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isAddressCopied, setIsAddressCopied] = useState(false);
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   useOutsideClick({
@@ -51,6 +53,7 @@ export const SettingsDropdown = () => {
     navigator.clipboard.writeText(walletAddress ?? "");
     setIsAddressCopied(true);
     setTimeout(() => setIsAddressCopied(false), 2000);
+    setIsWarningModalOpen(true);
   };
 
   const { logout } = useLogout({
@@ -293,6 +296,12 @@ export const SettingsDropdown = () => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <CopyAddressWarningModal 
+        isOpen={isWarningModalOpen}
+        onClose={() => setIsWarningModalOpen(false)}
+        address={walletAddress ?? ""}
+      />
     </div>
   );
 };

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -36,6 +36,7 @@ import { useCNGNRate } from "../hooks/useCNGNRate";
 import { useActualTheme } from "../hooks/useActualTheme";
 import TransactionList from "./transaction/TransactionList";
 import { FundWalletForm, TransferForm } from "./index";
+import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 
 export const WalletDetails = () => {
   const [isTransferModalOpen, setIsTransferModalOpen] =
@@ -48,6 +49,7 @@ export const WalletDetails = () => {
   const [selectedTransaction, setSelectedTransaction] =
     useState<TransactionHistory | null>(null);
   const [isAddressCopied, setIsAddressCopied] = useState(false);
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
 
   const { selectedNetwork } = useNetwork();
   const { allBalances, isLoading, refreshBalance } = useBalance();
@@ -101,6 +103,7 @@ export const WalletDetails = () => {
   // Copy wallet address to clipboard with feedback
   const handleCopyAddress = () => {
     navigator.clipboard.writeText(activeWallet?.address ?? "");
+    setIsWarningModalOpen(true);
     setIsAddressCopied(true);
     toast.success("Address copied to clipboard");
     setTimeout(() => setIsAddressCopied(false), 2000);
@@ -419,6 +422,12 @@ export const WalletDetails = () => {
           </AnimatedModal>
         </>
       )}
+
+      <CopyAddressWarningModal
+        isOpen={isWarningModalOpen}
+        onClose={() => setIsWarningModalOpen(false)}
+        address={activeWallet?.address ?? ""}
+      />
     </>
   );
 };

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -8,6 +8,7 @@ export { default as PWAInstall } from "./PWAInstallManager";
 export { ThemeSwitch } from "./ThemeSwitch";
 export { WalletDetails } from "./WalletDetails";
 export { SettingsDropdown } from "./SettingsDropdown";
+export { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 
 export {
   AnimatedPage,

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -6,6 +6,7 @@ import { ImSpinner } from "react-icons/im";
 import { toast } from "sonner";
 import { pdf } from "@react-pdf/renderer";
 import { PDFReceipt } from "../PDFReceipt";
+import { CopyAddressWarningModal } from "../CopyAddressWarningModal";
 import type { TransactionHistory, Network } from "../../types";
 import {
   getExplorerLink,
@@ -44,6 +45,7 @@ const getNetworkFromName = (networkName: string): Network | null => {
 
 export function TransactionDetails({ transaction }: TransactionDetailsProps) {
   const [isLoading, setIsLoading] = useState(false);
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
   const { selectedNetwork } = useNetwork();
   const isDark = useActualTheme();
   if (!transaction) return null;
@@ -240,6 +242,7 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
                       transaction.recipient.account_identifier,
                     );
                     toast.success("Address copied");
+                    setIsWarningModalOpen(true);
                   }}
                 >
                   <Copy01Icon
@@ -421,6 +424,12 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
           )}
         </button>
       )}
+
+      <CopyAddressWarningModal 
+            isOpen={isWarningModalOpen}
+            onClose={() => setIsWarningModalOpen(false)}
+            address={transaction.recipient.account_identifier ?? ""}
+        />
     </motion.div>
   );
 }


### PR DESCRIPTION
### Description

This pull request introduces a new modal component, `CopyAddressWarningModal`, which displays a warning and guidance message whenever a wallet address is copied throughout the app. The modal is integrated into several components to improve user awareness about network compatibility when depositing funds, aiming to reduce the risk of lost funds due to incorrect network usage.

**New Feature: Copy Address Warning Modal**

* Added the `CopyAddressWarningModal` component, which provides a warning and instructions to users after copying a wallet address, including a list of supported networks and a caution about sending funds only to those networks.

**Integration Across Components**

* Integrated `CopyAddressWarningModal` into `MobileDropdown`, `SettingsDropdown`, `WalletDetails`, and `TransactionDetails` components. The modal is triggered whenever a wallet address is copied in these components, ensuring consistent user guidance across the app. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R24) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R291-R296) [[3]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR29) [[4]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR299-R304) [[5]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R39) [[6]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R425-R430) [[7]](diffhunk://#diff-4bcb5c5fa5160668c19ce94ac1ef0d497de8993e1342ec2e8120cc4bdfcd5da0R9) [[8]](diffhunk://#diff-4bcb5c5fa5160668c19ce94ac1ef0d497de8993e1342ec2e8120cc4bdfcd5da0R427-R432)

**User Experience Improvements**

* Updated the address copy handlers in all relevant components to open the warning modal after copying, replacing or supplementing the previous toast notification, and providing additional feedback and safety information. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R70) [[2]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR56) [[3]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R106) [[4]](diffhunk://#diff-4bcb5c5fa5160668c19ce94ac1ef0d497de8993e1342ec2e8120cc4bdfcd5da0R245)

**State Management Updates**

* Added new state variables (e.g., `isWarningModalOpen`) to manage the modal's visibility in each component where the address can be copied, ensuring the modal appears only when appropriate. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R38) [[2]](diffhunk://#diff-4f8daf58cc1245aa1a3b5191551ac5b5c5e8c3c5e00f7bcb17e76815d5ffa8aeR39) [[3]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R52) [[4]](diffhunk://#diff-4bcb5c5fa5160668c19ce94ac1ef0d497de8993e1342ec2e8120cc4bdfcd5da0R48)

**Index Export**

* Exported `CopyAddressWarningModal` from the main components index file for easier imports throughout the codebase.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed e.g closes #407
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

closes #228 


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality
<img width="1903" height="1030" alt="Screenshot 2025-10-03 at 08 52 45" src="https://github.com/user-attachments/assets/9e0649d5-659b-49fc-9deb-840bd7d18545" />
<img width="342" height="765" alt="Screenshot 2025-10-03 at 08 53 24" src="https://github.com/user-attachments/assets/97a14e98-d04b-4168-b07c-636d121b99a1" />



### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).