### PR TITLE
feat: add user preference for hiding address warning modal

### DIFF
--- a/app/components/CopyAddressWarningModal.tsx
+++ b/app/components/CopyAddressWarningModal.tsx
@@ -288,7 +288,7 @@ export const CopyAddressWarningModal: React.FC<
 
                     {/* copied address */}
                     <div className="relative mb-2 flex h-fit min-h-[80px] w-full flex-col items-start gap-3 rounded-2xl border border-border-light bg-white px-3 py-3 dark:border-white/10 dark:bg-surface-canvas">
-                      <div className="relative mt-0 flex w-full items-start justify-between gap-4">
+                      <div className="group relative mt-0 flex w-full items-start justify-between gap-4">
                         <p className="w-[80%] text-wrap break-all text-lg font-medium text-black dark:text-white/70">
                           {address || "No address available"}
                         </p>


### PR DESCRIPTION
### Description

This pull request updates the `CopyAddressWarningModal` component to improve user experience and clarity of warnings, while adding a "Don't show again" option. The changes enhance the modal's messaging about supported tokens/networks and allow users to opt out of seeing the warning in the future. The modal's layout and accessibility have also been improved for both desktop and mobile.

**User Experience Improvements**
* Added a "Don't show this to me again" checkbox, allowing users to opt out of future warnings; this preference is saved in `localStorage` and respected on subsequent modal openings. [[1]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018R40) [[2]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018R49-R56) [[3]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018R78-R86) [[4]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L226-R276) [[5]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L353-R411)

**Warning Message Clarity**
* Updated modal text and warning messages to clearly specify the risks of depositing unsupported stablecoins or using unsupported networks, emphasizing potential loss of funds. [[1]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L136-R156) [[2]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L226-R276) [[3]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L262-R295) [[4]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L353-R411)

**Layout and Accessibility**
* Refactored modal structure for better positioning, backdrop handling, and responsiveness on both desktop and mobile, replacing `DialogPanel` with styled `motion.div` containers. [[1]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018R114-R137) [[2]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L226-R276) [[3]](diffhunk://#diff-b28ca0beaf5d1df741e7a3bc44685e41da5df808e4badba1ab0ada4f92dec018L353-R411)

**Code Cleanup**
* Removed unused import of `DialogPanel` from `@headlessui/react`.


This addresses the change on the design for the copy address warning modal and the change to the copy of the modal as well.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

<img width="1500" height="947" alt="Screenshot 2025-10-14 at 02 13 32" src="https://github.com/user-attachments/assets/387375b7-0622-460f-befe-42242c4b3650" />
<img width="1500" height="947" alt="Screenshot 2025-10-14 at 02 14 16" src="https://github.com/user-attachments/assets/bada7fd7-8d0b-49c7-9364-b9d6190022f6" />
<img width="1500" height="947" alt="Screenshot 2025-10-14 at 02 14 33" src="https://github.com/user-attachments/assets/0e84da5c-1cdd-487a-a29a-a4815b20c582" />
<img width="1500" height="947" alt="Screenshot 2025-10-14 at 02 14 41" src="https://github.com/user-attachments/assets/4f290602-75ad-45f5-abec-7d4b909f85a9" />
<img width="340" height="756" alt="Screenshot 2025-10-14 at 02 15 08" src="https://github.com/user-attachments/assets/cc50a73c-3129-48fe-b0ed-167492222c1a" />
<img width="340" height="756" alt="Screenshot 2025-10-14 at 02 15 15" src="https://github.com/user-attachments/assets/7d31e61b-7875-4056-9a69-dbbb52dbfcae" />



### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Don’t show again” checkbox to the Copy Address warning; preference is persisted and respected on load.
  * Modal now supports backdrop-click-to-close and provides optimized desktop and full-screen mobile layouts with responsive transitions.
  * Updated copy to emphasize supported stablecoins/networks and refined actions with a dedicated “Got it” button.
  * Acknowledgement now includes the “don’t show again” flag in analytics; ARIA semantics updated for the composed modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->