### PR TITLE
Revert "Ethereum integration"

### DIFF
--- a/app/lib/privy-config.ts
+++ b/app/lib/privy-config.ts
@@ -1,4 +1,4 @@
-import { arbitrum, base, bsc, polygon, lisk, mainnet } from "viem/chains";
+import { arbitrum, base, bsc, polygon, lisk } from "viem/chains";
 import {
   addRpcUrlOverrideToChain,
   type PrivyClientConfig,
@@ -19,7 +19,7 @@ const baseConfig: Omit<PrivyClientConfig, "appearance"> = {
       connectionOptions: "smartWalletOnly",
     },
   },
-  supportedChains: [mainnet, base, bscOverride, arbitrum, polygon, lisk],
+  supportedChains: [base, bscOverride, arbitrum, polygon, lisk],
 };
 
 export const lightModeConfig: PrivyClientConfig = {

--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -1,4 +1,4 @@
-import { arbitrum, base, bsc, polygon, lisk, celo, mainnet } from "viem/chains";
+import { arbitrum, base, bsc, polygon, lisk, celo } from "viem/chains";
 
 export const acceptedCurrencies = [
   {
@@ -36,10 +36,6 @@ export const acceptedCurrencies = [
 ];
 
 export const networks = [
-  {
-    chain: mainnet,
-    imageUrl: "/logos/ethereum-logo.svg",
-  },
   {
     chain: arbitrum,
     imageUrl: "/logos/arbitrum-one-logo.svg",

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -155,8 +155,6 @@ export const getExplorerLink = (network: string, txHash: string) => {
 // write function to get rpc url for a given network
 export function getRpcUrl(network: string) {
   switch (network) {
-    case "Ethereum":
-      return `https://1.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
     case "Polygon":
       return `https://137.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
     case "BNB Smart Chain":

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Paycrest",
     "email": "info@paycrest.io",
     "url": "https://paycrest.io"
-  }, 
+  },
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts paycrest/noblocks#224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Ethereum (Mainnet) from supported networks. It will no longer appear in network lists or be usable via RPC.
  * Current supported networks include Base, BNB Smart Chain, Arbitrum, Polygon, and Lisk.

* **Style**
  * Minor formatting update in package metadata (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->