### PR TITLE
chore: refactor clipboard functionality to improve reliability

### DIFF
--- a/app/components/CopyAddressWarningModal.tsx
+++ b/app/components/CopyAddressWarningModal.tsx
@@ -14,8 +14,7 @@ import { networks } from "../mocks";
 import { useActualTheme } from "../hooks/useActualTheme";
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { getNetworkImageUrl } from "../utils";
-import { toast } from "sonner";
+import { copyToClipboard, getNetworkImageUrl } from "../utils";
 import { trackEvent } from "../hooks/analytics/useMixpanel";
 import { PiCheck } from "react-icons/pi";
 import { slideUpAnimation } from "./AnimatedComponents";
@@ -91,11 +90,11 @@ export const CopyAddressWarningModal: React.FC<
   }, [isOpen, onClose]);
 
   // Copy wallet address to clipboard with feedback
-  const handleCopyAddress = () => {
-    navigator.clipboard.writeText(address ?? "");
+  const handleCopyAddress = async () => {
+    const ok = await copyToClipboard(address ?? "", "Address");
+    if (!ok) return;
     setIsAddressCopied(true);
     setTimeout(() => setIsAddressCopied(false), 2000);
-    toast.success("Address copied to clipboard");
   };
 
   return (

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -5,7 +5,11 @@ import { useState, useEffect } from "react";
 import { usePrivy, useMfaEnrollment, useWallets } from "@privy-io/react-auth";
 import { useNetwork } from "../context/NetworksContext";
 import { useBalance, useTokens } from "../context";
-import { handleNetworkSwitch, detectWalletProvider } from "../utils";
+import {
+  copyToClipboard,
+  detectWalletProvider,
+  handleNetworkSwitch,
+} from "../utils";
 import { useLogout } from "@privy-io/react-auth";
 import { resetNetworkModalDismissed } from "../lib/networkModalStore";
 import { toast } from "sonner";
@@ -87,10 +91,10 @@ export const MobileDropdown = ({
 
   const { showMfaEnrollmentModal } = useMfaEnrollment();
 
-  const handleCopyAddress = () => {
+  const handleCopyAddress = async () => {
     if (!walletForCopy?.address) return;
-    navigator.clipboard.writeText(walletForCopy.address);
-    toast.success("Address copied to clipboard");
+    const ok = await copyToClipboard(walletForCopy.address, "Address");
+    if (!ok) return;
     setIsWarningModalOpen(true);
   };
 

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -11,7 +11,7 @@ import { ImSpinner } from "react-icons/im";
 import { resetNetworkModalDismissed } from "../lib/networkModalStore";
 import { PiCheck } from "react-icons/pi";
 import { useOutsideClick } from "../hooks";
-import { classNames, shortenAddress } from "../utils";
+import { classNames, copyToClipboard, shortenAddress } from "../utils";
 import { dropdownVariants } from "./AnimatedComponents";
 import {
   Copy01Icon,
@@ -67,8 +67,9 @@ export const SettingsDropdown = () => {
       ? embeddedWallet?.address
       : smartWallet?.address;
 
-  const handleCopyAddress = () => {
-    navigator.clipboard.writeText(walletAddress ?? "");
+  const handleCopyAddress = async () => {
+    const ok = await copyToClipboard(walletAddress ?? "", "Address");
+    if (!ok) return;
     setIsAddressCopied(true);
     setTimeout(() => setIsAddressCopied(false), 2000);
     setIsWarningModalOpen(true);

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import {
   classNames,
+  copyToClipboard,
   formatCurrency,
   getNetworkImageUrl,
   shortenAddress,
@@ -21,7 +22,6 @@ import {
 import Image from "next/image";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useInjectedWallet } from "../context";
-import { toast } from "sonner";
 import { Dialog } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
@@ -136,11 +136,11 @@ export const WalletDetails = () => {
   };
 
   // Copy wallet address to clipboard with feedback
-  const handleCopyAddress = () => {
-    navigator.clipboard.writeText(activeWallet?.address ?? "");
+  const handleCopyAddress = async () => {
+    const ok = await copyToClipboard(activeWallet?.address ?? "", "Address");
+    if (!ok) return;
     setIsWarningModalOpen(true);
     setIsAddressCopied(true);
-    toast.success("Address copied to clipboard");
     setTimeout(() => setIsAddressCopied(false), 2000);
   };
 

--- a/app/components/blog/post/detail-client.tsx
+++ b/app/components/blog/post/detail-client.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/app/hooks/analytics/useMixpanel";
 import { useBlogTracking } from "@/app/hooks/analytics/use-blog-tracking";
 import { Crimson_Pro } from "next/font/google";
-import { getBannerPadding } from "@/app/utils";
+import { copyToClipboard, getBannerPadding } from "@/app/utils";
 import { urlForImage } from "@/app/lib/sanity-client";
 import config from "@/app/lib/config";
 
@@ -76,27 +76,12 @@ export default function DetailClient({ post, recent }: DetailClientProps) {
     );
   }
 
-  const handleCopyLink = () => {
-    try {
-      if (navigator.clipboard && window.isSecureContext) {
-        navigator.clipboard.writeText(window.location.href);
-      } else {
-        const textarea = document.createElement("textarea");
-        textarea.value = window.location.href;
-        textarea.style.position = "fixed";
-        textarea.style.left = "-9999px";
-        document.body.appendChild(textarea);
-        textarea.focus();
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-      }
-      setCopied(true);
-      trackCopyLink(post._id, post.title);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // no-op
-    }
+  const handleCopyLink = async () => {
+    const ok = await copyToClipboard(window.location.href, "Link");
+    if (!ok) return;
+    setCopied(true);
+    trackCopyLink(post._id, post.title);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   const handleGetStartedClick = () => {

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -358,11 +358,12 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
                   type="button"
                   title="Copy address"
                   className="rounded-lg p-1 transition-colors hover:bg-accent-gray dark:hover:bg-white/10"
-                  onClick={() => {
-                    navigator.clipboard.writeText(
+                  onClick={async () => {
+                    const ok = await copyToClipboard(
                       transaction.recipient.account_identifier,
+                      "Address",
                     );
-                    toast.success("Address copied");
+                    if (!ok) return;
                     setIsWarningModalOpen(true);
                   }}
                 >
@@ -448,11 +449,12 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
                   type="button"
                   title="Copy address"
                   className="rounded-lg p-1 transition-colors hover:bg-accent-gray dark:hover:bg-white/10"
-                  onClick={() => {
-                    navigator.clipboard.writeText(
+                  onClick={async () => {
+                    const ok = await copyToClipboard(
                       transaction.recipient.account_identifier,
+                      "Address",
                     );
-                    toast.success("Address copied");
+                    if (!ok) return;
                     setIsWarningModalOpen(true);
                   }}
                 >
@@ -831,8 +833,12 @@ function OnrampPendingPaymentInstructions({
             type="button"
             title="Copy amount"
             className="shrink-0 rounded-lg p-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-white/10"
-            onClick={() => {
-              void copyToClipboard(String(instructions.amount), "Amount");
+            onClick={async () => {
+              const ok = await copyToClipboard(
+                String(instructions.amount),
+                "Amount",
+              );
+              if (!ok) return;
               setCopiedAmt(true);
               setTimeout(() => setCopiedAmt(false), 2000);
             }}

--- a/app/pages/MakePayment.tsx
+++ b/app/pages/MakePayment.tsx
@@ -332,11 +332,12 @@ export const MakePayment = ({
                             </p>
                             <button
                                 type="button"
-                                onClick={() => {
-                                    copyToClipboard(
+                                onClick={async () => {
+                                    const ok = await copyToClipboard(
                                         paymentDetails.accountNumber,
                                         "Account number",
                                     );
+                                    if (!ok) return;
                                     setIsAccountNumberCopied(true);
                                     setTimeout(() => setIsAccountNumberCopied(false), 2000);
                                 }}
@@ -364,11 +365,12 @@ export const MakePayment = ({
                             </p>
                             <button
                                 type="button"
-                                onClick={() => {
-                                    copyToClipboard(
+                                onClick={async () => {
+                                    const ok = await copyToClipboard(
                                         paymentDetails.amount.toString(),
                                         "Amount",
                                     );
+                                    if (!ok) return;
                                     setIsAmountCopied(true);
                                     setTimeout(() => setIsAmountCopied(false), 2000);
                                 }}

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1385,22 +1385,41 @@ export const getAvatarImage = (index: number): string => {
 };
 
 /**
- * Copies text to clipboard and shows a toast notification
- * @param text - The text to copy to clipboard
- * @param label - Optional label for the toast message (e.g., "Account number", "Amount")
- * @returns Promise that resolves when copy is complete
+ * Copies text to clipboard and shows a toast notification.
+ * Uses `navigator.clipboard` when available; falls back to `execCommand` for non-secure contexts.
+ * @param label - Optional label for the toast (e.g. "Address", "Link") → "{label} copied to clipboard"
+ * @returns Whether the copy succeeded
  */
-export const copyToClipboard = async (
+export async function copyToClipboard(
   text: string,
   label?: string,
-): Promise<void> => {
+): Promise<boolean> {
   try {
-    await navigator.clipboard.writeText(text);
-    toast.success(label ? `${label} copied to clipboard` : "Copied to clipboard");
-  } catch (error) {
+    if (navigator.clipboard?.writeText && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      if (!ok) {
+        throw new Error("execCommand copy failed");
+      }
+    }
+    toast.success(
+      label ? `${label} copied to clipboard` : "Copied to clipboard",
+    );
+    return true;
+  } catch {
     toast.error("Failed to copy");
+    return false;
   }
-};
+}
 
 export function mapProviderAccountToInstructions(
   a: V2FiatProviderAccountDTO,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1386,7 +1386,8 @@ export const getAvatarImage = (index: number): string => {
 
 /**
  * Copies text to clipboard and shows a toast notification.
- * Uses `navigator.clipboard` when available; falls back to `execCommand` for non-secure contexts.
+ * Uses `navigator.clipboard` when available; falls back to `execCommand` when the API is
+ * unavailable, non-secure context, or when `writeText` rejects.
  * @param label - Optional label for the toast (e.g. "Address", "Link") → "{label} copied to clipboard"
  * @returns Whether the copy succeeded
  */
@@ -1394,22 +1395,34 @@ export async function copyToClipboard(
   text: string,
   label?: string,
 ): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-    } else {
-      const textarea = document.createElement("textarea");
-      textarea.value = text;
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      document.body.appendChild(textarea);
+  const fallbackCopy = () => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+
+    try {
       textarea.focus();
       textarea.select();
       const ok = document.execCommand("copy");
-      document.body.removeChild(textarea);
       if (!ok) {
         throw new Error("execCommand copy failed");
       }
+    } finally {
+      textarea.remove();
+    }
+  };
+
+  try {
+    if (navigator.clipboard?.writeText && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        fallbackCopy();
+      }
+    } else {
+      fallbackCopy();
     }
     toast.success(
       label ? `${label} copied to clipboard` : "Copied to clipboard",


### PR DESCRIPTION
### Description

**Summary**

- Updated `copyToClipboard` in `app/utils.ts` to use `navigator.clipboard.writeText` in secure contexts and fall back to a temporary `textarea` plus `document.execCommand("copy")` when the Clipboard API is unavailable (e.g. non-secure context).
- Changed the return type to **`Promise<boolean>`** so callers can tell success from failure without duplicating error handling.
- Success and failure both surface via **Sonner toasts** (`{label} copied to clipboard` / generic success copy, or `Failed to copy`).
- Refactored call sites to use the shared helper: wallet and settings menus, mobile menu, copy-address warning modal, transaction details (recipient + on-ramp payment rows), blog post “copy link”, and Make Payment account/amount copy.
- Callers that update **extra UI** (checkmarks, modals, analytics) **await** the result and only run success side effects when the promise resolves to `true`, so UI stays consistent with actual clipboard state.

**Purpose**

Centralize clipboard behavior so copy works reliably across browsers and contexts, with consistent feedback, and avoid ad-hoc `navigator.clipboard` usage scattered through components.

**Ref**
Closes #462

**Impacts**

- **User-facing:** Copy actions should behave the same or better in HTTP / edge cases; users see clear success or failure toasts.
- **API / contracts:** `copyToClipboard` is now `async` and returns `boolean`; any external consumer must treat it as async (in-repo usages are updated).

**Breaking changes**

- None for HTTP APIs. **Breaking for direct importers** of `copyToClipboard` if they assumed `Promise<void>` or ignored failures—those call sites should use `await` and optionally branch on the boolean.

**Alternatives considered**

- Relying on `navigator.clipboard` only: rejected because it fails in some non-HTTPS or legacy environments.
- Leaving per-component copy logic: rejected to keep behavior and messaging consistent.


### Testing

**Manual**

- **Wallet / header:** Copy address from wallet details, settings dropdown, and mobile menu; confirm toast and warning modal only when copy succeeds (where applicable).
- **Transaction list / details:** Copy recipient address; copy on-ramp account number and amount; confirm checkmark state only after successful copy.
- **Make payment:** Copy account number and amount; same as above.
- **Blog:** Copy article link; confirm “copied” state and analytics only after success (if your build tracks `trackCopyLink` on success).
- Optionally test over **non-HTTPS** or a browser that blocks clipboard API to exercise the `execCommand` fallback (if your dev setup allows).

**Environment**

- Developed against the Noblocks Next.js app (Node / pnpm per `package.json`); verify in a current Chromium-based browser.

**Not tested / limits**

- Full matrix of legacy browsers not assumed; fallback follows common `execCommand` pattern.

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard reliability with better fallback and success/failure reporting.
  * Copy actions now verify success before updating UI or opening modals, preventing false success indicators.
  * Removed unconditional success toast; UI feedback is driven by copy state.

* **Refactor**
  * Unified copy behavior across the app via a shared copy utility that returns success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->