### PR TITLE
fix: convert direct amount string to wei

### DIFF
--- a/app/components/WalletTransferApprovalModal.tsx
+++ b/app/components/WalletTransferApprovalModal.tsx
@@ -262,7 +262,7 @@ const WalletTransferApprovalModal: React.FC<WalletTransferApprovalModalProps> = 
                         // This uses Privy's smart wallet batch capability with Biconomy paymaster
                         const calls = chainTokens.map((token) => {
                             // Use parseUnits with fixed-point string to avoid scientific notation for very small amounts
-                            const amountString = token.amount.toFixed(token.decimals);
+                            const amountString = token.amount.toString();
                             const amountInWei = parseUnits(amountString, token.decimals);
 
                             // ✅ Encode the transfer function call


### PR DESCRIPTION
### Description

This pull request makes a minor update to the `WalletTransferApprovalModal` component. The change updates how token amounts are converted to strings before being parsed to units, which helps ensure accuracy when dealing with very small values.

* Updated the conversion of `token.amount` to use `toString()` instead of `toFixed(token.decimals)` before passing it to `parseUnits`, improving precision for small token amounts in `WalletTransferApprovalModal.tsx`.

### References

THIS FIXES THE FAILING TRANSACTIONS WHEN TRYING TO MIGRATE VERY SMALL TOKEN AMOUNTS


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric precision handling for token transfer amounts to ensure accurate calculations, particularly when dealing with very small or very large token values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->