### PR TITLE
fix: update messaging in MigrationZeroBalanceModal for clarity and us…

### DIFF
--- a/app/components/MigrationZeroBalanceModal.tsx
+++ b/app/components/MigrationZeroBalanceModal.tsx
@@ -152,7 +152,7 @@ export const MigrationZeroBalanceModal: React.FC<MigrationZeroBalanceModalProps>
                                                 backgroundClip: "text",
                                             }}
                                         >
-                                            Your wallet is now exportable
+                                            One wallet - Import anywhere
                                         </h2>
 
                                         <div className="mb-4 space-y-4">
@@ -161,14 +161,14 @@ export const MigrationZeroBalanceModal: React.FC<MigrationZeroBalanceModalProps>
                                                     className="font-[Inter] text-sm font-light leading-5 tracking-normal text-text-body dark:text-[#FFFFFFCC]"
 
                                                 >
-                                                    Your wallet has been successfully set up and is now exportable. This means you can now export your wallet and use it across different platforms like MetaMask.
+                                                    Your wallet has been successfully set up and is compatible with other on-chain apps.
                                                 </p>
                                             </div>
                                             <div className="rounded-[20px] bg-accent-gray p-4 dark:bg-[#2C2C2C]">
                                                 <p
                                                     className="font-[Inter] text-sm font-light leading-5 tracking-normal text-text-body dark:text-[#FFFFFFCC]"
                                                 >
-                                                    Note: If you&apos;ve saved or shared your wallet address elsewhere, make sure to update it to your new wallet address.
+                                                    Note: If you've saved or shared your wallet address elsewhere, make sure to update it to your new wallet address.
 
                                                 </p>
                                             </div>


### PR DESCRIPTION
### Description

This PR updates Noblocks wallet logic so that **users without a smart account** (e.g. after smart wallet creation is disabled in Privy) are consistently treated as EOA-only: the app uses and displays their embedded wallet (EOA) for nav, balance, and actions, and they never see any migration flow (banner or zero-balance modal).

**Background:** With smart wallet creation disabled in Privy, new users only receive an embedded EOA. The app should treat "no smart account" as "use EOA only" and not show migration UI. Existing users who already have a smart wallet continue to see the migration flow and behaviour unchanged.

**Changes in `app/hooks/useEIP7702Account.ts` (`useShouldUseEOA`):**

1. **No smart account → use EOA:** When the user has no smart wallet in Privy (`!hasSmartWallet`), the hook now returns `true` (use EOA) instead of `false`, so EOA-only users get the correct experience.
2. **Single ready guard:** When `user == null` (Privy still initialising), the hook returns `lastValueRef.current ?? false` without updating the ref. This avoids corrupting `lastValueRef` during init and prevents SCW users from briefly being treated as EOA until balances load. It also centralises init-phase handling in one place.
3. **Simplified `!hasSmartWallet` block:** Because the rest of the hook runs only when `user != null`, the inner `if (user != null)` was removed; when `!hasSmartWallet`, we set `lastValueRef.current = true` and return `true`.

**Impact:**
- **Users with a smart account:** Unchanged. They still follow the same migration-status and balance logic; migration banner, zero-balance modal, and migration flow behave as before. Init-phase flicker for SCW users is fixed by the ready guard.
- **Users without a smart account:** They consistently use EOA only and never see migration UI (the existing early return in `useWalletMigrationStatus` already prevented banner/modal for this case).

**Breaking changes:** None.

**Alternatives considered:** Using a DB "user first seen" table to distinguish new vs existing was discussed; this approach relies on Privy configuration (disable smart wallet creation for new users) and a single code path: "no smart account → EOA only," with no new backend or schema.

### References

_No issue or external references._

### Testing

- **Manual – EOA-only (new user):** Log in as a user with no smart wallet in Privy (or an account created after disabling smart wallet creation). Confirm: (1) No migration banner or zero-balance modal; (2) Nav and balance show the embedded (EOA) address; (3) Create order / transfer use the EOA.
- **Manual – SCW (existing user):** Log in as a user with a smart wallet. Confirm: migration banner / zero-balance modal and migration flow behave as before; after migration or with zero SCW balance, EOA is used; no brief EOA flicker during initial load (ready guard).
- **Regression:** Refresh as both EOA-only and SCW users; confirm no console errors and that wallet/balance UI remains correct after load.
- **Environment:** Node / Next.js; standard Noblocks setup.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated modal messaging: header now reads "One wallet - Import anywhere" and body clarifies the wallet is "successfully set up and is compatible with other on‑chain apps."
  * Adjusted note paragraph formatting and punctuation for clearer presentation. No functional behavior or APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->