### PR TITLE
feat(payment-orders): on-ramp-only proxy, messageHash apiKey, single env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@
 
 # Aggregator API
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
-AGGREGATOR_SENDER_API_KEY_ID=
+# Sender API key UUID (aggregator dashboard): server proxy + client on-chain messageHash
+NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
 
 # Local transfer fee (e.g. cNGN -> NGN)
 NEXT_PUBLIC_LOCAL_TRANSFER_FEE_PERCENT=0.1

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -964,8 +964,9 @@ export async function migrateLocalStorageRecipients(
 }
 
 /**
- * Creates a v2 payment order (onramp/offramp) via the server proxy to aggregator.
- * POST /api/v1/payment-orders → aggregator POST /v2/sender/orders
+ * Creates a v2 on-ramp payment order (fiat source) via the server proxy to aggregator.
+ * POST /api/v1/payment-orders (on-ramp only) → aggregator POST /v2/sender/orders.
+ * Off-ramp orders are created on-chain (gateway.createOrder), not through this proxy.
  */
 export async function createV2SenderPaymentOrder(
   payload: V2CreatePaymentOrderPayload,

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -47,11 +47,11 @@ export const GET = withRateLimit(
           request,
           "/api/v1/payment-orders/[id]",
           "GET",
-          new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+          new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
           500,
         );
         return NextResponse.json(
-          { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+          { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
           { status: 500 },
         );
       }

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -34,28 +34,42 @@ export const POST = withRateLimit(async (request: NextRequest) => {
         request,
         "/api/v1/payment-orders",
         "POST",
-        new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+        new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
         500,
       );
       return NextResponse.json(
-        { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+        { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
         { status: 500 },
       );
     }
 
     const body = await request.json();
 
-    // Detect flow: onramp has source.type = "fiat", offramp has source.type = "crypto"
+    // On-ramp (fiat source) only: off-ramp orders are created on-chain via gateway.createOrder, not via this proxy.
     const sourceType = (body as { source?: { type?: string } })?.source?.type;
-    const isOnramp = sourceType === "fiat";
+    if (sourceType !== "fiat") {
+      trackApiError(
+        request,
+        "/api/v1/payment-orders",
+        "POST",
+        new Error("Off-ramp payment orders are not created through this endpoint"),
+        400,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Only on-ramp (fiat source) orders are supported. Off-ramp uses on-chain gateway.createOrder.",
+        },
+        { status: 400 },
+      );
+    }
 
     const baseUrl = config.aggregatorUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
-    const url = isOnramp
-      ? `${baseUrl}/v2/sender/orders`
-      : `${baseUrl}/v1/sender/orders`;
+    const url = `${baseUrl}/v2/sender/orders`;
 
     if (process.env.NODE_ENV === "development") {
-      console.log(`[payment-orders] ${isOnramp ? "onramp→v2" : "offramp→v1"} url →`, url);
+      console.log("[payment-orders] onramp→v2 url →", url);
       console.log("[payment-orders] POST payload →", JSON.stringify(body, null, 2));
     }
 

--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -27,6 +27,8 @@ const crimsonPro = Crimson_Pro({
 interface HomePageProps {
   transactionFormComponent: ReactNode;
   isRecipientFormOpen: boolean;
+  /** On-ramp tab: cash → stablecoins hero copy. */
+  isOnramp: boolean;
   showBlockFestBanner?: boolean;
 }
 
@@ -47,6 +49,7 @@ const heroLineVariants = {
 function HomePageComponent({
   transactionFormComponent,
   isRecipientFormOpen,
+  isOnramp,
   showBlockFestBanner = false,
 }: HomePageProps) {
   const handleScrollToForm = () => {
@@ -90,12 +93,12 @@ function HomePageComponent({
               transition={{ duration: 0.7, ease: "easeInOut" }}
             >
               <span className="text-3xl text-text-secondary dark:text-white/80 sm:text-[2.5rem] md:text-[3.5rem] lg:text-[4rem]">
-                Move between stablecoins
+                {isOnramp ? "Change cash" : "Change stablecoins"}
               </span>
               <span
                 className={`${crimsonPro.className} text-[2.5rem] italic sm:text-[3.45rem] md:text-[4.75rem] lg:text-[5.25rem]`}
               >
-                and cash in seconds
+                {isOnramp ? "to stablecoins in seconds" : "to cash in seconds"}
               </span>
             </motion.h1>
           </motion.section>

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -48,6 +48,7 @@ const PageLayout = ({
   currentStep,
   transactionFormComponent,
   isRecipientFormOpen,
+  isOnramp,
   isBlockFestReferral,
 }: {
   authenticated: boolean;
@@ -55,6 +56,7 @@ const PageLayout = ({
   currentStep: string;
   transactionFormComponent: React.ReactNode;
   isRecipientFormOpen: boolean;
+  isOnramp: boolean;
   isBlockFestReferral: boolean;
 }) => {
   const { claimed, resetClaim } = useBlockFestClaim();
@@ -94,6 +96,7 @@ const PageLayout = ({
         <HomePage
           transactionFormComponent={transactionFormComponent}
           isRecipientFormOpen={isRecipientFormOpen}
+          isOnramp={isOnramp}
           showBlockFestBanner={claimed === true}
         />
       ) : (
@@ -160,10 +163,18 @@ export function MainPageContent() {
       accountIdentifier: "",
       accountType: "bank",
       isSwapped: false,
+      receiveDestinationExplicitlySelected: false,
     },
   });
   const { watch } = formMethods;
-  const { currency, amountSent, amountReceived, token, isSwapped } = watch();
+  const {
+    currency,
+    amountSent,
+    amountReceived,
+    token,
+    isSwapped,
+    receiveDestinationExplicitlySelected,
+  } = watch();
   /** On-ramp (fiat→crypto): same as TransactionForm `isSwapped` / v2 `buy` side. */
   const isOnrampRate = Boolean(isSwapped);
 
@@ -328,6 +339,8 @@ export function MainPageContent() {
 
       if (!currency) return;
 
+      if (isOnrampRate && !token) return;
+
       // Only fetch rate if at least one amount is greater than 0
       if (!amountSent && !amountReceived) return;
 
@@ -477,7 +490,9 @@ export function MainPageContent() {
     (isInjectedWallet && !injectedReady);
 
   const isRecipientFormOpen =
-    !!currency && (authenticated || isInjectedWallet) && isUserVerified;
+    receiveDestinationExplicitlySelected &&
+    (authenticated || isInjectedWallet) &&
+    isUserVerified;
 
   const renderTransactionStep = useCallback(() => {
     switch (currentStep) {
@@ -574,6 +589,7 @@ export function MainPageContent() {
           currentStep={currentStep}
           transactionFormComponent={transactionFormComponent}
           isRecipientFormOpen={isRecipientFormOpen}
+          isOnramp={isSwapped}
           isBlockFestReferral={isBlockFestReferral}
         />
       )}

--- a/app/components/PDFReceipt.tsx
+++ b/app/components/PDFReceipt.tsx
@@ -9,7 +9,7 @@ import {
   Font,
 } from "@react-pdf/renderer";
 import { format } from "date-fns";
-import { formatCurrency, getInstitutionNameByCode } from "../utils";
+import { getInstitutionNameByCode } from "../utils";
 import type { OrderDetailsData, InstitutionProps } from "../types";
 
 Font.register({

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -20,7 +20,6 @@ import {
   formatNumberWithCommas,
   getTokenLogoIdentifier,
   currencyToCountryCode,
-  formatCurrency,
   getCurrencySymbol,
   getNetworkImageUrl,
   shortenAddress,
@@ -28,6 +27,8 @@ import {
   mapProviderAccountToInstructions,
   ONRAMP_CLIENT_PAYMENT_SESSION_MS,
   isOnrampClientPaymentSessionExpired,
+  getTransactionHistoryTypeLabel,
+  formatTransactionAmountDisplay,
 } from "../../utils";
 import {
   fetchV2SenderPaymentOrderById,
@@ -265,22 +266,22 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
               );
             })()}
           </div>
-          <div className="ml-2 text-lg font-medium capitalize leading-6 text-text-body dark:text-white/80">
-            {transaction.transaction_type === "transfer"
-              ? "Transferred"
-              : transaction.transaction_type === "swap"
-                ? "Swapped"
-                : transaction.transaction_type}{" "}
+          <div className="ml-2 text-lg font-medium leading-6 text-text-body dark:text-white/80">
+            {getTransactionHistoryTypeLabel(transaction.transaction_type)}{" "}
             <span className="font-semibold text-text-body dark:text-white">
               {transaction.transaction_type === "onramp" ? (
                 <>
-                  {formatNumberWithCommas(transaction.amount_received ?? 0)}{" "}
-                  {transaction.to_currency}
+                  {formatTransactionAmountDisplay(
+                    transaction.amount_received ?? 0,
+                    transaction.to_currency,
+                  )}
                 </>
               ) : (
                 <>
-                  {formatNumberWithCommas(transaction.amount_sent)}{" "}
-                  {transaction.from_currency}
+                  {formatTransactionAmountDisplay(
+                    transaction.amount_sent,
+                    transaction.from_currency,
+                  )}
                 </>
               )}
             </span>
@@ -309,8 +310,10 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Amount"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {formatNumberWithCommas(transaction.amount_received ?? 0)}{" "}
-                {transaction.to_currency}
+                {formatTransactionAmountDisplay(
+                  transaction.amount_received ?? 0,
+                  transaction.to_currency,
+                )}
               </span>
             }
           />
@@ -386,10 +389,9 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Amount"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {formatCurrency(
+                {formatTransactionAmountDisplay(
                   transaction.amount_received ?? 0,
                   transaction.to_currency,
-                  `en-${transaction.to_currency.slice(0, 2)}`,
                 )}
               </span>
             }
@@ -398,9 +400,11 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Rate"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {getCurrencySymbol(transaction.from_currency)}
-                {formatNumberWithCommas(transaction.fee ?? 0)} ~ 1{" "}
-                {transaction.to_currency}
+                {formatTransactionAmountDisplay(
+                  transaction.fee ?? 0,
+                  transaction.from_currency,
+                )}{" "}
+                ~ 1 {transaction.to_currency}
               </span>
             }
           />
@@ -481,10 +485,9 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Amount"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {formatCurrency(
+                {formatTransactionAmountDisplay(
                   transaction.amount_received ?? 0,
                   transaction.to_currency,
-                  `en-${transaction.to_currency.slice(0, 2)}`,
                 )}
               </span>
             }
@@ -493,10 +496,9 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Rate"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {formatCurrency(
+                {formatTransactionAmountDisplay(
                   transaction.fee ?? 0,
                   transaction.to_currency,
-                  `en-${transaction.to_currency.slice(0, 2)}`,
                 )}
               </span>
             }

--- a/app/components/transaction/TransactionList.tsx
+++ b/app/components/transaction/TransactionList.tsx
@@ -7,6 +7,8 @@ import {
   generatePaginationItems,
   getRelativeDate,
   isOnrampClientPaymentSessionExpired,
+  getTransactionHistoryTypeLabel,
+  formatTransactionAmountDisplay,
 } from "../../utils";
 import type { TransactionHistory } from "../../types";
 import { useEffect, useMemo, useReducer } from "react";
@@ -91,9 +93,12 @@ export const TransactionListItem = ({
               height={16}
               quality={90}
             />
-            <span className="capitalize dark:text-white/80">
-              {transaction.transaction_type} {transaction.amount_sent}{" "}
-              {transaction.from_currency}
+            <span className="dark:text-white/80">
+              {getTransactionHistoryTypeLabel(transaction.transaction_type)}{" "}
+              {formatTransactionAmountDisplay(
+                transaction.amount_sent,
+                transaction.from_currency,
+              )}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -116,7 +121,10 @@ export const TransactionListItem = ({
         whileHover={{ x: -4 }}
         transition={{ duration: 0.2 }}
       >
-        {transaction.amount_received.toLocaleString()} {transaction.to_currency}
+        {formatTransactionAmountDisplay(
+          transaction.amount_received,
+          transaction.to_currency,
+        )}
       </motion.span>
     </div>
   );
@@ -305,14 +313,14 @@ export default function TransactionList({
                                 quality={90}
                                 className="rounded-full"
                               />
-                              <span className="capitalize dark:text-white/80">
-                                {transaction.transaction_type === "transfer"
-                                  ? "Transferred"
-                                  : transaction.transaction_type === "swap"
-                                    ? "Swapped"
-                                    : transaction.transaction_type}{" "}
-                                {transaction.amount_sent.toLocaleString()}{" "}
-                                {transaction.from_currency}
+                              <span className="dark:text-white/80">
+                                {getTransactionHistoryTypeLabel(
+                                  transaction.transaction_type,
+                                )}{" "}
+                                {formatTransactionAmountDisplay(
+                                  transaction.amount_sent,
+                                  transaction.from_currency,
+                                )}
                               </span>
                             </div>
                             <div className="flex items-center gap-x-2">
@@ -337,8 +345,10 @@ export default function TransactionList({
                         </div>
 
                         <span className="text-sm text-text-secondary dark:text-white/50">
-                          {transaction.amount_received.toLocaleString()}{" "}
-                          {transaction.to_currency}
+                          {formatTransactionAmountDisplay(
+                            transaction.amount_received,
+                            transaction.to_currency,
+                          )}
                         </span>
                       </motion.div>
                     );

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -32,9 +32,18 @@ export function useSwapButton({
 }: UseSwapButtonProps) {
   const { authenticated } = usePrivy();
   const { isInjectedWallet } = useInjectedWallet();
-  const { amountSent, currency, recipientName, walletAddress } = watch();
+  const {
+    amountSent,
+    currency,
+    recipientName,
+    walletAddress,
+    receiveDestinationExplicitlySelected,
+  } = watch();
 
-  const isAmountValid = Number(amountSent) >= 0.5;
+  // Off-ramp: min 0.5 token (~$0.5 stables). On-ramp: min fiat = 0.5×rate (fiat per 1 token) ≈ same token out.
+  const isAmountValid = isSwapped
+    ? Number(rate) > 0 && Number(amountSent) >= 0.5 * Number(rate)
+    : Number(amountSent) >= 0.5;
   const isCurrencySelected = Boolean(currency);
 
   const isMigrationMandatory =
@@ -57,6 +66,7 @@ export function useSwapButton({
   const isEnabled = (() => {
     if (needsMigration && authenticated && !isInjectedWallet) return true;
     if (isMigrationMandatory) return true;
+    if (!receiveDestinationExplicitlySelected) return false;
     if (!rate) return false;
     if (isInjectedWallet && hasInsufficientBalance) {
       return false;

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -44,7 +44,8 @@ const config: Config = {
     !!(process.env.NEXT_PUBLIC_MAINTENANCE_SCHEDULE || "").trim(),
   maintenanceSchedule:
     process.env.NEXT_PUBLIC_MAINTENANCE_SCHEDULE || "",
-  aggregatorSenderApiKey: process.env.AGGREGATOR_SENDER_API_KEY_ID || "",
+  /** Sender API key UUID (aggregator dashboard). Used by server proxy and client (on-chain messageHash metadata). */
+  aggregatorSenderApiKey: (process.env.NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID || "").trim(),
 };
 
 export default config;

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -33,8 +33,6 @@ import {
   formatDecimalPrecision,
   currencyToCountryCode,
   reorderCurrenciesByLocation,
-  fetchUserCountryCode,
-  mapCountryToCurrency,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -116,8 +114,15 @@ export const TransactionForm = ({
     getValues,
     formState: { errors, isValid, isDirty },
   } = formMethods;
-  const { amountSent, amountReceived, token, currency, walletAddress, isSwapped } =
-    watch();
+  const {
+    amountSent,
+    amountReceived,
+    token,
+    currency,
+    walletAddress,
+    isSwapped,
+    receiveDestinationExplicitlySelected,
+  } = watch();
 
   // Custom hook for CNGN rate fetching (used for validation limits when token is cNGN)
   const { rate: cngnRate, error: cngnRateError } = useCNGNRate({
@@ -268,8 +273,12 @@ export const TransactionForm = ({
         (c: CurrencyOption) => c.name === currency && !c.disabled,
       );
 
-      if (supported)
+      if (supported) {
         formMethods.setValue("currency", currency, { shouldDirty: true });
+        formMethods.setValue("receiveDestinationExplicitlySelected", true, {
+          shouldDirty: true,
+        });
+      }
     }
     if (tokenAmount && fiatAmount) {
       formMethods.setValue("amountReceived", fiatAmount, { shouldDirty: true });
@@ -288,6 +297,7 @@ export const TransactionForm = ({
 
   useEffect(
     function initSelectedToken() {
+      if (getValues("isSwapped")) return;
       if (
         !fetchedTokens.find((t) => t.symbol === token) &&
         fetchedTokens.length > 0
@@ -405,7 +415,11 @@ export const TransactionForm = ({
 
         const normalizedToken = token?.toUpperCase();
 
-        if (normalizedToken === "CNGN") {
+        if (isSwapped) {
+          // On-ramp: send NGN; min in validate.onrampFiatMin, max 2.3M NGN product cap.
+          maxAmountSentValue = 2_300_000;
+          setRateError(null);
+        } else if (normalizedToken === "CNGN") {
           if (cngnRate && cngnRate > 0) {
             // Valid rate available - calculate limits and clear errors
             maxAmountSentValue = 50000000;
@@ -421,11 +435,15 @@ export const TransactionForm = ({
 
         formMethods.register("amountSent", {
           required: { value: true, message: "Amount is required" },
-          disabled: !token,
-          min: {
-            value: minAmountSentValue,
-            message: `Minimum amount is ${formatNumberWithCommas(minAmountSentValue)}`,
-          },
+          disabled: isSwapped ? !currency : !token,
+          ...(!isSwapped
+            ? {
+                min: {
+                  value: minAmountSentValue,
+                  message: `Minimum amount is ${formatNumberWithCommas(minAmountSentValue)}`,
+                },
+              }
+            : {}),
           max: {
             value: maxAmountSentValue,
             message: `Maximum amount is ${formatNumberWithCommas(maxAmountSentValue)}`,
@@ -439,6 +457,14 @@ export const TransactionForm = ({
                 "Maximum 4 decimal places allowed"
               );
             },
+            onrampFiatMin: (value: number) => {
+              if (!isSwapped) return true;
+              if (!rate || rate <= 0) return "Loading exchange rate…";
+              const n = Number(value);
+              const floor = 0.5 * rate;
+              if (n >= floor) return true;
+              return `Minimum amount is ${formatNumberWithCommas(floor)} NGN`;
+            },
           },
         });
 
@@ -450,7 +476,15 @@ export const TransactionForm = ({
           required: { value: false, message: "Add description" },
         });
 
-        if (normalizedToken === "CNGN") {
+        if (isSwapped) {
+          // On-ramp is NGN-only for now (send side).
+          currencies.forEach((c: CurrencyOption) => {
+            c.disabled = c.name !== "NGN";
+          });
+          if (currency !== "NGN") {
+            formMethods.setValue("currency", "NGN", { shouldDirty: true });
+          }
+        } else if (normalizedToken === "CNGN") {
           // When cNGN is selected, only enable NGN
           currencies.forEach((currency: CurrencyOption) => {
             currency.disabled = currency.name !== "NGN";
@@ -459,6 +493,9 @@ export const TransactionForm = ({
           if (currency !== "NGN") {
             formMethods.setValue("currency", "NGN", { shouldDirty: true });
           }
+          formMethods.setValue("receiveDestinationExplicitlySelected", true, {
+            shouldDirty: true,
+          });
         } else {
           // Reset currencies to their default state from mocks
           currencies.forEach((currency: CurrencyOption) => {
@@ -486,6 +523,8 @@ export const TransactionForm = ({
       selectedNetwork,
       cngnRate,
       cngnRateError,
+      isSwapped,
+      rate,
     ],
   );
 
@@ -542,16 +581,26 @@ export const TransactionForm = ({
     // Only enable on-ramp from pre-filled wallet; do not force off-ramp (avoids clobbering toggle before this runs)
     if (hasWallet) {
       setValue("isSwapped", true, { shouldDirty: false });
+      const t = getValues("token");
+      if (typeof t === "string" && t.trim().length > 0) {
+        setValue("receiveDestinationExplicitlySelected", true, {
+          shouldDirty: false,
+        });
+      }
     }
     hasRestoredStateRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Handle swap button click to switch between token/currency dropdowns
-  const handleSwapFields = async () => {
+  const handleSwapFields = () => {
     const currentAmountSent = amountSent;
     const currentAmountReceived = amountReceived;
     const willBeSwapped = !isSwapped;
+
+    setValue("receiveDestinationExplicitlySelected", false, {
+      shouldDirty: true,
+    });
 
     // Toggle swap mode FIRST (persisted on form so parent rate fetch uses correct side)
     setValue("isSwapped", willBeSwapped, { shouldDirty: true });
@@ -566,34 +615,9 @@ export const TransactionForm = ({
 
     // Set defaults only if not already selected
     if (willBeSwapped) {
-      // Switching to onramp mode: Set currency based on user location
-      if (!currency) {
-        try {
-          const countryCode = await fetchUserCountryCode();
-          const locationCurrency = countryCode
-            ? mapCountryToCurrency(countryCode)
-            : null;
-
-          // Use location-based currency if available and supported, otherwise default to NGN
-          const defaultCurrency = locationCurrency &&
-            currencies.find(c => c.name === locationCurrency && !c.disabled)
-            ? locationCurrency
-            : "NGN";
-
-          setValue("currency", defaultCurrency, { shouldDirty: true });
-        } catch {
-          // Fallback to NGN if location detection fails
-          setValue("currency", "NGN", { shouldDirty: true });
-        }
-      }
-      // Only set default token if not already selected
-      if (!token && fetchedTokens.length > 0) {
-        const usdcToken = fetchedTokens.find((t) => t.symbol === "USDC");
-        const defaultToken = usdcToken?.symbol || fetchedTokens[0]?.symbol;
-        if (defaultToken) {
-          setValue("token", defaultToken, { shouldDirty: true });
-        }
-      }
+      // On-ramp: fiat send is NGN-only for now. Receive token chosen on the Receive row.
+      setValue("currency", "NGN", { shouldDirty: true });
+      setValue("token", "", { shouldDirty: true });
       // Clear walletAddress when switching to onramp mode
       if (!walletAddress) {
         setValue("walletAddress", "", { shouldDirty: true });
@@ -989,9 +1013,12 @@ export const TransactionForm = ({
                     (!authenticated ||
                       (authenticated && !(totalRequired > balance)))
                   }
-                  onSelect={(selectedToken) =>
-                    setValue("token", selectedToken, { shouldDirty: true })
-                  }
+                  onSelect={(selectedToken) => {
+                    setValue("token", selectedToken, { shouldDirty: true });
+                    setValue("receiveDestinationExplicitlySelected", true, {
+                      shouldDirty: true,
+                    });
+                  }}
                   className="min-w-32"
                   dropdownWidth={160}
                 />
@@ -1000,9 +1027,14 @@ export const TransactionForm = ({
                   defaultTitle="Select currency"
                   data={orderedCurrencies}
                   defaultSelectedItem={currency}
-                  onSelect={(selectedCurrency) =>
-                    setValue("currency", selectedCurrency, { shouldDirty: true })
-                  }
+                  onSelect={(selectedCurrency) => {
+                    setValue("currency", selectedCurrency, {
+                      shouldDirty: true,
+                    });
+                    setValue("receiveDestinationExplicitlySelected", true, {
+                      shouldDirty: true,
+                    });
+                  }}
                   className="min-w-80"
                   isCTA={
                     !currency &&
@@ -1018,7 +1050,8 @@ export const TransactionForm = ({
 
         {/* Recipient and memo */}
         <AnimatePresence>
-          {currency &&
+          {receiveDestinationExplicitlySelected &&
+            currency &&
             (authenticated || isInjectedWallet) &&
             isUserVerified && (
               <AnimatedComponent
@@ -1114,7 +1147,7 @@ export const TransactionForm = ({
         )}
 
         <AnimatePresence>
-          {currency && (
+          {receiveDestinationExplicitlySelected && currency && (
             <AnimatedComponent
               variant={slideInOut}
               className="flex w-full flex-col justify-between gap-2 py-3 text-xs text-text-disabled transition-all dark:text-white/30 xsm:flex-row xsm:items-center"

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -20,7 +20,7 @@ import {
   shortenAddress,
 } from "../utils";
 import { useNetwork, useTokens } from "../context";
-import {
+import config, {
   getDelegationContractAddress,
   localTransferFeePercent,
 } from "../lib/config";
@@ -263,10 +263,18 @@ export const TransactionPreview = ({
     };
 
   const prepareCreateOrderParams = async () => {
+    const senderApiKeyId = config.aggregatorSenderApiKey?.trim();
+    if (!senderApiKeyId) {
+      throw new Error(
+        "Sender API key is not configured (set NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID)",
+      );
+    }
+    const metadata = { apiKey: senderApiKeyId };
+
     const providerId =
       searchParams.get("provider") || searchParams.get("PROVIDER");
 
-    // Prepare recipient data
+    // Prepare recipient data (metadata.apiKey matches aggregator OrderEVM.CreateOrder + indexer)
     const recipient = isOnramp
       ? {
         accountIdentifier: walletAddress || "",
@@ -274,6 +282,7 @@ export const TransactionPreview = ({
         institution: "Wallet",
         ...(providerId && { providerId }),
         nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
+        metadata,
       }
       : {
         accountIdentifier: formValues.accountIdentifier,
@@ -282,6 +291,7 @@ export const TransactionPreview = ({
         memo: formValues.memo,
         ...(providerId && { providerId }),
         nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
+        metadata,
       };
 
     // Fetch aggregator public key

--- a/app/types.ts
+++ b/app/types.ts
@@ -36,6 +36,8 @@ export type FormData = {
   amountSent: number;
   amountReceived: number;
   isSwapped: boolean;
+  /** True after user picks the Receive row asset (fiat off-ramp, token on-ramp). */
+  receiveDestinationExplicitlySelected: boolean;
 };
 
 export const STEPS = {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -10,6 +10,7 @@ import type {
   V2FiatProviderAccountDTO,
   OnrampPaymentInstructions,
   TransactionHistory,
+  TransactionHistoryType,
 } from "./types";
 import type { SanityPost, SanityCategory } from "./blog/types";
 import { erc20Abi, createPublicClient, http } from "viem";
@@ -144,6 +145,51 @@ export const getCurrencySymbol = (currency: string): string => {
 
   return currencySymbols[currency.toUpperCase()] || currency;
 };
+
+/** Fiat codes supported in Noblocks swap (matches `mocks.acceptedCurrencies` names). */
+const NOBLOCKS_FIAT_CURRENCY_CODES = new Set([
+  "NGN",
+  "KES",
+  "UGX",
+  "TZS",
+  "MWK",
+  "GHS",
+  "BRL",
+  "ARS",
+]);
+
+export function isNoblocksFiatCurrencyCode(code: string): boolean {
+  return NOBLOCKS_FIAT_CURRENCY_CODES.has(code.toUpperCase());
+}
+
+/**
+ * List / details: fiat uses symbol prefix (e.g. ₦1,000.5); crypto uses "1.23 USDC".
+ */
+export function formatTransactionAmountDisplay(
+  amount: number,
+  currencyCode: string,
+): string {
+  if (isNoblocksFiatCurrencyCode(currencyCode)) {
+    return `${getCurrencySymbol(currencyCode)}${formatNumberWithCommas(amount)}`;
+  }
+  return `${formatNumberWithCommas(amount)} ${currencyCode}`;
+}
+
+/** User-facing label for transaction history rows (API still uses `onramp`). */
+export function getTransactionHistoryTypeLabel(
+  type: TransactionHistoryType,
+): string {
+  switch (type) {
+    case "transfer":
+      return "Transferred";
+    case "swap":
+      return "Swapped";
+    case "onramp":
+      return "Swapped";
+    default:
+      return type;
+  }
+}
 
 /**
  * Encrypts data using the provided public key.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,9 @@ This document lists all environment variables required for the Noblocks applicat
 # URL of an aggregator service
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
 
+# Sender API key UUID (aggregator dashboard). Used by the payment-orders proxy and the client for encrypted gateway.createOrder messageHash.
+NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
+
 # Auth services
 NEXT_PUBLIC_PRIVY_APP_ID=
 NEXT_PUBLIC_THIRDWEB_CLIENT_ID=


### PR DESCRIPTION
### Description

This PR aligns Noblocks with aggregator expectations for sender identification and tightens the payment-orders proxy, and ships related on-ramp UX and transaction history improvements.

**Payment-orders proxy (`POST /api/v1/payment-orders`):** Only on-ramp requests (`source.type === "fiat"`) are forwarded to the aggregator `POST /v2/sender/orders`. Off-ramp is not created through this endpoint; it uses on-chain `gateway.createOrder`. Non–on-ramp requests receive HTTP 400 with a clear message.

**On-chain `createOrder` / `messageHash`:** The encrypted recipient payload includes `metadata.apiKey` with the sender API key UUID, matching aggregator `OrderEVM.CreateOrder` so the indexer can resolve the sender profile after decrypting `messageHash`.

**Configuration:** A single environment variable `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` is used for both the server proxy (`API-Key` header) and the client embedding in `messageHash`. Deployments that previously set only `AGGREGATOR_SENDER_API_KEY_ID` should switch to `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` with the same UUID.

**On-ramp UX (second commit):** Introduces `receiveDestinationExplicitlySelected` so the swap CTA and recipient section stay gated until the user picks the Receive row (fiat off-ramp / token on-ramp). On-ramp mode uses NGN send-side rules, min fiat vs rate, rate fetch after a receive token is chosen, and hero copy that reflects on-ramp vs off-ramp. Centralizes transaction list/details formatting via `formatTransactionAmountDisplay` and `getTransactionHistoryTypeLabel`.

**Documentation:** `.env.example` and `docs/environment-variables.md` updated. `createV2SenderPaymentOrder` JSDoc clarifies on-ramp-only proxy usage.

### References

Closes #465


### Testing

**Manual**

- Set `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` in `.env.local` (valid aggregator sender API key UUID).
- On-ramp: create a payment order through flows that call `POST /api/v1/payment-orders` with `source.type: "fiat"` and confirm success against aggregator v2.
- Off-ramp: confirm `POST /api/v1/payment-orders` with non-fiat source returns 400 with the documented error body.
- Off-ramp on-chain: complete `createOrder` from Transaction Preview and confirm submission; verify indexer/aggregator can read `metadata.apiKey` after decrypt (environment-dependent).
- Swap form: confirm recipient and primary CTA only enable after selecting receive asset; exercise on-ramp toggle, NGN/min rules, and hero copy.
- History: spot-check list and detail rows for fiat symbol formatting and type labels.

**Automated:** Not run as part of this change (existing project lint/tsc noise).

**Environment:** Next.js app in this repo; browser as above.

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
