### PR TITLE
chore: refactor aggregator API URL handling to standardize base URL

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -50,11 +50,17 @@ function aggregatorBaseUrlV1(): string {
   if (!raw) {
     throw new Error("NEXT_PUBLIC_AGGREGATOR_URL is not configured");
   }
-  if (/\/v1$/i.test(raw)) {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error("NEXT_PUBLIC_AGGREGATOR_URL must be a valid absolute URL");
+  }
+  const pathNorm = u.pathname.replace(/\/+$/, "");
+  if (/\/v1$/i.test(pathNorm)) {
     return raw;
   }
   const withoutV2 = raw.replace(/\/v2$/i, "");
-  let u: URL;
   try {
     u = new URL(withoutV2);
   } catch {
@@ -144,8 +150,7 @@ export const fetchRate = async ({
     throw new Error("network is required for rate quotes");
   }
 
-  const base = (AGGREGATOR_URL || "").trim().replace(/\/+$/, "");
-  const endpoint = `${base}/rates/${encodeURIComponent(net)}/${encodeURIComponent(token)}/${amount}/${encodeURIComponent(currency)}`;
+  const endpoint = `${AGGREGATOR_URL}/rates/${encodeURIComponent(net)}/${encodeURIComponent(token)}/${amount}/${encodeURIComponent(currency)}`;
   const params: Record<string, string> = {
     side,
   };

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -38,6 +38,35 @@ import config from "../lib/config";
 
 const AGGREGATOR_URL = config.aggregatorUrl;
 
+/**
+ * Base for aggregator routes registered only under `/v1/` (tokens, verify-account, institutions,
+ * pubkey, orders/:chain/:id, reindex, KYC — see `aggregator/routers/index.go`).
+ * When env is `…/v2`, normalize to `…/v1` so paths are not `/v2/tokens`, etc.
+ * @returns {string} The base URL for the aggregator v1 API
+ * @throws {Error} If the aggregator URL is not configured or is not a valid absolute URL
+ */
+function aggregatorBaseUrlV1(): string {
+  const raw = (AGGREGATOR_URL || "").trim().replace(/\/+$/, "");
+  if (!raw) {
+    throw new Error("NEXT_PUBLIC_AGGREGATOR_URL is not configured");
+  }
+  if (/\/v1$/i.test(raw)) {
+    return raw;
+  }
+  const withoutV2 = raw.replace(/\/v2$/i, "");
+  let u: URL;
+  try {
+    u = new URL(withoutV2);
+  } catch {
+    throw new Error("NEXT_PUBLIC_AGGREGATOR_URL must be a valid absolute URL");
+  }
+  const path = u.pathname.replace(/\/+$/, "");
+  if (path === "" || path === "/") {
+    return `${u.origin}/v1`;
+  }
+  return `${withoutV2}/v1`;
+}
+
 /** Maps aggregator order status → Supabase `transactions.status`. Swap keeps validated→completed; on-ramp keeps pending until settled. */
 export function mapAggregatorStatusToDbStatus(
   status: string,
@@ -86,31 +115,6 @@ export function unwrapV2SenderOrderEnvelope(
   return o as unknown as OrderDetailsData;
 }
 
-/** Base URL without trailing `/v1` so v2 paths are `{origin}/v2/...` not `{origin}/v1/v2/...`. */
-function aggregatorOriginForV2(): string {
-  const raw = (AGGREGATOR_URL || "").trim();
-  if (!raw) {
-    throw new Error("NEXT_PUBLIC_AGGREGATOR_URL is not configured");
-  }
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    throw new Error(
-      "NEXT_PUBLIC_AGGREGATOR_URL must be a valid absolute URL (e.g. https://api.example.com/v1)",
-    );
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(
-      "NEXT_PUBLIC_AGGREGATOR_URL must use http: or https:",
-    );
-  }
-  const basePath = parsed.pathname
-    .replace(/\/v1\/?$/i, "")
-    .replace(/\/$/, "");
-  return `${parsed.origin}${basePath}`;
-}
-
 function pickV2RateQuote(
   quotes: V2RateQuoteResponse,
   side: RateSide,
@@ -133,15 +137,15 @@ export const fetchRate = async ({
   signal,
 }: RatePayload): Promise<RateResponse> => {
   const startTime = Date.now();
-  const analyticsEndpoint = "/v2/rates";
+  const analyticsEndpoint = "/rates";
   const net = (network || "").trim().toLowerCase();
 
   if (!net) {
     throw new Error("network is required for rate quotes");
   }
 
-  const origin = aggregatorOriginForV2();
-  const endpoint = `${origin}/v2/rates/${encodeURIComponent(net)}/${encodeURIComponent(token)}/${amount}/${encodeURIComponent(currency)}`;
+  const base = (AGGREGATOR_URL || "").trim().replace(/\/+$/, "");
+  const endpoint = `${base}/rates/${encodeURIComponent(net)}/${encodeURIComponent(token)}/${amount}/${encodeURIComponent(currency)}`;
   const params: Record<string, string> = {
     side,
   };
@@ -251,7 +255,7 @@ export const fetchSupportedInstitutions = async (
 ): Promise<InstitutionProps[]> => {
   try {
     const response = await axios.get(
-      `${AGGREGATOR_URL}/institutions/${currency}`,
+      `${aggregatorBaseUrlV1()}/institutions/${currency}`,
     );
     return response.data.data;
   } catch (error) {
@@ -267,7 +271,7 @@ export const fetchSupportedInstitutions = async (
  */
 export const fetchAggregatorPublicKey = async (): Promise<PubkeyResponse> => {
   try {
-    const response = await axios.get(`${AGGREGATOR_URL}/pubkey`);
+    const response = await axios.get(`${aggregatorBaseUrlV1()}/pubkey`);
     return response.data;
   } catch (error) {
     console.error("Error fetching aggregator public key:", error);
@@ -297,7 +301,7 @@ export const fetchAccountName = async (
     });
 
     const response = await axios.post(
-      `${AGGREGATOR_URL}/verify-account`,
+      `${aggregatorBaseUrlV1()}/verify-account`,
       payload,
     );
 
@@ -348,7 +352,7 @@ export const fetchOrderDetails = async (
 ): Promise<OrderDetailsResponse> => {
   try {
     const response = await axios.get(
-      `${AGGREGATOR_URL}/orders/${chainId}/${orderId}`,
+      `${aggregatorBaseUrlV1()}/orders/${chainId}/${orderId}`,
     );
     return response.data;
   } catch (error) {
@@ -376,7 +380,10 @@ export const initiateKYC = async (
       wallet_address: payload.walletAddress,
     });
 
-    const response = await axios.post(`${AGGREGATOR_URL}/kyc`, payload);
+    const response = await axios.post(
+      `${aggregatorBaseUrlV1()}/kyc`,
+      payload,
+    );
 
     // Track successful response
     const responseTime = Date.now() - startTime;
@@ -429,7 +436,9 @@ export const fetchKYCStatus = async (
       wallet_address: walletAddress,
     });
 
-    const response = await axios.get(`${AGGREGATOR_URL}/kyc/${walletAddress}`);
+    const response = await axios.get(
+      `${aggregatorBaseUrlV1()}/kyc/${walletAddress}`,
+    );
 
     // Track successful response
     const responseTime = Date.now() - startTime;
@@ -629,7 +638,7 @@ export async function reindexTransaction(
       retry_attempt: retryCount,
     });
 
-    const endpoint = `${AGGREGATOR_URL}/reindex/${network}/${txHash}`;
+    const endpoint = `${aggregatorBaseUrlV1()}/reindex/${network}/${txHash}`;
     const response = await axios.get(endpoint);
 
     // Track successful response (2xx status)
@@ -709,7 +718,7 @@ export async function reindexTransaction(
  */
 export const fetchTokens = async (): Promise<APIToken[]> => {
   try {
-    const response = await axios.get(`${AGGREGATOR_URL}/tokens`);
+    const response = await axios.get(`${aggregatorBaseUrlV1()}/tokens`);
     if (response.data?.data && Array.isArray(response.data.data)) {
       return response.data.data;
     }

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -56,7 +56,8 @@ export const GET = withRateLimit(
         );
       }
 
-      const url = `${config.aggregatorUrl}/sender/orders/${encodeURIComponent(id)}`;
+      const baseUrl = config.aggregatorUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
+      const url = `${baseUrl}/v2/sender/orders/${encodeURIComponent(id)}`;      
 
       const { data, status } = await axios.get(url, {
         headers: {

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -56,8 +56,7 @@ export const GET = withRateLimit(
         );
       }
 
-      const baseUrl = config.aggregatorUrl.replace(/\/+$/, "");
-      const url = `${baseUrl}/sender/orders/${encodeURIComponent(id)}`;
+      const url = `${config.aggregatorUrl}/sender/orders/${encodeURIComponent(id)}`;
 
       const { data, status } = await axios.get(url, {
         headers: {

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -56,8 +56,8 @@ export const GET = withRateLimit(
         );
       }
 
-      const baseUrl = config.aggregatorUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
-      const url = `${baseUrl}/v2/sender/orders/${encodeURIComponent(id)}`;
+      const baseUrl = config.aggregatorUrl.replace(/\/+$/, "");
+      const url = `${baseUrl}/sender/orders/${encodeURIComponent(id)}`;
 
       const { data, status } = await axios.get(url, {
         headers: {

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -45,31 +45,16 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const body = await request.json();
 
-    // Detect flow: onramp has source.type = "fiat", offramp has source.type = "crypto"
-    const sourceType = (body as { source?: { type?: string } })?.source?.type;
-    const isOnramp = sourceType === "fiat";
-
-    const baseUrl = config.aggregatorUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
-    const url = isOnramp
-      ? `${baseUrl}/v2/sender/orders`
-      : `${baseUrl}/v1/sender/orders`;
-
-    if (process.env.NODE_ENV === "development") {
-      console.log(`[payment-orders] ${isOnramp ? "onramp→v2" : "offramp→v1"} url →`, url);
-      console.log("[payment-orders] POST payload →", JSON.stringify(body, null, 2));
-    }
+    const baseUrl = config.aggregatorUrl.replace(/\/+$/, "");
+    const url = `${baseUrl}/sender/orders`;
 
     const { data, status } = await axios.post(url, body, {
-      headers: {
+      headers: {  
         "Content-Type": "application/json",
         "API-Key": config.aggregatorSenderApiKey.trim(),
       },
       validateStatus: () => true,
     });
-
-    if (process.env.NODE_ENV === "development" && status >= 400) {
-      console.log("[payment-orders] aggregator response →", status, JSON.stringify(data, null, 2));
-    }
 
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/v1/payment-orders", "POST", status, responseTime, {

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -45,8 +45,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const body = await request.json();
 
-    const baseUrl = config.aggregatorUrl.replace(/\/+$/, "");
-    const url = `${baseUrl}/sender/orders`;
+    const url = `${config.aggregatorUrl}/sender/orders`;
 
     const { data, status } = await axios.post(url, body, {
       headers: {  


### PR DESCRIPTION
### Description


This PR updates the Noblocks frontend’s integration with the Paycrest aggregator so environment-driven base URLs and versioned paths match the current aggregator API layout. Call sites that previously assumed a separate “origin for v2” now use a single, explicit v1 path prefix where required.

**Summary**

- Introduced `aggregatorBaseUrlV1` to normalize API paths under `/v1/`, so Noblocks builds consistent URLs for aggregator endpoints.
- Removed the deprecated `aggregatorOriginForV2` helper and routed API usage through the new base-URL approach aligned with the v2 aggregator URL configuration.
- Adjusted payment-order API routes so paths no longer embed redundant version segments, simplifying on-ramp and off-ramp request URLs while keeping behavior the same at the HTTP contract level.
- Tightened configuration handling around the aggregator base URL so misconfigured or non-absolute values fail clearly instead of producing invalid requests at runtime.
- **Environment configuration has been updated so deployment/staging (and local `.env`) use the v2 aggregator base URL** (e.g. `NEXT_PUBLIC_AGGREGATOR_URL` or the project equivalent), matching this migration.

**Ref**
Closes: #460

**Impacts**

- **Runtime / config:** Deployments must supply a valid **v2** absolute aggregator base URL in environment configuration. Invalid values should surface as configuration errors rather than silent bad URLs.
- **API usage:** Internal fetch paths for payment orders and related flows are updated; external public HTTP contracts exposed by Noblocks API routes should remain compatible unless reviewers rely on exact prior path strings in proxies or tests.

**Breaking changes**

- None intended for end users. Any breakage would be limited to custom infrastructure that hard-coded old path shapes or the removed `aggregatorOriginForV2` symbol (internal code only).

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated aggregator requests to a single normalized /v1 base for all services.
  * Removed development-only logging and minor whitespace cleanups in payment-order routing.
  * Eliminated legacy URL rewriting for aggregator calls to streamline request construction.

* **Bug Fixes**
  * Added stricter validation for aggregator URL configuration to surface missing/invalid settings.
  * Fixed analytics/rates request routing to use the normalized aggregator base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->