### PR TITLE
fix: drop engines.pnpm for Heroku compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,7 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": "22.x",
-    "pnpm": "10.14.0"
+    "node": "22.x"
   },
   "packageManager": "pnpm@10.27.0",
   "pnpm": {


### PR DESCRIPTION
### Description





### References


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the pnpm package manager version constraint, allowing greater flexibility with pnpm versions while maintaining Node.js version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->