### PR TITLE
fix: adjust MaintenanceBanner styling for 4k screen

### DIFF
--- a/app/components/MaintenanceNoticeModal.tsx
+++ b/app/components/MaintenanceNoticeModal.tsx
@@ -93,7 +93,7 @@ export function MaintenanceBanner({
 
   return (
     <motion.div
-      className="fixed left-0 right-0 top-16 z-30 mt-1 flex min-h-14 w-full items-center bg-[#0860F0] px-0"
+      className="fixed left-0 right-0 top-16 z-30 mt-1 flex min-h-14 w-full items-center bg-[#0860F0] px-0 max-w-[1480px] mx-auto"
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, ease: "easeOut" }}


### PR DESCRIPTION
### Description

This pull request makes a small adjustment to the styling of the `MaintenanceBanner` component. The change constrains the banner's width and centers it horizontally for improved layout consistency.

* Added `max-w-[1480px] mx-auto` to the `className` of the `motion.div` in `MaintenanceNoticeModal.tsx` to limit the banner's maximum width and center it on the page.


### References



### Testing
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/d43fa1cc-6e44-4dd6-b49b-a4fbc0872d3a" />



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).