### PR TITLE
feat(rates): fetch quotes via aggregator v2 with buy/sell side

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -2,6 +2,8 @@ import axios from "axios";
 import type {
   RatePayload,
   RateResponse,
+  RateSide,
+  V2RateQuoteResponse,
   InstitutionProps,
   PubkeyResponse,
   VerifyAccountPayload,
@@ -28,16 +30,26 @@ import {
 
 const AGGREGATOR_URL = process.env.NEXT_PUBLIC_AGGREGATOR_URL;
 
+/** Base URL without trailing `/v1` so v2 paths are `{origin}/v2/...` not `{origin}/v1/v2/...`. */
+function aggregatorOriginForV2(): string {
+  const raw = (AGGREGATOR_URL || "").trim();
+  if (!raw) {
+    throw new Error("NEXT_PUBLIC_AGGREGATOR_URL is not configured");
+  }
+  return raw.replace(/\/v1\/?$/i, "").replace(/\/$/, "") || raw;
+}
+
+function pickV2RateQuote(
+  quotes: V2RateQuoteResponse,
+  side: RateSide,
+): { rate: string } | undefined {
+  return side === "buy" ? quotes.buy : quotes.sell;
+}
+
 /**
- * Fetches the current exchange rate for a given token and currency pair
- * @param {RatePayload} params - The rate request parameters
- * @param {string} params.token - The token symbol
- * @param {number} [params.amount=1] - The amount to convert
- * @param {string} params.currency - The target currency
- * @param {string} [params.providerId] - Optional provider ID
- * @param {string} [params.network] - Optional network identifier (e.g., "arbitrum-one", "polygon")
- * @returns {Promise<RateResponse>} The rate response containing exchange rate and fees
- * @throws {Error} If the API request fails or returns an error
+ * Fetches the current exchange rate via aggregator **v2** (buy = onramp, sell = offramp).
+ * @param params.network - Required; sent as path segment (e.g. "arbitrum-one").
+ * @param params.side - `"buy"` or `"sell"`.
  */
 export const fetchRate = async ({
   token,
@@ -45,77 +57,104 @@ export const fetchRate = async ({
   currency,
   providerId,
   network,
+  side,
   signal,
 }: RatePayload): Promise<RateResponse> => {
   const startTime = Date.now();
+  const analyticsEndpoint = "/v2/rates";
+  const net = (network || "").trim().toLowerCase();
+
+  if (!net) {
+    throw new Error("network is required for rate quotes");
+  }
+
+  const origin = aggregatorOriginForV2();
+  const endpoint = `${origin}/v2/rates/${encodeURIComponent(net)}/${encodeURIComponent(token)}/${amount}/${encodeURIComponent(currency)}`;
+  const params: Record<string, string> = {
+    side,
+  };
+  if (providerId) {
+    params.provider_id = providerId;
+  }
 
   try {
-    // Track external API request
     trackServerEvent("External API Request", {
       service: "aggregator",
-      endpoint: "/rates",
+      endpoint: analyticsEndpoint,
       method: "GET",
       token,
       amount,
       currency,
       provider_id: providerId,
-      network,
+      network: net,
+      side,
     });
 
-    const endpoint = `${AGGREGATOR_URL}/rates/${token}/${amount}/${currency}`;
-    const params: Record<string, string> = {};
-
-    if (providerId) {
-      params.provider_id = providerId;
-    }
-    if (network) {
-      params.network = network;
-    }
-
     const response = await axios.get(endpoint, { params, signal });
-    const { data } = response;
+    const payload = response.data as {
+      status: string;
+      message: string;
+      data: V2RateQuoteResponse;
+    };
 
-    // Track successful response
+    if (payload.status === "error") {
+      throw new Error(payload.message || "Rate request failed");
+    }
+
+    const sideQuote = pickV2RateQuote(payload.data ?? {}, side);
+    if (!sideQuote?.rate) {
+      throw new Error(
+        payload.message || `No ${side} rate returned for this pair`,
+      );
+    }
+
+    const numericRate = Number(sideQuote.rate);
+    if (!Number.isFinite(numericRate)) {
+      throw new Error("Invalid rate value from aggregator");
+    }
+
+    const normalized: RateResponse = {
+      status: payload.status,
+      message: payload.message,
+      data: numericRate,
+    };
+
     const responseTime = Date.now() - startTime;
-    trackApiResponse("/rates", "GET", 200, responseTime, {
+    trackApiResponse(analyticsEndpoint, "GET", 200, responseTime, {
       service: "aggregator",
       token,
       amount,
       currency,
       provider_id: providerId,
-      network,
-      rate: data.data,
+      network: net,
+      side,
+      rate: numericRate,
     });
 
-    // Track business event
     trackBusinessEvent("Rate Fetched", {
       token,
       amount,
       currency,
       provider_id: providerId,
-      network,
-      rate: data.data,
+      network: net,
+      side,
+      rate: numericRate,
     });
 
-    // Check the API response status first
-    if (data.status === "error") {
-      throw new Error(data.message || "Provider not found");
-    }
-
-    return data;
+    return normalized;
   } catch (error) {
     const responseTime = Date.now() - startTime;
 
-    // Track API error
     trackServerEvent("External API Error", {
       service: "aggregator",
-      endpoint: "/rates",
+      endpoint: analyticsEndpoint,
       method: "GET",
       token,
       amount,
       currency,
       provider_id: providerId,
-      network,
+      network: net,
+      side,
       error_message: error instanceof Error ? error.message : "Unknown error",
       response_time_ms: responseTime,
     });

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -36,7 +36,23 @@ function aggregatorOriginForV2(): string {
   if (!raw) {
     throw new Error("NEXT_PUBLIC_AGGREGATOR_URL is not configured");
   }
-  return raw.replace(/\/v1\/?$/i, "").replace(/\/$/, "") || raw;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(
+      "NEXT_PUBLIC_AGGREGATOR_URL must be a valid absolute URL (e.g. https://api.example.com/v1)",
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      "NEXT_PUBLIC_AGGREGATOR_URL must use http: or https:",
+    );
+  }
+  const basePath = parsed.pathname
+    .replace(/\/v1\/?$/i, "")
+    .replace(/\/$/, "");
+  return `${parsed.origin}${basePath}`;
 }
 
 function pickV2RateQuote(

--- a/app/api/v1/rates/route.ts
+++ b/app/api/v1/rates/route.ts
@@ -29,7 +29,10 @@ export const GET = withRateLimit(async (request: NextRequest) => {
     const amount = rawAmount === null ? 1 : Number(rawAmount);
     const currency = searchParams.get("currency")?.trim();
     const providerId = searchParams.get("providerId");
-    const network = searchParams.get("network");
+    const network = searchParams.get("network")?.trim();
+    const rawSide = searchParams.get("side")?.trim().toLowerCase();
+    const side =
+      rawSide === "buy" || rawSide === "sell" ? rawSide : ("sell" as const);
 
     const invalidAmount = Number.isNaN(amount) || amount <= 0;
     if (!token || !currency || invalidAmount) {
@@ -50,13 +53,53 @@ export const GET = withRateLimit(async (request: NextRequest) => {
       );
     }
 
+    if (!network) {
+      trackApiError(
+        request,
+        "/api/v1/rates",
+        "GET",
+        new Error("network query parameter is required"),
+        400,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error: "network is required for rate quotes",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (
+      rawSide !== undefined &&
+      rawSide !== "" &&
+      rawSide !== "buy" &&
+      rawSide !== "sell"
+    ) {
+      trackApiError(
+        request,
+        "/api/v1/rates",
+        "GET",
+        new Error("Invalid side parameter"),
+        400,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'side must be "buy" or "sell" when provided',
+        },
+        { status: 400 },
+      );
+    }
+
     // Call the aggregator service to fetch rate
     const rateData = await fetchRate({
       token,
       amount,
       currency,
       providerId: providerId || undefined,
-      network: network || undefined,
+      network,
+      side,
     });
 
     const response = {
@@ -67,6 +110,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
         currency,
         providerId,
         network,
+        side,
         rate: rateData.data,
         fetchedAt: new Date().toISOString(),
       },
@@ -81,6 +125,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
       currency,
       provider_id: providerId,
       network,
+      side,
       rate: rateData.data,
     });
 
@@ -92,6 +137,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
       currency,
       provider_id: providerId,
       network,
+      side,
       rate: rateData.data,
     });
 

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -181,8 +181,8 @@ export function MainPageContent() {
       setOrderId,
       setCreatedAt,
       setTransactionStatus,
-    }
-    
+    };
+
   useEffect(function setPageLoadingState() {
     setOrderId("");
     setIsPageLoading(false);
@@ -323,6 +323,7 @@ export function MainPageContent() {
             currency,
             providerId,
             network: normalizeNetworkForRateFetch(selectedNetwork.chain.name),
+            side: "sell",
           });
           setRate(rate.data);
           setRateError(null); // Clear error on success

--- a/app/hooks/useCNGNRate.ts
+++ b/app/hooks/useCNGNRate.ts
@@ -91,6 +91,7 @@ async function fetchRateWithTimeout(
       amount: 100,
       currency: "NGN",
       network: normalizeNetworkForRateFetch(network),
+      side: "sell",
       signal: controller.signal,
     });
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -115,12 +115,20 @@ export type VerifyAccountPayload = {
   accountIdentifier: string;
 };
 
+/** Paycrest v2 rates: onramp uses `buy`, offramp uses `sell`. */
+export type RateSide = "buy" | "sell";
+
 export type RatePayload = {
   token: string;
+  /**
+   * Token amount used in the aggregator path (provider min/max are in token).
+   * For onramp UIs where the user types fiat first, convert to token before quoting.
+   */
   amount?: number;
   currency: string;
+  network: string;
+  side: RateSide;
   providerId?: string;
-  network?: string;
   signal?: AbortSignal;
 };
 
@@ -128,6 +136,19 @@ export type RateResponse = {
   status: string;
   data: number;
   message: string;
+};
+
+/** Aggregator v2 `data` for GET /v2/rates/... */
+export type V2RateQuoteSide = {
+  rate: string;
+  providerIds?: string[];
+  orderType?: string;
+  refundTimeoutMinutes?: number;
+};
+
+export type V2RateQuoteResponse = {
+  buy?: V2RateQuoteSide;
+  sell?: V2RateQuoteSide;
 };
 
 export type PubkeyResponse = {


### PR DESCRIPTION
Closes #454

### Description

This change routes all Noblocks rate fetching through the Paycrest aggregator **v2** rates API instead of the legacy v1 single-side endpoint. The client keeps a stable **`RateResponse`** shape (`data` as a numeric rate) by parsing the v2 envelope and selecting the requested side.

**Implementation details**

- **`fetchRate`** in `app/api/aggregator.ts` calls `GET {origin}/v2/rates/{network}/{token}/{amount}/{currency}` with query params `side` (required: `buy` | `sell`) and optional `provider_id`. The base URL strips a trailing `/v1` from `NEXT_PUBLIC_AGGREGATOR_URL` so paths are not doubled as `/v1/v2/...`.
- **`RatePayload`** now requires **`network`** and **`side`**. Types include **`V2RateQuoteSide`** / **`V2RateQuoteResponse`** for parsing.
- **MainPageContent** passes **`side: "sell"`** for the current offramp (crypto → fiat) flow; **`useCNGNRate`** also uses **`sell`** for NGN balance context.
- **Next route** `GET /api/v1/rates` now requires the **`network`** query parameter (400 if missing). Optional **`side`** (`buy` | `sell`); invalid values return 400; default is **`sell`**. Successful JSON **`data`** includes **`side`**.

**Breaking changes**

- Callers of **`fetchRate`** must pass **`network`** and **`side`**.
- External or internal consumers of **`/api/v1/rates`** must send **`network`**; previously it was optional when proxying to v1.

**Alternatives considered**

- A separate `fetchV2Rate` helper was avoided in favor of a single **`fetchRate`** entry point as in the agreed plan.

### Testing

- Ran **`npm run build`** in this repo; compile and type check for the app completed successfully (existing ESLint warnings unrelated to these files remain).
- **Manual QA suggested:** load the swap form and confirm rates load with and without a `provider` / `PROVIDER` query param; verify CNGN-related flows; call **`/api/v1/rates`** with **`network`** and optional **`side=buy`** / **`side=sell`**. Confirm **`NEXT_PUBLIC_AGGREGATOR_URL`** (e.g. `https://api.paycrest.io/v1`) still resolves v2 correctly after base stripping.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for specifying buy vs sell when requesting rates.

* **Improvements**
  * Switched rate quoting to v2 with stricter validation and numeric rate normalization.
  * Network is now required and normalized for rate requests.
  * Enhanced error handling and analytics for v2 rate requests, including side and parsed rate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
