### PR TITLE
remove celo from migration path

### DIFF
--- a/app/components/WalletTransferApprovalModal.tsx
+++ b/app/components/WalletTransferApprovalModal.tsx
@@ -36,7 +36,7 @@ function getTransportForChain(chain: Chain) {
     return http(getRpcUrl(chain.name));
 }
 
-// Map network names to viem chains (migration flow only; excludes Celo — see migrationChecklistNetworks)
+// Map network names to viem chains (migration flow only; see migrationChecklistNetworks)
 const CHAIN_MAP = Object.fromEntries(
     migrationChecklistNetworks.map(n => [n.chain.name, n.chain])
 );
@@ -93,7 +93,7 @@ const WalletTransferApprovalModal: React.FC<WalletTransferApprovalModalProps> = 
             const balancesByChain: Record<string, Record<string, number>> = {};
             const rawByChain: Record<string, Record<string, bigint>> = {};
 
-            // Fetch balances for each network in the migration checklist (Celo excluded)
+            // Fetch balances for each network in the migration checklist (excluded chains omitted)
             for (const network of migrationChecklistNetworks) {
                 try {
                     const publicClient = createPublicClient({

--- a/app/components/WalletTransferApprovalModal.tsx
+++ b/app/components/WalletTransferApprovalModal.tsx
@@ -17,7 +17,7 @@ import WalletMigrationSuccessModal from "./WalletMigrationSuccessModal";
 import { type Address, type Chain, createPublicClient, http, fallback, erc20Abi, encodeAbiParameters } from "viem";
 import { bsc } from "viem/chains";
 import { toast } from "sonner";
-import { networks } from "../mocks";
+import { migrationChecklistNetworks, networks } from "../mocks";
 import config from "../lib/config";
 import {
   createMeeClient,
@@ -36,9 +36,9 @@ function getTransportForChain(chain: Chain) {
     return http(getRpcUrl(chain.name));
 }
 
-// Map network names to viem chains
+// Map network names to viem chains (migration flow only; excludes Celo — see migrationChecklistNetworks)
 const CHAIN_MAP = Object.fromEntries(
-    networks.map(n => [n.chain.name, n.chain])
+    migrationChecklistNetworks.map(n => [n.chain.name, n.chain])
 );
 
 // Biconomy v2 ECDSA module address (same across chains). Signature must be ABI-encoded as (bytes moduleSig, address moduleAddress) per blog.
@@ -93,8 +93,8 @@ const WalletTransferApprovalModal: React.FC<WalletTransferApprovalModalProps> = 
             const balancesByChain: Record<string, Record<string, number>> = {};
             const rawByChain: Record<string, Record<string, bigint>> = {};
 
-            // Fetch balances for each supported network
-            for (const network of networks) {
+            // Fetch balances for each network in the migration checklist (Celo excluded)
+            for (const network of migrationChecklistNetworks) {
                 try {
                     const publicClient = createPublicClient({
                         chain: network.chain,

--- a/app/context/BalanceContext.tsx
+++ b/app/context/BalanceContext.tsx
@@ -19,11 +19,16 @@ import { useNetwork } from "./NetworksContext";
 import { useSmartWallets } from "@privy-io/react-auth/smart-wallets";
 import { createPublicClient, fallback, http } from "viem";
 import { useInjectedWallet } from "./InjectedWalletContext";
-import { networks } from "../mocks";
+import { migrationChecklistNetworks, networks } from "../mocks";
 import type { Network } from "../types";
 import { bsc } from "viem/chains";
 
 // All networks are fetched in parallel — no artificial concurrency limit
+
+/** Chain IDs included in wallet migration UX (Celo and any future exclusions omitted). */
+const MIGRATION_RELEVANT_CHAIN_IDS = new Set(
+  migrationChecklistNetworks.map((n) => n.chain.id),
+);
 
 interface WalletBalances {
   total: number;
@@ -35,6 +40,20 @@ interface WalletBalances {
 export interface CrossChainBalanceEntry {
   network: Network;
   balances: WalletBalances;
+}
+
+function sumMigrationRelevantTotals(entries: CrossChainBalanceEntry[]): number {
+  return entries.reduce((sum, entry) => {
+    if (!MIGRATION_RELEVANT_CHAIN_IDS.has(entry.network.chain.id)) return sum;
+    return sum + (entry.balances.total || 0);
+  }, 0);
+}
+
+function sumAllChainTotals(entries: CrossChainBalanceEntry[]): number {
+  return entries.reduce(
+    (sum, entry) => sum + (entry.balances.total || 0),
+    0,
+  );
 }
 
 /**
@@ -84,6 +103,16 @@ interface BalanceContextProps {
   };
   crossChainBalances: CrossChainBalanceEntry[];
   crossChainTotal: number;
+  /** Same as crossChainTotal but excludes chains omitted from migration (e.g. Celo). For migration/banner logic only. */
+  crossChainTotalMigrationRelevant: number;
+  /**
+   * Last SCW cross-chain totals (all networks vs migration-eligible only).
+   * Used when the UI shows EOA balances but migration logic must still see SCW state (e.g. funds only on Celo).
+   */
+  smartWalletCrossChainTotals: {
+    totalAll: number;
+    totalMigrationRelevant: number;
+  } | null;
   smartWalletRemainingTotal: number;
   refreshBalance: () => void;
   isLoading: boolean;
@@ -112,6 +141,11 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
   >([]);
   const [smartWalletRemainingTotal, setSmartWalletRemainingTotal] =
     useState(0);
+  const [smartWalletCrossChainTotals, setSmartWalletCrossChainTotals] =
+    useState<{
+      totalAll: number;
+      totalMigrationRelevant: number;
+    } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Hook for CNGN rate to correct total balances
@@ -182,6 +216,7 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
       setInjectedWalletBalance(null);
       setCrossChainBalances([]);
       setSmartWalletRemainingTotal(0);
+      setSmartWalletCrossChainTotals(null);
     };
 
     /** Clear only per-network balances so migration banner stays correct on fetch error (keeps cross-chain state). */
@@ -243,17 +278,14 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         if (isMigrationComplete && embeddedWalletAccount) {
           primaryIsEOA = true;
           setSmartWalletBalance(null);
+          setSmartWalletCrossChainTotals(null);
 
           // Fetch EOA cross-chain and SCW remaining in parallel
           const eoaCrossChainPromise =
             fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
           const scwRemainingPromise = smartWalletAccount
             ? fetchCrossChainEntriesForAddress(smartWalletAccount.address).then(
-                (entries) =>
-                  entries.reduce(
-                    (sum, e) => sum + (e.balances.total || 0),
-                    0,
-                  ),
+                (entries) => sumMigrationRelevantTotals(entries),
               )
             : Promise.resolve(0);
 
@@ -286,10 +318,13 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           // Not migrated: fetch SCW cross-chain first to determine total and selected-network balance
           const scwCrossChainEntries =
             await fetchCrossChainEntriesForAddress(smartWalletAccount.address);
-          const scwCrossChainTotal = scwCrossChainEntries.reduce(
-            (sum, entry) => sum + (entry.balances.total || 0),
-            0,
-          );
+          const scwCrossChainTotalMigrationRelevant =
+            sumMigrationRelevantTotals(scwCrossChainEntries);
+          const scwTotalAll = sumAllChainTotals(scwCrossChainEntries);
+          setSmartWalletCrossChainTotals({
+            totalAll: scwTotalAll,
+            totalMigrationRelevant: scwCrossChainTotalMigrationRelevant,
+          });
 
           // Extract selected-network balance from cross-chain entries
           const selectedEntry = scwCrossChainEntries.find(
@@ -312,7 +347,7 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
             });
           }
 
-          if (scwCrossChainTotal === 0 && embeddedWalletAccount) {
+          if (scwCrossChainTotalMigrationRelevant === 0 && embeddedWalletAccount) {
             primaryIsEOA = true;
             const eoaEntries =
               await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
@@ -339,6 +374,7 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           // New user: has embedded wallet — use EOA directly
           primaryIsEOA = true;
           setSmartWalletBalance(null);
+          setSmartWalletCrossChainTotals(null);
 
           const eoaEntries =
             await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
@@ -449,6 +485,7 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
           setSmartWalletBalance(null);
           setExternalWalletBalance(null);
+          setSmartWalletCrossChainTotals(null);
         } catch (error) {
           console.error("Error fetching injected wallet balance:", error);
           clearAllWalletBalances();
@@ -490,6 +527,8 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const crossChainTotal = crossChainBalances.reduce((total, entry) => {
     return total + (entry.balances.total || 0);
   }, 0);
+  const crossChainTotalMigrationRelevant =
+    sumMigrationRelevantTotals(crossChainBalances);
 
   return (
     <BalanceContext.Provider
@@ -500,6 +539,8 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         allBalances,
         crossChainBalances,
         crossChainTotal,
+        crossChainTotalMigrationRelevant,
+        smartWalletCrossChainTotals,
         smartWalletRemainingTotal,
         refreshBalance: fetchBalances,
         isLoading,

--- a/app/context/BalanceContext.tsx
+++ b/app/context/BalanceContext.tsx
@@ -25,7 +25,7 @@ import { bsc } from "viem/chains";
 
 // All networks are fetched in parallel — no artificial concurrency limit
 
-/** Chain IDs included in wallet migration UX (Celo and any future exclusions omitted). */
+/** Chain IDs included in wallet migration UX (see MIGRATION_EXCLUDED_CHAIN_IDS in mocks). */
 const MIGRATION_RELEVANT_CHAIN_IDS = new Set(
   migrationChecklistNetworks.map((n) => n.chain.id),
 );
@@ -103,11 +103,11 @@ interface BalanceContextProps {
   };
   crossChainBalances: CrossChainBalanceEntry[];
   crossChainTotal: number;
-  /** Same as crossChainTotal but excludes chains omitted from migration (e.g. Celo). For migration/banner logic only. */
+  /** Same as crossChainTotal but excludes chains omitted from migration (e.g. Celo, Scroll). For migration/banner logic only. */
   crossChainTotalMigrationRelevant: number;
   /**
    * Last SCW cross-chain totals (all networks vs migration-eligible only).
-   * Used when the UI shows EOA balances but migration logic must still see SCW state (e.g. funds only on Celo).
+   * Used when the UI shows EOA balances but migration logic must still see SCW state (e.g. funds only on excluded chains).
    */
   smartWalletCrossChainTotals: {
     totalAll: number;

--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -165,7 +165,7 @@ export function useWalletMigrationStatus(): WalletMigrationStatus {
             const all = smartWalletCrossChainTotals?.totalAll ?? 0;
             const hasMigrationBalance = hasMeaningfulBalance(migr);
             setNeedsMigration(hasMigrationBalance);
-            // No banner/modal if SCW only has funds on excluded chains (e.g. Celo).
+            // No banner/modal if SCW only has funds on excluded chains (e.g. Celo, Scroll).
             setShowZeroBalanceMessage(
                 !hasMigrationBalance && !hasMeaningfulBalance(all),
             );

--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -83,11 +83,14 @@ export { useMigrationStatus, triggerMigrationStatusRefetch } from "../context/Mi
 export function useShouldUseEOA(): boolean {
     const { user } = usePrivy();
     const { isMigrationComplete, isLoading: isMigrationLoading } = useMigrationStatus();
-    const { crossChainTotal, isLoading: isBalanceLoading } = useBalance();
+    const { smartWalletCrossChainTotals, isLoading: isBalanceLoading } = useBalance();
     const lastValueRef = useRef<boolean | null>(null);
 
     const hasSmartWallet = !!user?.linkedAccounts?.find((a) => a.type === "smart_wallet");
-    const smartWalletCrossChainTotal = hasSmartWallet && !isMigrationComplete ? crossChainTotal : 0;
+    const smartWalletCrossChainTotal =
+        hasSmartWallet && !isMigrationComplete
+            ? (smartWalletCrossChainTotals?.totalMigrationRelevant ?? 0)
+            : 0;
 
     if (user == null) {
         return lastValueRef.current ?? true;
@@ -131,7 +134,11 @@ interface WalletMigrationStatus {
 export function useWalletMigrationStatus(): WalletMigrationStatus {
     const { user, authenticated } = usePrivy();
     const { isMigrationComplete, isLoading: isMigrationLoading, refetch } = useMigrationStatus();
-    const { crossChainTotal, isLoading: isBalanceLoading, smartWalletRemainingTotal } = useBalance();
+    const {
+        smartWalletCrossChainTotals,
+        isLoading: isBalanceLoading,
+        smartWalletRemainingTotal,
+    } = useBalance();
     const [needsMigration, setNeedsMigration] = useState(false);
     const [showZeroBalanceMessage, setShowZeroBalanceMessage] = useState(false);
 
@@ -154,11 +161,16 @@ export function useWalletMigrationStatus(): WalletMigrationStatus {
             setNeedsMigration(hasMeaningfulBalance(smartWalletRemainingTotal));
             setShowZeroBalanceMessage(false);
         } else {
-            const hasBalance = hasMeaningfulBalance(crossChainTotal);
-            setNeedsMigration(hasBalance);
-            setShowZeroBalanceMessage(!hasBalance);
+            const migr = smartWalletCrossChainTotals?.totalMigrationRelevant ?? 0;
+            const all = smartWalletCrossChainTotals?.totalAll ?? 0;
+            const hasMigrationBalance = hasMeaningfulBalance(migr);
+            setNeedsMigration(hasMigrationBalance);
+            // No banner/modal if SCW only has funds on excluded chains (e.g. Celo).
+            setShowZeroBalanceMessage(
+                !hasMigrationBalance && !hasMeaningfulBalance(all),
+            );
         }
-    }, [authenticated, user, hasSmartWallet, isMigrationComplete, isMigrationLoading, crossChainTotal, isBalanceLoading, smartWalletRemainingTotal]);
+    }, [authenticated, user, hasSmartWallet, isMigrationComplete, isMigrationLoading, smartWalletCrossChainTotals, isBalanceLoading, smartWalletRemainingTotal]);
 
     const isRemainingFundsMigration =
         isMigrationComplete === true && hasMeaningfulBalance(smartWalletRemainingTotal);

--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -94,6 +94,9 @@ export const networks = [
   // },
 ];
 
+/** Networks scanned and shown in the wallet migration modal; Celo is excluded from migration UX. */
+export const migrationChecklistNetworks = networks.filter((n) => n.chain.id !== celo.id);
+
 export const colors = [
   "bg-blue-600",
   "bg-indigo-600",

--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -94,8 +94,13 @@ export const networks = [
   // },
 ];
 
-/** Networks scanned and shown in the wallet migration modal; Celo is excluded from migration UX. */
-export const migrationChecklistNetworks = networks.filter((n) => n.chain.id !== celo.id);
+/** Chain IDs excluded from wallet migration (popup math + transfer modal). */
+export const MIGRATION_EXCLUDED_CHAIN_IDS = new Set<number>([celo.id, scroll.id]);
+
+/** Networks scanned and shown in the wallet migration modal (excludes Celo and Scroll). */
+export const migrationChecklistNetworks = networks.filter(
+  (n) => !MIGRATION_EXCLUDED_CHAIN_IDS.has(n.chain.id),
+);
 
 export const colors = [
   "bg-blue-600",


### PR DESCRIPTION
### Description

This pull request refines the wallet migration logic to more accurately handle network exclusions (notably Celo) throughout the migration UX and related balance computations. It introduces new helpers and state to distinguish between all-chain totals and migration-relevant totals, ensuring that UI and migration logic consistently exclude balances on unsupported chains. These changes help prevent migration prompts or banners from appearing when a user only has funds on excluded chains.

**Migration network filtering and logic:**

* Introduced `migrationChecklistNetworks` (excluding Celo) and updated all relevant balance queries and UI logic to use this filtered list instead of the full `networks` array. This ensures that migration flows and banners only consider balances on supported chains. [[1]](diffhunk://#diff-5cef9b68abafa52ec52595fa36fc23b188891a59f1e0df39f92559ebec5ac0eaR97-R99) [[2]](diffhunk://#diff-8bdc1ec71ac54a21f708286bdb4a8d8013ead91816051cc2ebf76fcc39acc56dL20-R20) [[3]](diffhunk://#diff-8bdc1ec71ac54a21f708286bdb4a8d8013ead91816051cc2ebf76fcc39acc56dL39-R41) [[4]](diffhunk://#diff-8bdc1ec71ac54a21f708286bdb4a8d8013ead91816051cc2ebf76fcc39acc56dL96-R97) [[5]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201L22-R32)

**Balance calculation improvements:**

* Added helper functions `sumMigrationRelevantTotals` and `sumAllChainTotals` to compute cross-chain totals for migration-relevant and all networks, respectively, and integrated these into the balance provider logic. [[1]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R45-R58) [[2]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201L289-R327) [[3]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201L315-R350)
* Extended the balance context to provide both `crossChainTotalMigrationRelevant` and a new `smartWalletCrossChainTotals` object containing both migration-relevant and all-chain totals, for use in migration logic and UI. [[1]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R106-R115) [[2]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R144-R148) [[3]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R281-R288) [[4]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R377) [[5]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R488) [[6]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R530-R531) [[7]](diffhunk://#diff-1bd75f62570fd9cb0ec4fd47278dab3754005849afc5e02db6d34dc86abf9201R542-R543)

**Migration status and UI logic updates:**

* Updated `useShouldUseEOA` and `useWalletMigrationStatus` hooks to use the new migration-relevant totals, ensuring migration prompts and banners are only shown if the user has funds on eligible chains, and not when funds exist solely on excluded chains like Celo. [[1]](diffhunk://#diff-25812247e22551b8923156063f44e7f755e0e4d0ef7ad2e8bc11a7f8236e881eL86-R93) [[2]](diffhunk://#diff-25812247e22551b8923156063f44e7f755e0e4d0ef7ad2e8bc11a7f8236e881eL134-R141) [[3]](diffhunk://#diff-25812247e22551b8923156063f44e7f755e0e4d0ef7ad2e8bc11a7f8236e881eL157-R173)

These changes together ensure that the wallet migration experience is accurate, clear, and only prompts users when action is actually needed.


### References




### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cross-chain balance calculations to filter and display only migration-eligible networks.
  * Fixed zero-balance messaging so it is suppressed when funds exist only on excluded chains.

* **Refactor**
  * Wallet transfer approval now queries and shows balances from migration-eligible networks only.
  * Balance tracking now maintains separate migration-relevant and all-chain totals and a migration-exclusion list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->