### PR TITLE
fix: make BlockFest network check case-insensitive

### DIFF
--- a/app/components/blockfest/BlockFestCashbackComponent.tsx
+++ b/app/components/blockfest/BlockFestCashbackComponent.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import { toast } from "sonner";
 import { usePrivy } from "@privy-io/react-auth";
+import { classNames } from "@/app/utils";
 
 interface BlockFestCashbackComponentProps {
   transactionId: string;
@@ -132,9 +133,16 @@ export default function BlockFestCashbackComponent({
   };
 
   return (
-    <div className="inline-flex w-80 flex-col items-center justify-start gap-3 rounded-[20px] bg-gray-50 px-1 pb-3 pt-1 dark:bg-white/5">
+    <div
+      className={classNames(
+        "inline-flex w-80 flex-col items-center justify-start gap-3 rounded-[20px]",
+        transferStatus === "success"
+          ? "bg-gray-50 px-1 pb-3 pt-1 dark:bg-white/5"
+          : "",
+      )}
+    >
       {/* Banner with cashback message */}
-      <div className="relative rounded-2xl bg-[url('/images/blockfest/blockfest-banner-bg.svg')] bg-cover bg-left-top bg-no-repeat py-1 pl-12 pr-2.5">
+      <div className="relative rounded-2xl bg-[url('/images/blockfest/blockfest-banner-bg.svg')] bg-cover bg-left-top bg-no-repeat py-1 pl-12 pr-2.5 text-sm">
         {getBannerText()}
       </div>
 

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -659,7 +659,7 @@ export function TransactionStatus({
               {/* BlockFest Cashback Component - only when validated/settled and claimed and on Base network */}
               {["validated", "settled"].includes(transactionStatus) &&
                 claimed === true &&
-                orderDetails?.network === "Base" &&
+                orderDetails?.network?.toLowerCase() === "base" &&
                 orderId &&
                 orderDetails?.token &&
                 ALLOWED_CASHBACK_TOKENS.has(orderDetails.token) && (
@@ -809,7 +809,7 @@ export function TransactionStatus({
             !(
               ["validated", "settled"].includes(transactionStatus) &&
               claimed === true &&
-              orderDetails?.network === "Base" &&
+              orderDetails?.network?.toLowerCase() === "base" &&
               orderDetails?.token &&
               ALLOWED_CASHBACK_TOKENS.has(orderDetails.token)
             ) && (


### PR DESCRIPTION
## Problem

BlockFest cashback component was not displaying after transactions completed. Network field is stored as lowercase `"base"` in the database, but the visibility condition was checking for capitalized `"Base"`, causing the match to always fail.

## Solution

Updated network comparison to use case-insensitive matching with `.toLowerCase()` in both the cashback visibility check and the inverse condition for social sharing section.

## Additional Changes

- Added conditional styling to cashback component container
- Reduced banner text size for improved readability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the BlockFest cashback section and its finalization flow appear correctly for the Base network regardless of letter casing.

* **Style**
  * Cashback banner now applies a success-state background and padding after a successful transfer, with slightly smaller text for improved readability while preserving layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->