### PR TITLE
Update BlockFestClaimGate.tsx logic so blocker claim modals don’t sho…

### DIFF
--- a/app/components/blockfest/BlockFestClaimGate.tsx
+++ b/app/components/blockfest/BlockFestClaimGate.tsx
@@ -22,7 +22,7 @@ export function BlockFestClaimGate({
 
   // One-time claim check when wallet is ready
   useEffect(() => {
-    if (!isBlockFestActive() && !hasCheckedRef.current && authenticated && ready && userAddress) {
+    if (isBlockFestActive() && !hasCheckedRef.current && authenticated && ready && userAddress) {
       if (/^0x[a-fA-F0-9]{40}$/.test(userAddress)) {
         hasCheckedRef.current = true;
         checkClaim(userAddress);
@@ -42,7 +42,7 @@ export function BlockFestClaimGate({
   // Show modal only once if referred and not yet claimed
   useEffect(() => {
     if (
-      !isBlockFestActive() &&
+      isBlockFestActive() &&
       !hasShownModalRef.current &&
       isReferred &&
       authenticated &&


### PR DESCRIPTION
…w up unless the campaign is still active.

### Description

This PR just fixes a tiny logic mistake that checks if the blockfest campaign is active and shows the claim modal if it is not active 

This PR fixes it so that it only shows up if it's active.


### References


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BlockFest claiming gate to activate during the event period instead of outside it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->