### PR TITLE
fix: disable page view tracking in Mixpanel initialization

### DIFF
--- a/app/hooks/analytics/useMixpanel.ts
+++ b/app/hooks/analytics/useMixpanel.ts
@@ -17,7 +17,7 @@ export const initMixpanel = () => {
 
   if (mixpanelToken) {
     mixpanel.init(mixpanelToken, {
-      track_pageview: true,
+      track_pageview: false,
       persistence: "localStorage",
       ignore_dnt: false,
       verbose: process.env.NODE_ENV === "development",


### PR DESCRIPTION
### Description

This pull request makes a minor update to the Mixpanel analytics initialization. The change disables automatic pageview tracking by setting `track_pageview` to `false` instead of `true`.



### References

This references issue #257 in the dashboard repository.

### Testing



### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics tracking configuration to improve data handling accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->