### PR TITLE
fix: improve wallet initialization logic to handle user linked accounts

### DIFF
--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -108,7 +108,7 @@ export function MainPageContent() {
   const searchParams = useSearchParams();
   const { authenticated, ready, getAccessToken, user } = usePrivy();
   const { currentStep, setCurrentStep } = useStep();
-  const { isInjectedWallet, injectedAddress, injectedReady } = useInjectedWallet();
+  const { isInjectedWallet, injectedAddress, injectedReady, embeddedWalletReady } = useInjectedWallet();
   const { crossChainBalances, isLoading: isBalanceLoading } = useBalance();
   const { selectedNetwork, setDisplayedNetwork } = useNetwork();
   const { isBlockFestReferral } = useBlockFestReferral();
@@ -223,7 +223,7 @@ export function MainPageContent() {
         return;
       }
 
-      if (!ready || (isInjectedWallet && !injectedReady) || isBalanceLoading) {
+      if (!ready || (isInjectedWallet && !injectedReady) || (!isInjectedWallet && authenticated && !embeddedWalletReady) || isBalanceLoading) {
         return;
       }
 
@@ -444,7 +444,8 @@ export function MainPageContent() {
   const showLoading =
     isPageLoading ||
     (!ready && !isInjectedWallet) ||
-    (isInjectedWallet && !injectedReady);
+    (isInjectedWallet && !injectedReady) ||
+    (!isInjectedWallet && authenticated && !embeddedWalletReady);
 
   const isRecipientFormOpen =
     !!currency && (authenticated || isInjectedWallet) && isUserVerified;

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -250,6 +250,7 @@ export function MainPageContent() {
       crossChainBalances,
       injectedAddress,
       injectedReady,
+      embeddedWalletReady,
       isBalanceLoading,
       isInjectedWallet,
       ready,

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -105,10 +105,14 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (!ready || !user || wallets.length === 0) return;
+    if (!ready || !user) return;
 
-    const hasEmbeddedWallet = wallets.some(
-      (wallet) => wallet.walletClientType === "privy",
+    // Check linkedAccounts (not wallets) — useWallets() only returns currently
+    // connected wallets. A returning user's embedded wallet may not be connected
+    // in a session started via MetaMask, so it wouldn't appear in wallets even
+    // though it exists. linkedAccounts reflects the full persistent account state.
+    const hasEmbeddedWallet = user.linkedAccounts.some(
+      (account) => account.type === "wallet" && account.connectorType === "embedded",
     );
     const externalWallet = wallets.find(
       (wallet) => wallet.walletClientType !== "privy",

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -19,6 +19,7 @@ interface InjectedWalletContextType {
   injectedAddress: string | null;
   injectedProvider: any | null;
   injectedReady: boolean;
+  embeddedWalletReady: boolean;
 }
 
 const InjectedWalletContext = createContext<InjectedWalletContextType>({
@@ -26,6 +27,7 @@ const InjectedWalletContext = createContext<InjectedWalletContextType>({
   injectedAddress: null,
   injectedProvider: null,
   injectedReady: false,
+  embeddedWalletReady: false,
 });
 
 function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
@@ -36,6 +38,7 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   const [injectedAddress, setInjectedAddress] = useState<string | null>(null);
   const [injectedProvider, setInjectedProvider] = useState<any | null>(null);
   const [injectedReady, setInjectedReady] = useState(false);
+  const [embeddedWalletReady, setEmbeddedWalletReady] = useState(false);
 
   // Track whether the URL param flow is active so the Privy detection doesn't conflict
   const urlParamActive = useRef(false);
@@ -102,6 +105,7 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       setInjectedAddress(null);
       setInjectedProvider(null);
       setInjectedReady(false);
+      setEmbeddedWalletReady(false);
       return;
     }
 
@@ -118,10 +122,24 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       (wallet) => wallet.walletClientType !== "privy",
     );
 
-    // Only activate if user has an external wallet but no embedded wallet
-    if (hasEmbeddedWallet || !externalWallet) {
+    if (hasEmbeddedWallet) {
+      // User has an embedded wallet — wait for Privy to connect it into useWallets()
+      // before declaring the wallet layer ready. This prevents the app from rendering
+      // wallet-dependent UI before embeddedWallet is available.
+      const embeddedInWallets = wallets.some(
+        (w) => w.walletClientType === "privy",
+      );
+      setEmbeddedWalletReady(embeddedInWallets);
       return;
     }
+
+    if (!externalWallet) {
+      // Authenticated but no wallets yet — still waiting
+      return;
+    }
+
+    // External-wallet-only user (no embedded wallet ever created) — nothing to wait for
+    setEmbeddedWalletReady(true);
 
     const initPrivyExternalWallet = async () => {
       try {
@@ -149,6 +167,7 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
         injectedAddress,
         injectedProvider,
         injectedReady,
+        embeddedWalletReady,
       }}
     >
       {children}

--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -7,6 +7,8 @@ import {
     type PublicClient,
     SignedAuthorization,
     createPublicClient,
+    createWalletClient,
+    custom,
     http,
 } from "viem";
 import { useBalance } from "../context/BalanceContext";
@@ -178,26 +180,44 @@ export function useDelegationContractAuth() {
     const { signAuthorization } = useSign7702Authorization();
     const { wallets } = useWallets();
     const embeddedWallet = wallets.find((w) => w.walletClientType === "privy");
+    const externalWallet = wallets.find((w) => w.walletClientType !== "privy");
 
     const signDelegationAuthorization = useCallback(
-        async (chainId: number): Promise<SignedAuthorization> => {
-            if (!embeddedWallet?.address) {
-                throw new Error("Embedded wallet not ready for EIP-7702 signing");
-            }
+        async (chainId: number, chain: Chain): Promise<SignedAuthorization> => {
             const delegationAddress = getDelegationContractAddress(chainId);
             if (!delegationAddress || delegationAddress === "") {
                 throw new Error(`Delegation contract not configured for chain ${chainId}. Add the contract for this chain or set NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS.`);
             }
-            const signed = await signAuthorization(
-                {
+
+            if (embeddedWallet?.address) {
+                // Embedded wallet: Privy manages the key — use its hook (no wallet popup)
+                const signed = await signAuthorization(
+                    { contractAddress: delegationAddress as `0x${string}`, chainId },
+                    { address: embeddedWallet.address as Address }
+                );
+                return signed as SignedAuthorization;
+            }
+
+            if (externalWallet) {
+                // External wallet via Privy (e.g. MetaMask): bypass Privy's signAuthorization
+                // which only works for embedded wallets. Use viem's walletClient.signAuthorization
+                // directly against the external wallet's provider — EIP-7702 authorization signing
+                // ultimately calls eth_sign on a specific hash, which any wallet supports.
+                const provider = await externalWallet.getEthereumProvider();
+                const walletClient = createWalletClient({
+                    account: externalWallet.address as Address,
+                    chain,
+                    transport: custom(provider),
+                });
+                return await walletClient.signAuthorization({
                     contractAddress: delegationAddress as `0x${string}`,
                     chainId,
-                },
-                { address: embeddedWallet.address as Address }
-            );
-            return signed as SignedAuthorization;
+                });
+            }
+
+            throw new Error("No wallet available for EIP-7702 signing");
         },
-        [signAuthorization, embeddedWallet?.address]
+        [signAuthorization, embeddedWallet, externalWallet]
     );
 
     return { signDelegationAuthorization };

--- a/app/hooks/useSmartWalletTransfer.ts
+++ b/app/hooks/useSmartWalletTransfer.ts
@@ -170,7 +170,7 @@ export function useSmartWalletTransfer({
 
         let authorization: Awaited<ReturnType<typeof signDelegationAuthorization>> | undefined;
         if (needsDelegation) {
-          authorization = await signDelegationAuthorization(chainId);
+          authorization = await signDelegationAuthorization(chainId, chain);
         }
 
         // 2) Build single transfer call

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -237,10 +237,17 @@ export const TransactionPreview = ({
     }
   };
 
+  // Privy external wallet (Flow 2 in InjectedWalletContext) vs raw ?injected=true URL param.
+  // External Privy wallets are authenticated and can use the EIP-7702 bundler flow.
+  // URL param injected wallets use raw eth_sendTransaction (unauthenticated / no bundler).
+  const isUrlParamInjected = searchParams.get("injected") === "true";
+  const isPrivyExternalWallet =
+    isInjectedWallet && !isUrlParamInjected && !!injectedProvider && !!injectedAddress;
+
   const createOrder = async () => {
     try {
-      if (isInjectedWallet && injectedProvider) {
-        // Injected wallet
+      if (isInjectedWallet && isUrlParamInjected && injectedProvider) {
+        // URL param ?injected=true — raw eth_sendTransaction (user pays gas)
         if (!injectedReady) {
           throw new Error("Injected wallet not ready");
         }
@@ -322,8 +329,10 @@ export const TransactionPreview = ({
           "Entry point": "Transaction preview",
           "Wallet type": "Injected wallet",
         });
-      } else if (shouldUseEOA && embeddedWallet) {
-        // EIP-7702 + bundler (execute-sponsored): check delegationContractAddress, attach delegation with signature if needed
+      } else if (shouldUseEOA && (embeddedWallet || isPrivyExternalWallet)) {
+        // EIP-7702 + bundler (execute-sponsored).
+        // Works for both embedded wallets (Privy manages key) and Privy external wallets
+        // (MetaMask etc.) — the only difference is how we get the provider and address.
         const chain = selectedNetwork?.chain;
         if (!chain) throw new Error("Network not ready");
         const chainId = chain.id;
@@ -340,15 +349,28 @@ export const TransactionPreview = ({
 
         const bundlerUrl = "/api/bundler";
 
-        await embeddedWallet.switchChain(chainId);
-        const provider = await embeddedWallet.getEthereumProvider();
+        // Normalize provider and address across embedded vs external wallet
+        let provider: any;
+        let accountAddress: `0x${string}`;
+        if (embeddedWallet) {
+          await embeddedWallet.switchChain(chainId);
+          provider = await embeddedWallet.getEthereumProvider();
+          accountAddress = embeddedWallet.address as `0x${string}`;
+        } else {
+          // Privy external wallet — injectedProvider is already the wallet's provider
+          await (injectedProvider as any).request({
+            method: "wallet_switchEthereumChain",
+            params: [{ chainId: `0x${chainId.toString(16)}` }],
+          });
+          provider = injectedProvider;
+          accountAddress = injectedAddress as `0x${string}`;
+        }
 
         const rpcUrl = getRpcUrl(selectedNetwork.chain.name);
         if (!rpcUrl) {
           throw new Error(`RPC URL not configured for network: ${selectedNetwork.chain.name}`);
         }
 
-        const accountAddress = embeddedWallet.address as `0x${string}`;
         const publicClient = createPublicClient({
           chain,
           transport: http(rpcUrl),
@@ -367,7 +389,7 @@ export const TransactionPreview = ({
 
         let authorization: Awaited<ReturnType<typeof signDelegationAuthorization>> | undefined;
         if (needsDelegation) {
-          authorization = await signDelegationAuthorization(chainId);
+          authorization = await signDelegationAuthorization(chainId, chain);
         }
 
         const params = await prepareCreateOrderParams();
@@ -452,7 +474,7 @@ export const TransactionPreview = ({
 
         trackEvent("Swap started", {
           "Entry point": "Transaction preview",
-          "Wallet type": "EIP-7702 (bundler)",
+          "Wallet type": embeddedWallet ? "EIP-7702 (bundler)" : "EIP-7702 (external wallet)",
         });
 
         toast.success("Order created successfully");


### PR DESCRIPTION
### Description

This pull request updates the logic in the `InjectedWalletProviderContent` component to more accurately detect the presence of an embedded wallet for a user. Instead of relying on the currently connected wallets, which may not include all persistent wallets, the code now checks the user's `linkedAccounts` to determine if an embedded wallet exists. This ensures that returning users who may have connected via an external wallet (like MetaMask) are still recognized as having an embedded wallet even if it is not currently connected.

**Improvements to embedded wallet detection:**

* Updated the embedded wallet check in `InjectedWalletProviderContent` to use `user.linkedAccounts` instead of the `wallets` array, ensuring the detection accounts for all persistent wallets, not just currently connected ones.


### References



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for signing delegation authorizations using external (non-embedded) wallets.
  * Transaction preview now recognizes explicit injected-wallet mode and applies the sponsored/bundler flow to Privy external wallets as well.

* **Bug Fixes**
  * Improved embedded wallet readiness detection to avoid premature UI transitions.
  * Deferred automatic network selection and kept loading state until embedded wallet readiness is confirmed; readiness resets on logout.

* **Breaking Changes**
  * Delegation-authorization API now requires chain details when requesting a signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->