### PR TITLE
feat: enhance FundWalletForm to support embedded wallets and EOA usage

### DIFF
--- a/app/components/FundWalletForm.tsx
+++ b/app/components/FundWalletForm.tsx
@@ -141,6 +141,12 @@ export const FundWalletForm: React.FC<{
       const walletAddress = shouldUseEOA
         ? (embeddedWallet?.address ?? "")
         : (smartWalletAccount?.address ?? "");
+
+      if (!walletAddress) {
+        setIsFundConfirming(false);
+        toast.error("Wallet not ready. Please try again.");
+        return;
+      }
       setFundingInProgress(true);
       await handleFundWallet(
         walletAddress,


### PR DESCRIPTION
### Description

This pull request updates the `FundWalletForm` component to support selecting between an EOA (Externally Owned Account) and a smart wallet when funding a wallet, based on new logic. The changes improve how the funding address is determined and make the component more flexible for different wallet types.

Wallet selection improvements:

* Added the `useWallets` and `useShouldUseEOA` hooks to allow the component to access all available wallets and determine whether to use an EOA or a smart wallet when funding. (`app/components/FundWalletForm.tsx`)
* Updated the logic for determining the `walletAddress` to use the EOA address if `shouldUseEOA` is true, otherwise defaulting to the smart wallet address. (`app/components/FundWalletForm.tsx`)

Component state and initialization:

* Included `wallets` and `shouldUseEOA` in the component's state initialization to support the new wallet selection logic. (`app/components/FundWalletForm.tsx`)


### References

closes #393 


### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet selection now respects embedded vs. smart wallet types, improving address resolution in the fund wallet flow.
* **Bug Fixes**
  * Funding flow now halts with a clear user-facing error and resets UI if no valid wallet address is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->