### PR TITLE
fix: add Hedera Mainnet gateway contract address

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -552,6 +552,7 @@ export function getGatewayContractAddress(network = ""): string | undefined {
     Optimism: "0xd293fcd3dbc025603911853d893a4724cf9f70a0",
     Celo: "0xf418217e3f81092ef44b81c5c8336e6a6fdb0e4b",
     Lisk: "0xff0E00E0110C1FBb5315D276243497b66D3a4d8a",
+    "Hedera Mainnet": "0x17d13B7032944af8B420Ac5bedb12a7D92270478",
   }[network];
 }
 


### PR DESCRIPTION
### Description

Adds missing Hedera Mainnet gateway contract address (0x17d13B7032944af8B420Ac5bedb12a7D92270478) to the `getGatewayContractAddress` function in `app/utils.ts`.

### Testing

- Verified the contract address is returned correctly when network is "Hedera Mainnet"
- No linting errors introduced

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hedera Mainnet integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->