### PR TITLE
feat: integrate WalletMigrationModal across components

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -24,6 +24,7 @@ import { WalletView, HistoryView, SettingsView } from "./wallet-mobile-modal";
 import { slideUpAnimation } from "./AnimatedComponents";
 import { FundWalletForm, TransferForm } from "./index";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
+import WalletMigrationModal from "./WalletMigrationModal";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
 import { clearUserSessionData } from "../lib/session-cleanup";
 
@@ -40,6 +41,7 @@ export const MobileDropdown = ({
   const [isNetworkListOpen, setIsNetworkListOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
+  const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false);
 
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { user, linkEmail, updateEmail, exportWallet } = usePrivy();
@@ -292,6 +294,10 @@ export const MobileDropdown = ({
                                 onClose={onClose}
                                 showBackButton
                                 setCurrentView={setCurrentView}
+                                onOpenMigration={() => {
+                                  onClose();
+                                  setIsMigrationModalOpen(true);
+                                }}
                               />
                             </div>
                           )}
@@ -328,6 +334,11 @@ export const MobileDropdown = ({
         isOpen={isWarningModalOpen}
         onClose={() => setIsWarningModalOpen(false)}
         address={walletForCopy?.address ?? ""}
+      />
+
+      <WalletMigrationModal
+        isOpen={isMigrationModalOpen}
+        onClose={() => setIsMigrationModalOpen(false)}
       />
     </>
   );

--- a/app/components/TransferForm.tsx
+++ b/app/components/TransferForm.tsx
@@ -40,7 +40,8 @@ export const TransferForm: React.FC<{
   onSuccess?: () => void;
   showBackButton?: boolean;
   setCurrentView?: React.Dispatch<React.SetStateAction<MobileView>>;
-}> = ({ onClose, onSuccess, showBackButton = false, setCurrentView }) => {
+  onOpenMigration?: () => void;
+}> = ({ onClose, onSuccess, showBackButton = false, setCurrentView, onOpenMigration }) => {
   const searchParams = useSearchParams();
   const { selectedNetwork } = useNetwork();
   const { user, getAccessToken } = usePrivy();
@@ -123,7 +124,7 @@ export const TransferForm: React.FC<{
     supportedTokens: fetchedTokens,
     getAccessToken,
     refreshBalance,
-    onRequireMigration: () => setIsMigrationModalOpen(true),
+    onRequireMigration: onOpenMigration ?? (() => setIsMigrationModalOpen(true)),
   });
 
   useEffect(() => {
@@ -328,7 +329,11 @@ export const TransferForm: React.FC<{
 
   const onFormSubmit = (data: any) => {
     if (needsMigration || isMigrationMandatory) {
-      setIsMigrationModalOpen(true);
+      if (onOpenMigration) {
+        onOpenMigration();
+      } else {
+        setIsMigrationModalOpen(true);
+      }
       return;
     }
     transfer({ ...data, resetForm: reset });
@@ -635,10 +640,12 @@ export const TransferForm: React.FC<{
       </button>
     </form>
 
-    <WalletMigrationModal
-      isOpen={isMigrationModalOpen}
-      onClose={() => setIsMigrationModalOpen(false)}
-    />
+    {!onOpenMigration && (
+      <WalletMigrationModal
+        isOpen={isMigrationModalOpen}
+        onClose={() => setIsMigrationModalOpen(false)}
+      />
+    )}
     </>
   );
 };

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -38,6 +38,7 @@ import { useSortedCrossChainBalances } from "../hooks/useSortedCrossChainBalance
 import TransactionList from "./transaction/TransactionList";
 import { FundWalletForm, TransferForm } from "./index";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
+import WalletMigrationModal from "./WalletMigrationModal";
 import { useCNGNRate } from "../hooks/useCNGNRate";
 
 const Divider = () => (
@@ -47,6 +48,7 @@ const Divider = () => (
 export const WalletDetails = () => {
   const [isTransferModalOpen, setIsTransferModalOpen] =
     useState<boolean>(false);
+  const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false);
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"balances" | "transactions">(
     "balances",
@@ -490,8 +492,19 @@ export const WalletDetails = () => {
             isOpen={isTransferModalOpen}
             onClose={() => setIsTransferModalOpen(false)}
           >
-            <TransferForm onClose={() => setIsTransferModalOpen(false)} />
+            <TransferForm
+              onClose={() => setIsTransferModalOpen(false)}
+              onOpenMigration={() => {
+                setIsTransferModalOpen(false);
+                setIsMigrationModalOpen(true);
+              }}
+            />
           </AnimatedModal>
+
+          <WalletMigrationModal
+            isOpen={isMigrationModalOpen}
+            onClose={() => setIsMigrationModalOpen(false)}
+          />
 
           <AnimatedModal
             isOpen={isFundModalOpen}

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -49,7 +49,8 @@ export function useSwapButton({
   const hasInsufficientBalance = totalRequired > balance;
 
   const isEnabled = (() => {
-    if (isMigrationMandatory || needsMigration) return true;
+    if (needsMigration && authenticated && !isInjectedWallet) return true;
+    if (isMigrationMandatory) return true;
     if (!rate) return false;
     if (isInjectedWallet && hasInsufficientBalance) {
       return false;
@@ -89,6 +90,10 @@ export function useSwapButton({
   })();
 
   const buttonText = (() => {
+    if (needsMigration && authenticated && !isInjectedWallet) {
+      return "Migrate wallet to swap";
+    }
+
     if (isInjectedWallet && hasInsufficientBalance) {
       return "Insufficient balance";
     }
@@ -114,7 +119,11 @@ export function useSwapButton({
     handleFundWallet: () => void,
     setIsKycModalOpen: () => void,
     isUserVerified: boolean,
+    openMigrationModal?: () => void,
   ) => {
+    if (needsMigration && authenticated && !isInjectedWallet && openMigrationModal) {
+      return openMigrationModal;
+    }
     if (!authenticated && !isInjectedWallet) {
       return login;
     }

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -913,6 +913,7 @@ export const TransactionForm = ({
                   ),
                 () => setIsKycModalOpen(true),
                 isUserVerified,
+                () => setIsMigrationModalOpen(true),
               )}
             >
               {buttonText}


### PR DESCRIPTION
### Description
This pull request introduces wallet migration modal support throughout the mobile wallet UI, enabling users to migrate their wallets when required by various flows (such as transfers and swaps). The changes ensure that the migration modal is properly triggered and displayed in relevant scenarios, and that the UI and button logic reflect migration requirements.

**Wallet migration modal integration:**

* Added `WalletMigrationModal` imports and state management to `MobileDropdown.tsx` and `WalletDetails.tsx`, along with logic to open/close the modal when migration is required. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R27) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R44) [[3]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R338-R342) [[4]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R41) [[5]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R51) [[6]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0L493-R508)

* Updated `TransferForm` to accept an `onOpenMigration` prop, allowing parent components to control when the migration modal is shown. The form now triggers migration via this callback when needed, and conditionally renders its own modal only if the prop is not provided. [[1]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afL43-R44) [[2]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afL126-R127) [[3]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afR332-R336) [[4]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afR643-R648)

**Swap and transaction button logic improvements:**

* Enhanced `useSwapButton` hook to:
  - Enable the swap button and show "Migrate wallet to swap" when migration is needed and the user is authenticated (but not using an injected wallet).
  - Return the correct button handler to trigger the migration modal when appropriate. [[1]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696L52-R53) [[2]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696R93-R96) [[3]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696R122-R126)

* Updated `TransactionForm` to pass a migration modal open callback to the button handler, ensuring migration is surfaced in the transaction flow as well.

**Summary of most important changes:**

**Wallet migration modal integration**
- Integrated `WalletMigrationModal` into `MobileDropdown` and `WalletDetails`, with proper state and open/close logic. [[1]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R27) [[2]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R44) [[3]](diffhunk://#diff-da0424d36864efc6eae58426bbffee8a857e2f6e22d3ddf1e8fd122582581109R338-R342) [[4]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R41) [[5]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0R51) [[6]](diffhunk://#diff-2d2f6cafa992c1e8fb7bed5df555ec1d5c988552500481ba87c0e01990fccdb0L493-R508)
- Refactored `TransferForm` to accept an `onOpenMigration` prop, and updated internal logic to use this callback or fallback to its own modal when migration is required. [[1]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afL43-R44) [[2]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afL126-R127) [[3]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afR332-R336) [[4]](diffhunk://#diff-3bdaac8ebc5b9fb8ba7c0dd7d154868e019d4c93b2c6443136ea99aefb8271afR643-R648)

**Swap and transaction flow updates**
- Modified `useSwapButton` to enable the swap button and update button text when migration is needed, and to trigger the migration modal when appropriate. [[1]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696L52-R53) [[2]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696R93-R96) [[3]](diffhunk://#diff-0ae1f7d6a6189aa6610f76d65afde64c633aff89f52340df333b20bdbdf0f696R122-R126)
- Ensured the transaction form triggers the migration modal via the button handler when migration is required.

### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet migration modal now integrated into transfer forms, swap flows, and mobile menu contexts.
  * Users can initiate wallet migration seamlessly without interrupting their current transaction workflows.
  * Enhanced accessibility of wallet migration features across multiple user interaction points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->