### PR TITLE
Revert "feat: make recipient name editable when unresolved from psp"

### DIFF
--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -2,11 +2,7 @@
 import { ImSpinner } from "react-icons/im";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ArrowDown01Icon,
-  InformationSquareIcon,
-  Tick02Icon,
-} from "hugeicons-react";
+import { ArrowDown01Icon, Tick02Icon } from "hugeicons-react";
 
 import { AnimatedFeedbackItem } from "../AnimatedComponents";
 import { InstitutionProps } from "@/app/types";
@@ -15,7 +11,6 @@ import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
 import { classNames } from "@/app/utils";
-import { trackEvent } from "@/app/hooks/analytics/useMixpanel";
 import {
   RecipientDetails,
   RecipientDetailsFormProps,
@@ -27,48 +22,6 @@ import {
 } from "@/app/api/aggregator";
 import { SavedBeneficiariesModal } from "@/app/components/recipient/SavedBeneficiariesModal";
 import { SelectBankModal } from "@/app/components/recipient/SelectBankModal";
-
-interface RecipientAlertProps {
-  isEditable: boolean;
-  message: string;
-  currency: string;
-  institutionName: string;
-  onLearnMore: () => void;
-}
-
-const RecipientAlert = ({
-  isEditable,
-  message,
-  currency,
-  institutionName,
-  onLearnMore,
-}: RecipientAlertProps) => {
-  const handleLearnMoreClick = () => {
-    trackEvent("recipient_alert_learn_more_clicked", {
-      alert_type: isEditable ? "verification_failed" : "verification_success",
-      message: message.substring(0, 100),
-      currency,
-      institution: institutionName,
-    });
-    onLearnMore();
-  };
-
-  return (
-    <div className="flex h-fit min-h-[48px] w-full items-start gap-2 rounded-xl bg-warning-background/35 px-3 py-2 dark:bg-warning-background/10">
-      <InformationSquareIcon className="h-[36px] w-[36px] text-warning-foreground dark:text-warning-text md:h-[24px] md:w-[24px]" />
-      <p className="text-xs font-light leading-tight text-warning-foreground dark:text-warning-text">
-        {message}{" "}
-        <button
-          type="button"
-          onClick={handleLearnMoreClick}
-          className="font-semibold text-lavender-500"
-        >
-          Learn more.
-        </button>
-      </p>
-    </div>
-  );
-};
 
 export const RecipientDetailsForm = ({
   formMethods,
@@ -105,7 +58,6 @@ export const RecipientDetailsForm = ({
 
   const [isFetchingRecipientName, setIsFetchingRecipientName] = useState(false);
   const [recipientNameError, setRecipientNameError] = useState("");
-  const [isRecipientNameEditable, setIsRecipientNameEditable] = useState(false);
 
   const [savedRecipients, setSavedRecipients] = useState<
     RecipientDetailsWithId[]
@@ -115,8 +67,6 @@ export const RecipientDetailsForm = ({
 
   const [recipientToDelete, setRecipientToDelete] =
     useState<RecipientDetails | null>(null);
-
-  const [alertViewed, setAlertViewed] = useState(false);
 
   const institutionsDropdownRef = useRef<HTMLDivElement>(null);
   useOutsideClick({
@@ -128,13 +78,6 @@ export const RecipientDetailsForm = ({
   const [isReturningFromPreview, setIsReturningFromPreview] = useState(false);
 
   const prevCurrencyRef = useRef(currency);
-
-  const handleLearnMore = () => {
-    window.open(
-      "https://noblocks.xyz/blog/understanding-account-name-verification-on-noblocks",
-      "_blank",
-    );
-  };
 
   /**
    * Array of institutions filtered and sorted alphabetically based on the bank search term.
@@ -181,7 +124,6 @@ export const RecipientDetailsForm = ({
     recipient.name = recipient.name.replace(/\s+/g, " ").trim();
     setValue("recipientName", recipient.name, { shouldDirty: true });
     setIsManualEntry(false);
-    setIsRecipientNameEditable(false);
     setIsModalOpen(false);
   };
 
@@ -243,40 +185,6 @@ export const RecipientDetailsForm = ({
 
   // * USE EFFECTS
 
-  // Track alert visibility
-  useEffect(() => {
-    const shouldShowAlert =
-      (isRecipientNameEditable &&
-        recipientName &&
-        !errors.recipientName &&
-        !recipientNameError) ||
-      (!isRecipientNameEditable && recipientName && !recipientNameError);
-
-    if (shouldShowAlert && !alertViewed) {
-      trackEvent("recipient_alert_viewed", {
-        alert_type: isRecipientNameEditable
-          ? "verification_failed"
-          : "verification_success",
-        has_recipient_name: !!recipientName,
-        is_editable: isRecipientNameEditable,
-        currency: currency,
-        institution: selectedInstitution?.name || "",
-      });
-      setAlertViewed(true);
-    } else if (!shouldShowAlert && alertViewed) {
-      // Reset viewed state when alert is no longer visible
-      setAlertViewed(false);
-    }
-  }, [
-    isRecipientNameEditable,
-    recipientName,
-    recipientNameError,
-    alertViewed,
-    currency,
-    selectedInstitution?.name,
-    errors.recipientName,
-  ]);
-
   useEffect(() => {
     let isCancelled = false;
 
@@ -330,7 +238,6 @@ export const RecipientDetailsForm = ({
         setValue("recipientName", "");
         setValue("accountIdentifier", "");
         setRecipientNameError("");
-        setIsRecipientNameEditable(false);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -348,14 +255,10 @@ export const RecipientDetailsForm = ({
 
       if (!institution || !accountIdentifier) {
         setRecipientNameError("");
-        setValue("recipientName", "");
-        setIsRecipientNameEditable(false);
         return;
       }
 
       if (isNGN && digits.length !== requiredLen) {
-        setValue("recipientName", "");
-        setIsRecipientNameEditable(false);
         if (digits.length > 0) {
           setRecipientNameError(
             requiredLen === 10
@@ -377,20 +280,10 @@ export const RecipientDetailsForm = ({
           institution: institution.toString(),
           accountIdentifier: accountIdentifier.toString(),
         });
-
-        // Check if the response is "Ok" which means verification failed but not an error
-        if (accountName.toLowerCase() === "ok") {
-          setIsRecipientNameEditable(true);
-          setValue("recipientName", "");
-          setRecipientNameError("");
-        } else {
-          setIsRecipientNameEditable(false);
-          setValue("recipientName", accountName);
-        }
+        setValue("recipientName", accountName);
         setIsFetchingRecipientName(false);
       } catch (error) {
         setRecipientNameError("No recipient account found.");
-        setIsRecipientNameEditable(false);
         setIsFetchingRecipientName(false);
       }
     };
@@ -438,7 +331,6 @@ export const RecipientDetailsForm = ({
     setValue("accountIdentifier", "");
     setRecipientNameError("");
     setIsManualEntry(true);
-    setIsRecipientNameEditable(false);
   };
 
   // Only clear when currency actually changes (not on mount or preview return)
@@ -549,45 +441,7 @@ export const RecipientDetailsForm = ({
             </div>
           ) : (
             <>
-              {isRecipientNameEditable ? (
-                <AnimatedFeedbackItem className="flex-col items-start gap-2">
-                  <input
-                    type="text"
-                    placeholder="Enter recipient name"
-                    {...register("recipientName", {
-                      validate: (value) => {
-                        const normalized = String(value ?? "")
-                          .replace(/\s+/g, " ")
-                          .trim();
-
-                        if (!normalized) {
-                          return "Recipient name is required";
-                        }
-
-                        if (normalized.length < 2) {
-                          return "Recipient name must be at least 2 characters";
-                        }
-
-                        return true;
-                      },
-                    })}
-                    className={classNames(
-                      "w-full rounded-xl border bg-transparent px-4 py-2.5 text-sm outline-none transition-all duration-300 placeholder:text-text-placeholder focus:outline-none dark:text-white/80 dark:placeholder:text-white/30",
-                      errors.recipientName
-                        ? "border-input-destructive focus:border-gray-400 dark:border-input-destructive"
-                        : "border-border-input dark:border-white/20 dark:focus:border-white/40 dark:focus:ring-offset-neutral-900",
-                    )}
-                  />
-                  {errors.recipientName && (
-                    <InputError
-                      message={
-                        errors.recipientName.message ||
-                        "Recipient name is required"
-                      }
-                    />
-                  )}
-                </AnimatedFeedbackItem>
-              ) : recipientName ? (
+              {recipientName ? (
                 <AnimatedFeedbackItem className="justify-between text-gray-400 dark:text-white/50">
                   <motion.div
                     className="relative overflow-hidden rounded-lg p-0.5"
@@ -620,29 +474,6 @@ export const RecipientDetailsForm = ({
         </AnimatePresence>
       </div>
 
-      <AnimatedFeedbackItem>
-        {isRecipientNameEditable &&
-          recipientName &&
-          !errors.recipientName &&
-          !recipientNameError && (
-            <RecipientAlert
-              isEditable={true}
-              message="Unable to verify details. Ensure the recipient's account number is accurate before proceeding with swap."
-              currency={currency}
-              institutionName={selectedInstitution?.name || ""}
-              onLearnMore={handleLearnMore}
-            />
-          )}
-        {!isRecipientNameEditable && recipientName && !recipientNameError && (
-          <RecipientAlert
-            isEditable={false}
-            message="Make sure the recipient's account number is accurate before proceeding with swap."
-            currency={currency}
-            institutionName={selectedInstitution?.name || ""}
-            onLearnMore={handleLearnMore}
-          />
-        )}
-      </AnimatedFeedbackItem>
       <SelectBankModal
         isOpen={isSelectBankModalOpen}
         onClose={() => setIsSelectBankModalOpen(false)}

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -189,26 +189,13 @@ export const TransactionPreview = ({
     network: selectedNetwork.chain.name,
   };
 
-  const normalizeAccountIdentifier = (identifier: string): string => {
-    const digits = identifier.replace(/\D/g, "");
-    if (
-      currency === "UGX" &&
-      formValues.accountType === "mobile_money" &&
-      !digits.startsWith("256")
-    ) {
-      const local = digits.startsWith("0") ? digits.slice(1) : digits;
-      return `256${local}`;
-    }
-    return digits || identifier;
-  };
-
   const prepareCreateOrderParams = async () => {
     const providerId =
       searchParams.get("provider") || searchParams.get("PROVIDER");
 
     // Prepare recipient data
     const recipient = {
-      accountIdentifier: normalizeAccountIdentifier(formValues.accountIdentifier),
+      accountIdentifier: formValues.accountIdentifier,
       accountName: recipientName,
       institution: formValues.institution,
       memo: formValues.memo,
@@ -613,7 +600,7 @@ export const TransactionPreview = ({
             institution,
             supportedInstitutions,
           ) as string,
-          account_identifier: normalizeAccountIdentifier(accountIdentifier),
+          account_identifier: accountIdentifier,
           ...(memo && { memo }),
         },
         status: "pending",


### PR DESCRIPTION
Reverts paycrest/noblocks#407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the recipient details form by removing the editable recipient name field; recipient information now displays as read-only.
  * Removed alert notifications from the recipient details flow.
  * Updated account identifier processing to handle values directly without additional formatting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->