### PR TITLE
fix: show BlockFest cashback for both validated and settled transactions

### DIFF
--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -656,8 +656,8 @@ export function TransactionStatus({
         <AnimatePresence>
           {["validated", "settled", "refunded"].includes(transactionStatus) && (
             <>
-              {/* BlockFest Cashback Component - only when settled and claimed and on Base network */}
-              {transactionStatus === "settled" &&
+              {/* BlockFest Cashback Component - only when validated/settled and claimed and on Base network */}
+              {["validated", "settled"].includes(transactionStatus) &&
                 claimed === true &&
                 orderDetails?.network === "Base" &&
                 orderId &&
@@ -807,7 +807,7 @@ export function TransactionStatus({
         <AnimatePresence>
           {["validated", "settled"].includes(transactionStatus) &&
             !(
-              transactionStatus === "settled" &&
+              ["validated", "settled"].includes(transactionStatus) &&
               claimed === true &&
               orderDetails?.network === "Base" &&
               orderDetails?.token &&


### PR DESCRIPTION
## Problem

BlockFest cashback component only displayed for transactions with `settled` status. However, both `validated` and `settled` statuses indicate completed transactions, causing users to miss cashback opportunities when transactions complete in the `validated` state.

## Solution

Updated the cashback visibility condition to show for both `validated` and `settled` transaction statuses. This ensures users can claim their cashback as soon as their transaction completes, regardless of the final status state.

## Changes

- Updated cashback component visibility check from `transactionStatus === "settled"` to `["validated", "settled"].includes(transactionStatus)`
- Updated the inverse condition for social sharing section to maintain mutual exclusivity
- Updated comment to reflect both statuses

## Testing

Verified that:

- Cashback component shows for both validated and settled transactions
- Social sharing section remains hidden when cashback is displayed
- All other eligibility conditions (network, token, claimed status) still apply


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BlockFest cashback now appears for transactions in either validated or settled states, enabling earlier confirmation of eligibility.
  * The final status area updates to reflect both validated and settled outcomes, improving clarity around completion.
  * UI visibility and messaging are aligned with the expanded finalization states for a more consistent experience.
  * No other user-facing behavior is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->