### PR TITLE
feat: enhance maintenance notice functionality with auto-hide feature

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -20,7 +20,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <Providers>
       <div className="min-h-full min-w-full bg-white transition-colors dark:bg-neutral-900">
-        <div className="relative">
+        <div className={`relative ${config.maintenanceEnabled ? 'mb-16' : ''}`}>
           <Navbar />
           {config.maintenanceEnabled ? (
             <MaintenanceBanner />

--- a/app/components/MaintenanceNoticeModal.tsx
+++ b/app/components/MaintenanceNoticeModal.tsx
@@ -20,7 +20,7 @@ export interface MaintenanceNoticeConfig {
 const SCHEDULE =
   process.env.NEXT_PUBLIC_MAINTENANCE_SCHEDULE || "";
 
-const ENABLED = !!process.env.NEXT_PUBLIC_MAINTENANCE_NOTICE_ENABLED;
+const ENABLED = process.env.NEXT_PUBLIC_MAINTENANCE_NOTICE_ENABLED === "true";
 
 /** Simple deterministic hash for the noticeKey so each schedule gets its own. */
 function simpleHash(str: string): string {
@@ -29,6 +29,77 @@ function simpleHash(str: string): string {
     h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
   }
   return Math.abs(h).toString(36);
+}
+
+// ---------------------------------------------------------------------------
+// Parse the end-of-maintenance datetime from the schedule text so the notice
+// auto-hides once the window is over — no code change or redeploy needed.
+//
+// Expected format examples:
+//   "Friday, February 13th, from 7:00 PM to 11:00 PM WAT"
+//   "Saturday, March 1st, from 2:00 AM to 6:00 AM UTC"
+// ---------------------------------------------------------------------------
+
+const TZ_OFFSETS: Record<string, number> = {
+  UTC: 0, GMT: 0,
+  WAT: 1, CET: 1,
+  CAT: 2, CEST: 2, EET: 2, SAST: 2,
+  EAT: 3, EEST: 3,
+  EST: -5, CST: -6, MST: -7, PST: -8,
+  EDT: -4, CDT: -5, MDT: -6, PDT: -7,
+  IST: 5.5, SGT: 8, JST: 9, AEST: 10,
+};
+
+const MONTH_MAP: Record<string, number> = {
+  january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+  july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+};
+
+/**
+ * Parse the end datetime from the schedule string.
+ * Returns a Date in UTC, or null if parsing fails.
+ */
+function parseScheduleEndTime(schedule: string): Date | null {
+  if (!schedule) return null;
+  try {
+    // Extract month + day: "February 13th"
+    const dateMatch = schedule.match(
+      /(\b(?:January|February|March|April|May|June|July|August|September|October|November|December))\s+(\d{1,2})(?:st|nd|rd|th)?/i,
+    );
+    if (!dateMatch) return null;
+    const month = MONTH_MAP[dateMatch[1].toLowerCase()];
+    const day = parseInt(dateMatch[2], 10);
+    if (month === undefined || isNaN(day)) return null;
+
+    // Extract end time: "to 11:00 PM"
+    const timeMatch = schedule.match(/to\s+(\d{1,2}):(\d{2})\s*(AM|PM)/i);
+    if (!timeMatch) return null;
+    let hours = parseInt(timeMatch[1], 10);
+    const minutes = parseInt(timeMatch[2], 10);
+    const meridiem = timeMatch[3].toUpperCase();
+    if (meridiem === "PM" && hours !== 12) hours += 12;
+    if (meridiem === "AM" && hours === 12) hours = 0;
+
+    // Extract timezone abbreviation (last word of uppercase letters)
+    const tzMatch = schedule.match(/([A-Z]{2,5})\s*$/);
+    const tzName = tzMatch ? tzMatch[1] : "UTC";
+    const tzOffset = TZ_OFFSETS[tzName] ?? 0;
+
+    // Build the date using the current year
+    const year = new Date().getFullYear();
+    // Construct as UTC then subtract the tz offset to get true UTC
+    const utcMs = Date.UTC(year, month, day, hours, minutes) - tzOffset * 60 * 60 * 1000;
+    return new Date(utcMs);
+  } catch {
+    return null;
+  }
+}
+
+/** Check (client-side) whether the maintenance window has already ended. */
+function isMaintenanceOver(): boolean {
+  const endTime = parseScheduleEndTime(SCHEDULE);
+  if (!endTime) return false; // can't parse → stay visible (safe default)
+  return Date.now() > endTime.getTime();
 }
 
 export const DEFAULT_MAINTENANCE_CONFIG: MaintenanceNoticeConfig = {
@@ -89,16 +160,29 @@ export function MaintenanceBanner({
 }: {
   config?: MaintenanceNoticeConfig;
 }) {
-  if (!config.enabled) return null;
+  const [expired, setExpired] = useState(false);
+
+  useEffect(() => {
+    if (!config.enabled) return;
+    // Check immediately
+    if (isMaintenanceOver()) { setExpired(true); return; }
+    // Re-check every 10 minutes so it auto-hides without a reload
+    const id = setInterval(() => {
+      if (isMaintenanceOver()) { setExpired(true); clearInterval(id); }
+    }, 600_000);
+    return () => clearInterval(id);
+  }, [config.enabled]);
+
+  if (!config.enabled || expired) return null;
 
   return (
     <motion.div
-      className="fixed left-0 right-0 top-16 z-30 mt-1 flex min-h-14 w-full items-center bg-[#0860F0] px-0 max-w-[1480px] mx-auto"
+      className="fixed left-0 right-0 top-16 z-10 mt-1 hidden min-h-[4.5rem] items-center bg-[#2D77E2] py-2 sm:flex"
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, ease: "easeOut" }}
     >
-      <div className="relative flex w-full items-center sm:pr-8">
+      <div className="mx-auto flex w-full max-w-screen-2xl items-center justify-between px-4 lg:px-8">
         {/* Mobile illustration */}
         <div className="absolute left-0 top-0 z-0 sm:hidden">
           <Image
@@ -148,6 +232,7 @@ export function MaintenanceNoticeModal({
 
   useEffect(() => {
     if (!config.enabled) return;
+    if (isMaintenanceOver()) return;
     if (isDismissed(config.noticeKey)) return;
     // Small delay so it doesn't flash on initial page load
     const timer = setTimeout(() => setIsOpen(true), 400);

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   biconomyPaymasterKey:
     process.env.NEXT_PUBLIC_BICONOMY_PAYMASTER_KEY || "",
   maintenanceEnabled:
-    !!process.env.NEXT_PUBLIC_MAINTENANCE_NOTICE_ENABLED &&
+    process.env.NEXT_PUBLIC_MAINTENANCE_NOTICE_ENABLED === "true" &&
     !!(process.env.NEXT_PUBLIC_MAINTENANCE_SCHEDULE || "").trim(),
   maintenanceSchedule:
     process.env.NEXT_PUBLIC_MAINTENANCE_SCHEDULE || "",


### PR DESCRIPTION
### Description

This pull request introduces enhancements to the maintenance notice system, including automatic hiding of the maintenance banner and modal once the scheduled window has ended, improved environment variable handling, and UI adjustments for the maintenance banner. The changes ensure that maintenance notices are more reliable, user-friendly, and require less manual intervention.

Maintenance window auto-hide and parsing improvements:

* Added logic to parse the maintenance schedule string and automatically hide the maintenance banner and modal when the maintenance window ends, using timezone-aware parsing and client-side checks (`parseScheduleEndTime`, `isMaintenanceOver`).
* Updated the `MaintenanceBanner` and `MaintenanceNoticeModal` components to check for maintenance expiration and auto-hide without requiring a page reload. [[1]](diffhunk://#diff-fe9974b1c197fb35e822b960c47535fcbb386091e401856030ace73d0453ca9eL92-R185) [[2]](diffhunk://#diff-fe9974b1c197fb35e822b960c47535fcbb386091e401856030ace73d0453ca9eR235)

Environment variable handling:

* Changed the interpretation of `NEXT_PUBLIC_MAINTENANCE_NOTICE_ENABLED` to require the string `"true"` instead of any truthy value, improving clarity and preventing accidental activation. [[1]](diffhunk://#diff-fe9974b1c197fb35e822b960c47535fcbb386091e401856030ace73d0453ca9eL23-R23) [[2]](diffhunk://#diff-c4ed30e3604e1eb907168cfdb8e17a52ed1efcf4f87f187a96588db4b0249620L21-R21)

UI and layout adjustments:

* Modified the `AppLayout` to add extra margin at the bottom when maintenance is enabled, preventing overlap with the banner.
* Updated the maintenance banner's styling for better visibility and responsiveness, including new color and layout classes.

### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance banner now automatically hides once the maintenance window expires.
  * Enhanced maintenance notice handling with improved timing and layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->