### PR TITLE
fix: correct logic for EOA usage in useShouldUseEOA hook to ensure ne…

### DIFF
--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -156,18 +156,18 @@ export function useShouldUseEOA(): boolean {
     // When not migrated, crossChainTotal is SCW total across all networks (not selected network only)
     const smartWalletCrossChainTotal = hasSmartWallet && !isMigrationComplete ? crossChainTotal : 0;
 
+    // Single ready guard: during Privy init (user null) preserve last value, don't update ref
+    if (user == null) {
+        return lastValueRef.current ?? false;
+    }
+
     if (isMigrationComplete) {
         lastValueRef.current = true;
         return true;
     }
     if (!hasSmartWallet) {
-        // Only treat as EOA when user is loaded; avoid corrupting lastValueRef during Privy init (user null)
-        if (user != null) {
-            lastValueRef.current = true;
-            return true; // No smart account → use EOA only (e.g. new users with smart wallet creation disabled)
-        }
-        lastValueRef.current = false;
-        return false;
+        lastValueRef.current = true;
+        return true; // No smart account → use EOA only (e.g. new users with smart wallet creation disabled)
     }
     // During load, keep last value to avoid SCW→EOA flicker on refresh
     if (isBalanceLoading) return lastValueRef.current ?? false;


### PR DESCRIPTION
### Description

This PR updates the Noblocks wallet logic so that **users without a smart account** (e.g. after smart wallet creation is disabled in Privy) are always treated as EOA-only: the app uses and displays their embedded wallet (EOA) for nav, balance, and actions, and they never see any migration flow (banner or zero-balance modal).

**Change:** In `useShouldUseEOA` (`app/hooks/useEIP7702Account.ts`), when the user has no smart wallet in Privy (`!hasSmartWallet`), the hook now returns `true` (use EOA) instead of `false`. Previously, “no smart account” still returned “don’t use EOA,” which was inconsistent for users who only have an embedded wallet.

**Impact:**
- **Users with a smart account:** Unchanged. They still go through the same migration-status and balance logic (migrated → EOA; not migrated + balance → SCW; not migrated + 0 balance → EOA). Migration banner, zero-balance modal, and migration flow are unchanged.
- **Users without a smart account:** Now consistently use EOA only; no migration UI is shown (the existing early return in `useWalletMigrationStatus` already prevented banner/modal for this case).

**Alternatives considered:** Using a DB “user first seen” table to distinguish new vs existing was discussed; this approach relies on Privy configuration (disable smart wallet creation for new users) and a single code path: “no smart account → EOA only,” with no new backend or schema.

### References

_No issue or external references; delete this section if your repo doesn’t require it._

### Testing

- **Manual:** Log in as a user who has **no** smart wallet in Privy (or use an account created after disabling smart wallet creation). Confirm: (1) No migration banner or zero-balance modal appears; (2) Nav and balance show the embedded (EOA) address; (3) Create order / transfer use the EOA.
- **Regression:** Log in as a user who **has** a smart wallet. Confirm: migration banner / zero-balance modal and migration flow behave as before; after migration or with zero SCW balance, EOA is used as before.
- **Environment:** Node/Next.js; developed in standard Noblocks setup (language/platform/browser as applicable).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed/fixed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented temporary account-mode flicker during startup by holding the previous account-mode value until user state is available, avoiding abrupt switches while initialization completes.
  * Ensured devices without a linked smart wallet consistently use external-account behavior rather than briefly appearing as non-external, improving stability when transitioning from smart-wallet to external-account modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->