### PR TITLE
fix: update migration modal visibility logic

### DIFF
--- a/app/context/MigrationContext.tsx
+++ b/app/context/MigrationContext.tsx
@@ -33,7 +33,8 @@ export const MigrationBannerWrapper = () => {
     // Fallback: covers page-reload when localStorage already has the key
     const dismissedViaStorage = hasSeenNetworkModal(walletAddress);
 
-    const canShowMigrationModal = isInjectedWallet || dismissedViaStore || dismissedViaStorage;
+    const canShowMigrationModal =
+        !isInjectedWallet && (dismissedViaStore || dismissedViaStorage);
 
     // Keep the last stable visibility while loading to avoid unmounting migration modals mid-flow.
     useEffect(() => {


### PR DESCRIPTION
### Description

This pull request updates the logic for displaying the migration modal in the `MigrationBannerWrapper` component. The new logic ensures that the modal is only shown to users who are not using an injected wallet and have dismissed the modal via store or storage.

* Migration modal display logic:
  * Updated `canShowMigrationModal` to only allow showing the modal if the user is not using an injected wallet and has dismissed the modal via store or storage, preventing injected wallet users from seeing the modal. (`app/context/MigrationContext.tsx`, [app/context/MigrationContext.tsxL36-R37](diffhunk://#diff-92a2311601894ac1e42d85e0f2a040ddb6caa5db0c618d81d3d5a51141a752d3L36-R37))


### References

closes #373 


### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed migration modal display behavior for injected wallets and dismissal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->