### PR TITLE
refactor: update RPC URL handling for various networks

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -161,21 +161,22 @@ export const getExplorerLink = (network: string, txHash: string) => {
 
 // write function to get rpc url for a given network
 export function getRpcUrl(network: string) {
+  const rpcUrlKey = process.env.NEXT_PUBLIC_RPC_URL_KEY;
   switch (network) {
     case "Polygon":
-      return `https://137.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-polygon-mainnet-full.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "BNB Smart Chain":
-      return `https://56.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-bsc-mainnet-full.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "Base":
-      return `https://8453.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-base-mainnet-archive.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "Arbitrum One":
-      return `https://42161.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-arbitrum-mainnet-archive.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "Celo":
-      return `https://42220.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-celo-mainnet-archive.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "Lisk":
-      return `https://1135.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-lisk-mainnet.n.dwellir.com/${rpcUrlKey ?? ""}`;
     case "Ethereum":
-      return `https://1.rpc.thirdweb.com/${process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID}`;
+      return `https://api-ethereum-mainnet.n.dwellir.com/${rpcUrlKey ?? ""}`;
     default:
       return undefined;
   }


### PR DESCRIPTION


### Description

* Replaced hardcoded RPC URLs with dynamic URLs using environment variable for improved flexibility and maintainability.
* Updated the getRpcUrl function to return new API endpoints for Polygon, BNB Smart Chain, Base, Arbitrum One, Celo, Lisk, and Ethereum networks.

This pull request updates the way RPC URLs are generated for different blockchain networks in the `getRpcUrl` function. Instead of using Thirdweb endpoints and the `NEXT_PUBLIC_THIRDWEB_CLIENT_ID`, the function now uses Dwellir endpoints and a new environment variable, `NEXT_PUBLIC_RPC_URL_KEY`, for authentication.

**RPC URL provider migration:**

* Switched RPC endpoints for all supported networks in `getRpcUrl` from Thirdweb to Dwellir, and replaced usage of `NEXT_PUBLIC_THIRDWEB_CLIENT_ID` with `NEXT_PUBLIC_RPC_URL_KEY` for authentication. (`app/utils.ts`)

### References




### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).