### PR TITLE
fix: use fallback tokens for networks missing from API response

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -414,6 +414,12 @@ export async function getNetworkTokens(network = ""): Promise<Token[]> {
             tokens["Base"].push(usdtBase);
           }
         }
+        // Merge fallback tokens for any networks missing from API response
+        Object.keys(FALLBACK_TOKENS).forEach((networkName) => {
+          if (!tokens[networkName] || tokens[networkName].length === 0) {
+            tokens[networkName] = FALLBACK_TOKENS[networkName];
+          }
+        });
         tokensCache = tokens;
         lastTokenFetch = now;
       })();


### PR DESCRIPTION
### Description

Fixes balance fetch by ensuring networks missing from the API response fall back to FALLBACK_TOKENS. This prevents empty token lists that would cause balance fetching to fail for those networks.

### Testing

- Verified fallback tokens are used when networks are missing from API response
- No linting errors introduced

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token availability across networks: Networks without complete API token data now automatically receive predefined fallback tokens during fetching and caching. This ensures consistent token coverage across all supported networks, prevents service gaps, and enhances platform reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->