### PR TITLE
feat: add refund reason handling to transaction updates and details

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -461,6 +461,7 @@ export async function updateTransactionDetails({
   status,
   txHash,
   timeSpent,
+  refundReason,
   accessToken,
   walletAddress,
 }: UpdateTransactionDetailsPayload): Promise<SaveTransactionResponse> {
@@ -475,6 +476,9 @@ export async function updateTransactionDetails({
   }
   if (timeSpent !== undefined && timeSpent !== null && timeSpent !== "") {
     data.timeSpent = timeSpent;
+  }
+  if (refundReason !== undefined && refundReason !== null && refundReason !== "") {
+    data.refundReason = refundReason;
   }
 
   const response = await axios.put(

--- a/app/api/v1/transactions/route.ts
+++ b/app/api/v1/transactions/route.ts
@@ -157,6 +157,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
         time_spent: body.time_spent,
         tx_hash: body.txHash,
         order_id: body.orderId,
+        refund_reason: body.refundReason ?? null,
       })
       .select()
       .single();

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -373,6 +373,18 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             </span>
           }
         />
+        {transaction.status === "refunded" &&
+          transaction.refund_reason &&
+          transaction.refund_reason.trim() !== "" && (
+            <DetailRow
+              label="Refund reason"
+              value={
+                <span className="text-text-accent-gray dark:text-white/80">
+                  {transaction.refund_reason}
+                </span>
+              }
+            />
+          )}
         <DetailRow
           label="Transaction status"
           value={

--- a/app/components/transaction/TransactionList.tsx
+++ b/app/components/transaction/TransactionList.tsx
@@ -77,22 +77,31 @@ export const TransactionListItem = ({
               {transaction.from_currency}
             </span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-text-disabled dark:text-white/30">
-              {new Date(transaction.created_at).toLocaleTimeString([], {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </span>
-            <span className="size-1 bg-icon-outline-disabled dark:bg-white/5"></span>
-            <span
-              className={classNames(
-                STATUS_COLOR_MAP[transaction.status] ||
-                  "text-text-secondary dark:text-white/50",
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <span className="text-text-disabled dark:text-white/30">
+                {new Date(transaction.created_at).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+              <span className="size-1 bg-icon-outline-disabled dark:bg-white/5"></span>
+              <span
+                className={classNames(
+                  STATUS_COLOR_MAP[transaction.status] ||
+                    "text-text-secondary dark:text-white/50",
+                )}
+              >
+                {transaction.status}
+              </span>
+            </div>
+            {transaction.status === "refunded" &&
+              transaction.refund_reason &&
+              transaction.refund_reason.trim() !== "" && (
+                <span className="text-xs text-text-secondary dark:text-white/50 line-clamp-1">
+                  {transaction.refund_reason}
+                </span>
               )}
-            >
-              {transaction.status}
-            </span>
           </div>
         </div>
       </div>

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -222,12 +222,18 @@ export function TransactionStatus({
         return;
       }
 
+      const refundReason =
+        transactionStatus === "refunded" && orderDetails?.cancellationReasons?.length
+          ? orderDetails.cancellationReasons.join(", ")
+          : undefined;
+
       const response = await updateTransactionDetails({
         transactionId,
         status: transactionStatus,
         txHash:
           transactionStatus !== "refunded" ? createdHash : orderDetails?.txHash,
         timeSpent,
+        refundReason,
         accessToken,
         walletAddress: embeddedWallet.address,
       });
@@ -363,9 +369,14 @@ export function TransactionStatus({
           trackEvent("Swap completed", eventData);
           setIsTracked(true);
         } else if (transactionStatus === "refunded") {
+          const reason =
+            orderDetails?.cancellationReasons?.length &&
+            orderDetails.cancellationReasons[0]
+              ? orderDetails.cancellationReasons[0]
+              : "Transaction failed and refunded";
           trackEvent("Swap failed", {
             ...eventData,
-            "Reason for failure": "Transaction failed and refunded",
+            "Reason for failure": reason,
           });
           setIsTracked(true);
         }
@@ -642,6 +653,11 @@ export function TransactionStatus({
       : "";
 
     if (transactionStatus === "refunded") {
+      const refundReason =
+        orderDetails?.cancellationReasons?.length &&
+        orderDetails.cancellationReasons[0]
+          ? orderDetails.cancellationReasons[0]
+          : null;
       return (
         <>
           Your transfer of{" "}
@@ -650,6 +666,14 @@ export function TransactionStatus({
             {formatCurrency(fiat ?? 0, currency, `en-${currency.slice(0, 2)}`)})
           </span>{" "}
           to {formattedRecipientName} was unsuccessful.
+          {refundReason && (
+            <>
+              <br />
+              <span className="text-text-secondary dark:text-white/70">
+                {refundReason}
+              </span>
+            </>
+          )}
           <br />
           <br />
           The stablecoin has been refunded to your account.

--- a/app/types.ts
+++ b/app/types.ts
@@ -150,6 +150,7 @@ export type OrderDetailsData = {
   settlements: Settlement[];
   txReceipts: TxReceipt[];
   updatedAt: string;
+  cancellationReasons?: string[];
 };
 
 type Settlement = {
@@ -321,6 +322,7 @@ export interface TransactionHistory {
   created_at: string;
   updated_at: string;
   order_id?: string;
+  refund_reason?: string | null;
 }
 
 export interface TransactionCreateInput {
@@ -337,12 +339,14 @@ export interface TransactionCreateInput {
   txHash?: string;
   timeSpent?: string;
   orderId?: string;
+  refundReason?: string | null;
 }
 
 export interface TransactionUpdateInput {
   status: TransactionStatus;
   timeSpent?: string;
   txHash?: string;
+  refundReason?: string | null;
 }
 
 export type JWTProvider = "privy" | "thirdweb";
@@ -381,6 +385,7 @@ export interface UpdateTransactionDetailsPayload
   extends UpdateTransactionStatusPayload {
   txHash?: string;
   timeSpent?: string;
+  refundReason?: string | null;
 }
 
 export type Currency = {

--- a/supabase/migrations/20250204000000_add_refund_reason_to_transactions.sql
+++ b/supabase/migrations/20250204000000_add_refund_reason_to_transactions.sql
@@ -1,0 +1,5 @@
+-- Add refund_reason column to store cancellation/refund reason from aggregator when status is refunded
+ALTER TABLE transactions
+ADD COLUMN IF NOT EXISTS refund_reason TEXT NULL;
+
+COMMENT ON COLUMN transactions.refund_reason IS 'Reason for refund when status is refunded (from aggregator cancellationReasons)';


### PR DESCRIPTION
### Description

This pull request adds support for tracking and displaying the reason for refunded transactions throughout the application. It introduces a new `refund_reason` field to the `transactions` table, updates backend and frontend logic to handle this field, and ensures the refund reason is shown to users when relevant.

**Database and API updates:**

* Added a `refund_reason` column to the `transactions` table to store the reason for refunds, and updated Supabase queries and API payloads to include this field when a transaction is refunded. [[1]](diffhunk://#diff-20a0c6b520646dc2a9a21787265e8115a23c55cbb63920c61be764bd096757a8R1-R5) [app/api/v1/transactions/[id]/route.tsL67-R79](diffhunk://#diff-1f650c105bbe1937a1d0c85df3f0847ad0b2e561174b297ae24cf600ee0c04a5L67-R79), [[2]](diffhunk://#diff-9fcb13b7c2e5ec2e9b82f19a90de0968567a2fcff197b4397e0c596db36d8869R160) F239bae5L322R322, F239bae5L339R339, F239bae5L385R385, [[3]](diffhunk://#diff-cf9ca814f61d82675e908bb51c095017cc6e0d61eaaced4b0212893f5cd3a2fdR464) [[4]](diffhunk://#diff-cf9ca814f61d82675e908bb51c095017cc6e0d61eaaced4b0212893f5cd3a2fdR480-R482)

**Backend logic enhancements:**

* Modified transaction update and creation logic to conditionally include the `refund_reason` when present, ensuring the backend accurately reflects the reason for refunds. ([app/api/v1/transactions/[id]/route.tsL42-R42](diffhunk://#diff-1f650c105bbe1937a1d0c85df3f0847ad0b2e561174b297ae24cf600ee0c04a5L42-R42), [app/api/v1/transactions/[id]/route.tsL67-R79](diffhunk://#diff-1f650c105bbe1937a1d0c85df3f0847ad0b2e561174b297ae24cf600ee0c04a5L67-R79), [[1]](diffhunk://#diff-e7af85e93533d18093c87e2dc01c024497959cf2953aa6423ab5b27ccb83bb49L91-R101) [[2]](diffhunk://#diff-e7af85e93533d18093c87e2dc01c024497959cf2953aa6423ab5b27ccb83bb49L133-R150) [[3]](diffhunk://#diff-e7af85e93533d18093c87e2dc01c024497959cf2953aa6423ab5b27ccb83bb49R161) [[4]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R225-R236)

**Frontend UI improvements:**

* Updated transaction details and list components to display the refund reason to users when a transaction has been refunded and a reason is available. [[1]](diffhunk://#diff-4bcb5c5fa5160668c19ce94ac1ef0d497de8993e1342ec2e8120cc4bdfcd5da0R376-R387) [[2]](diffhunk://#diff-083a09f2db3fb26263538565ee8e3d8f77638aa5d4591ffc44444e4de1393eb2R80) [[3]](diffhunk://#diff-083a09f2db3fb26263538565ee8e3d8f77638aa5d4591ffc44444e4de1393eb2R98-R105) [[4]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R656-R660) [[5]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R669-R676)

**Type and data structure updates:**

* Extended TypeScript types and interfaces to include `refundReason` and related fields, ensuring type safety across the application. [[1]](diffhunk://#diff-b83306d67ff352a9c40a4fba4a7acfd9f9074b5a44d119621af72cd78486353dR153) [[2]](diffhunk://#diff-b83306d67ff352a9c40a4fba4a7acfd9f9074b5a44d119621af72cd78486353dR325) [[3]](diffhunk://#diff-b83306d67ff352a9c40a4fba4a7acfd9f9074b5a44d119621af72cd78486353dR342-R349) [[4]](diffhunk://#diff-b83306d67ff352a9c40a4fba4a7acfd9f9074b5a44d119621af72cd78486353dR388)

**User experience enhancements:**

* Improved transaction status messaging and analytics tracking to include the refund reason, providing clearer feedback to users and more accurate event logging. [[1]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R372-R379) [[2]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R656-R660) [[3]](diffhunk://#diff-e9e97ad71fd764eb4144f4c360ba4d9ea81e6029b0cc1ce41332d406b4bbc6b6R669-R676)

### References

closes #356 


### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Refunded transactions now display the reason for the refund across transaction details, lists, and status pages.
  * Refund reasons are captured and shown alongside transaction status to provide clearer visibility into why a transaction was refunded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->