### PR TITLE
fix: hide Hedera Mainnet in mobile wallet view for smart wallets

### DIFF
--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -259,7 +259,8 @@ export const WalletView: React.FC<WalletViewProps> = ({
               {networks
                 .filter(
                   (network) =>
-                    isInjectedWallet || network.chain.name !== "Celo",
+                    isInjectedWallet || 
+                    (network.chain.name !== "Celo" && network.chain.name !== "Hedera Mainnet"),
                 )
                 .map((network) => (
                   <button


### PR DESCRIPTION
### Description

Fixes network filtering in the mobile wallet view to hide Hedera Mainnet when using smart wallets (regular Privy wallet). Hedera Mainnet was incorrectly showing up in the mobile wallet view network list even when using smart wallets, despite being properly filtered in other components.

**The Problem:**
Hedera Mainnet was showing up in the mobile wallet view network list even when using smart wallets, despite being filtered in other components (NetworksDropdown, NetworkSelectionModal, FundWalletForm, TransferForm, and CopyAddressWarningModal).

**The Fix:**
Added Hedera Mainnet to the network filter in `WalletView.tsx` mobile component, ensuring consistent behavior across all network selection interfaces. Now Hedera Mainnet only appears in injected wallet mode, consistent with Celo's behavior.

**Impact:**

- Users with smart wallets will no longer see Hedera Mainnet in the mobile wallet view network list
- Consistent network filtering behavior across desktop and mobile interfaces
- Prevents confusion and potential user errors from selecting unsupported networks

### Testing

**Manual Testing Steps:**

1. **Smart Wallet Mode:**
   - Open the app without `?injected=true` parameter
   - Navigate to mobile wallet view
   - Open network selection list
   - Verify Hedera Mainnet does NOT appear in the list
   - Verify Celo also does NOT appear (existing behavior)

2. **Injected Wallet Mode:**
   - Open the app with `?injected=true` parameter
   - Navigate to mobile wallet view
   - Open network selection list
   - Verify Hedera Mainnet DOES appear in the list
   - Verify all networks are available

**Environment:**

- Platform: Next.js web application
- Browser: Chrome, Firefox, Safari (mobile view)
- Tested on: Mobile wallet modal component

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed/fixed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network filtering for non-injected wallets to exclude "Hedera Mainnet" in addition to "Celo" from the available network list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->