### PR TITLE
fix: add Malawian Kwacha (MWK) to accepted currencies and country mapping

### DIFF
--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -17,6 +17,11 @@ export const acceptedCurrencies = [
     name: "TZS",
     label: "Tanzanian Shilling (TZS)",
   },
+    {
+    name: "MWK",
+    label: "Malawian Kwacha (MWK)",
+    disabled: true,
+  },
   {
     name: "GHS",
     label: "Ghanaian Cedi (GHS)",

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -901,6 +901,7 @@ export function mapCountryToCurrency(countryCode: string): string | null {
     AR: "ARS",
     US: "USD",
     GB: "GBP",
+    MW: "MWK",
     // add more as needed
   };
   return mapping[countryCode] || null;


### PR DESCRIPTION


### Description

This pull request adds support for the Malawian Kwacha (MWK) currency to the application, including updates to currency mapping and the list of accepted currencies. The MWK currency is initially marked as disabled in the accepted currencies list.

Currency support updates:

* Added `MWK` (Malawian Kwacha) to the `acceptedCurrencies` array in `app/mocks.ts`, with the `disabled` flag set to true.
* Updated the `mapCountryToCurrency` function in `app/utils.ts` to map the country code `MW` to `MWK`.

### References

closes #264 


### Testing

<img width="1906" height="1032" alt="Screenshot 2025-10-30 at 15 47 16" src="https://github.com/user-attachments/assets/65c6feee-bd90-4704-afe0-b30a80e9bd44" />


- [x] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Malawian Kwacha (MWK) currency support infrastructure across platform systems, preparing for future regional expansion (currently disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->