### PR TITLE
fix: use 'hedera' instead of 'hedera-mainnet' for rate fetching

### DIFF
--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -20,6 +20,7 @@ import { useBlockFestClaim } from "../context/BlockFestClaimContext";
 import { BlockFestClaimGate } from "./blockfest/BlockFestClaimGate";
 import { useBlockFestReferral } from "../hooks/useBlockFestReferral";
 import { fetchRate, fetchSupportedInstitutions } from "../api/aggregator";
+import { normalizeNetworkForRateFetch } from "../utils";
 import {
   STEPS,
   type FormData,
@@ -267,9 +268,7 @@ export function MainPageContent() {
             amount: amountSent || 100,
             currency,
             providerId,
-            network: selectedNetwork.chain.name
-              .toLowerCase()
-              .replace(/\s+/g, "-"),
+            network: normalizeNetworkForRateFetch(selectedNetwork.chain.name),
           });
           setRate(rate.data);
           setRateError(null); // Clear error on success

--- a/app/hooks/useCNGNRate.ts
+++ b/app/hooks/useCNGNRate.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
 import { fetchRate } from "../api/aggregator";
-import { getPreferredRateToken } from "../utils";
+import { getPreferredRateToken, normalizeNetworkForRateFetch } from "../utils";
 
 interface UseCNGNRateOptions {
   network: string;
@@ -52,7 +52,7 @@ export function useCNGNRate({
         token: preferredToken,
         amount: 100,
         currency: "NGN",
-        network: network.toLowerCase().replace(/\s+/g, "-"),
+        network: normalizeNetworkForRateFetch(network),
       });
 
       if (rateResponse?.data && typeof rateResponse.data === "string") {
@@ -110,7 +110,7 @@ export async function getCNGNRateForNetwork(
       token: preferredToken,
       amount: 100,
       currency: "NGN",
-      network: network.toLowerCase().replace(/\s+/g, "-"),
+      network: normalizeNetworkForRateFetch(network),
     });
 
     if (rateResponse?.data && typeof rateResponse.data === "string") {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -544,6 +544,20 @@ export function shortenAddress(
 }
 
 /**
+ * Normalizes network name for rate fetching API.
+ * Maps "Hedera Mainnet" to "hedera" instead of "hedera-mainnet".
+ * @param network - The network name to normalize.
+ * @returns The normalized network name for rate fetching.
+ */
+export function normalizeNetworkForRateFetch(network: string): string {
+  // Special case: Hedera Mainnet should be "hedera" not "hedera-mainnet"
+  if (network.toLowerCase() === "hedera mainnet") {
+    return "hedera";
+  }
+  return network.toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
  * Retrieves the contract address for the specified network.
  * @param network - The network for which to retrieve the contract address.
  * @returns The contract address for the specified network, or undefined if the network is not found.


### PR DESCRIPTION
### Description

Fixes network name normalization for rate fetching. When fetching rates for Hedera Mainnet, the network parameter should be "hedera" instead of "hedera-mainnet". Added a utility function `normalizeNetworkForRateFetch` to handle this special case and updated all rate fetching calls to use it.

### Testing

- Verified network name is normalized correctly for Hedera Mainnet
- No linting errors introduced

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized network name normalization logic for rate fetching operations to ensure consistent formatting across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->