### PR TITLE
feat(settings): add theme switch to desktop dropdown

### DIFF
--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -20,13 +20,14 @@ import {
   Setting07Icon,
   Wallet01Icon,
   Key01Icon,
-  Download01Icon,
   AccessIcon,
+  ColorsIcon,
 } from "hugeicons-react";
 import { toast } from "sonner";
 import { useInjectedWallet } from "../context";
 import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
+import { ThemeSwitch } from "./ThemeSwitch";
 import { useWallets } from "@privy-io/react-auth";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
 import { clearUserSessionData } from "../lib/session-cleanup";
@@ -51,10 +52,10 @@ export const SettingsDropdown = () => {
 
   // Get embedded wallet (EOA) and smart wallet (SCW)
   const embeddedWallet = wallets.find(
-    (wallet) => wallet.walletClientType === "privy"
+    (wallet) => wallet.walletClientType === "privy",
   );
   const smartWallet = user?.linkedAccounts.find(
-    (account) => account.type === "smart_wallet"
+    (account) => account.type === "smart_wallet",
   );
 
   // Determine active wallet based on migration status
@@ -309,6 +310,13 @@ export const SettingsDropdown = () => {
                 </li>
               )}
             </ul>
+            <div className="-mx-2 mt-0 flex items-center justify-between gap-3 border-t border-border-light pb-2 pl-6 pr-4 pt-4 dark:border-white/10">
+              <div className="flex items-center gap-2.5">
+                <ColorsIcon className="size-5 text-icon-outline-secondary dark:text-white/50" />
+                <p>Theme</p>
+              </div>
+              <ThemeSwitch />
+            </div>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
### Description

Adds the existing theme switch to the desktop settings dropdown so users can change theme without needing to scroll to the footer.

The control is placed below the existing menu actions, keeps the footer switch as a secondary entry point, and uses a full-width divider with inline layout to fit the current dropdown design.

### Screenshots

<img width="439" height="374" alt="image" src="https://github.com/user-attachments/assets/14ebf0fc-4103-4a11-babb-b43d19208c83" />

<img width="434" height="390" alt="image" src="https://github.com/user-attachments/assets/07d48fa1-ae0b-4eaf-b8e6-74ac19d9d03b" />

### References

- Closes #434

### Testing

- `pnpm lint`
- Manual: open the desktop settings dropdown and confirm the theme switch appears below `Sign out`
- Manual: verify the theme label and selector stay side by side, the divider spans edge to edge, and the footer theme switch still works
- Environment: Node v25.4.0, pnpm 10.27.0
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selector added to the Settings menu for convenient theme customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->