### PR TITLE
fix: prevent early return on BlockFest expiration and ensure claim check only when active

### DIFF
--- a/app/components/blockfest/BlockFestClaimGate.tsx
+++ b/app/components/blockfest/BlockFestClaimGate.tsx
@@ -19,12 +19,10 @@ export function BlockFestClaimGate({
     const { claimed, checkClaim } = useBlockFestClaim();
   const hasCheckedRef = useRef(false);
   const hasShownModalRef = useRef(false);
-  const isActive = isBlockFestActive();
-
 
   // One-time claim check when wallet is ready
   useEffect(() => {
-    if (!isActive && !hasCheckedRef.current && authenticated && ready && userAddress) {
+    if (!isBlockFestActive() && !hasCheckedRef.current && authenticated && ready && userAddress) {
       if (/^0x[a-fA-F0-9]{40}$/.test(userAddress)) {
         hasCheckedRef.current = true;
         checkClaim(userAddress);
@@ -44,7 +42,7 @@ export function BlockFestClaimGate({
   // Show modal only once if referred and not yet claimed
   useEffect(() => {
     if (
-      !isActive &&
+      !isBlockFestActive() &&
       !hasShownModalRef.current &&
       isReferred &&
       authenticated &&


### PR DESCRIPTION

### Description


This pull request updates the logic in the `BlockFestClaimGate` component to ensure that claim checks and modal displays only occur when the BlockFest campaign is not active. The previous early return was removed in favor of more granular checks within the component's effects.

**BlockFest campaign status logic:**

* Removed the early return for inactive campaigns and replaced it with a local `isActive` variable for more flexible checks.
* Updated the claim check effect to trigger only when the campaign is inactive, ensuring checks do not run during an active campaign.
* Modified the modal display effect to show the modal only when the campaign is inactive, preventing unnecessary modal displays during active periods.


### References

This fixes the build error on main


### Testing

<img width="1333" height="955" alt="Screenshot 2025-10-24 at 15 29 43" src="https://github.com/user-attachments/assets/c9ff6456-f231-46a6-bdb6-6672a7fb2043" />


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BlockFest campaign handling so claims and related modals only run when the campaign is active, preventing unintended checks or displays when the campaign is inactive and ensuring consistent claim behavior for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->