### PR TITLE
feat(balances): parallelize rate+RPC, multicall per chain, SWR cache, CNGN UX

### DIFF
--- a/__tests__/tokenBalanceRowVisible.test.ts
+++ b/__tests__/tokenBalanceRowVisible.test.ts
@@ -1,0 +1,17 @@
+import { tokenBalanceRowVisible } from "../app/utils";
+
+describe("tokenBalanceRowVisible", () => {
+  it("shows CNGN on non-selected network when raw > 0 but USD slot is 0", () => {
+    expect(
+      tokenBalanceRowVisible({ CNGN: 100 }, "CNGN", 0, false),
+    ).toBe(true);
+  });
+
+  it("hides zero row on non-selected network when no raw", () => {
+    expect(tokenBalanceRowVisible(undefined, "USDC", 0, false)).toBe(false);
+  });
+
+  it("always includes rows on selected network", () => {
+    expect(tokenBalanceRowVisible(undefined, "USDC", 0, true)).toBe(true);
+  });
+});

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -54,7 +54,7 @@ export const MobileDropdown = ({
   const { currentStep } = useStep();
 
   const { user, linkEmail, updateEmail, exportWallet } = usePrivy();
-  const { allBalances, crossChainBalances, isLoading, refreshBalance } = useBalance();
+  const { allBalances, crossChainBalances, isLoading, isRefreshing, refreshBalance } = useBalance();
   const { allTokens } = useTokens();
   const { ensureWalletExists } = useStarknet();
   const { logout } = useLogout({
@@ -288,6 +288,7 @@ export const MobileDropdown = ({
                               onHistory={() => setCurrentView("history")}
                               setSelectedNetwork={setSelectedNetwork}
                               onRefreshBalance={refreshBalance}
+                              isRefreshing={isRefreshing}
                             />
                           )}
 

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useMemo, useReducer } from "react";
+import { useState, useEffect, useMemo, useReducer, useRef } from "react";
 import {
   classNames,
   copyToClipboard,
@@ -8,6 +8,7 @@ import {
   shortenAddress,
   hasOnrampAwaitingBankTransfer,
   OnrampPendingNotificationDot,
+  tokenBalanceRowVisible,
 } from "../utils";
 import { useBalance, useTransactions, useStep } from "../context";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
@@ -69,7 +70,9 @@ export const WalletDetails = () => {
     crossChainBalances,
     crossChainTotal,
     isLoading,
+    isRefreshing,
     refreshBalance,
+    softRefresh,
   } = useBalance();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
   const { user, getAccessToken } = usePrivy();
@@ -84,14 +87,15 @@ export const WalletDetails = () => {
   const { handleFundWallet } = useFundWalletHandler("Wallet details");
 
   // Custom hook for CNGN rate fetching
-  const {
-    rate,
-    isLoading: isRateLoading,
-    error: rateError,
-  } = useCNGNRate({
+  const { refetch: refetchCngnRate } = useCNGNRate({
     network: selectedNetwork.chain.name,
     dependencies: [selectedNetwork],
   });
+
+  const softRefreshRef = useRef(softRefresh);
+  softRefreshRef.current = softRefresh;
+  const refetchCngnRateRef = useRef(refetchCngnRate);
+  refetchCngnRateRef.current = refetchCngnRate;
 
   const embeddedWallet = wallets.find(
     (wallet) => wallet.walletClientType === "privy",
@@ -125,6 +129,8 @@ export const WalletDetails = () => {
     selectedNetwork.chain.name,
   );
 
+  const showBalanceSkeleton = isLoading && !isRefreshing;
+
   const [onrampDotRevision, bumpOnrampDot] = useReducer(
     (n: number) => n + 1,
     0,
@@ -143,6 +149,18 @@ export const WalletDetails = () => {
       }
     });
   }, [activeWallet?.address, fetchTransactions, getAccessToken]);
+
+  // Focus refresh: re-quote NGN→USD and SWR-refresh balances when opening the drawer.
+  // Uses softRefresh (cache-respecting) so repeated drawer opens within the cache TTL
+  // don't trigger fresh RPC fan-out; the explicit Refresh button still bypasses cache.
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    const id = window.setTimeout(() => {
+      void refetchCngnRateRef.current();
+      void softRefreshRef.current();
+    }, 300);
+    return () => clearTimeout(id);
+  }, [isSidebarOpen]);
 
   const showOnrampAwaitingDot = useMemo(
     () =>
@@ -203,7 +221,7 @@ export const WalletDetails = () => {
         <Wallet01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
         <div className="h-9 w-px border-r border-dashed border-border-light dark:border-white/10" />
         <div className="flex items-center gap-1.5 dark:text-white/80">
-          {isLoading ? (
+          {showBalanceSkeleton ? (
             <BalanceSkeleton />
           ) : selectedNetwork.chain.name === "Starknet" ? (
             <p>${(activeBalance?.total ?? 0).toFixed(2)}</p>
@@ -306,7 +324,7 @@ export const WalletDetails = () => {
 
                       <div className="flex items-center justify-between">
                         <div className="text-2xl font-medium text-text-body dark:text-white">
-                          {isLoading ? (
+                          {showBalanceSkeleton ? (
                             <BalanceSkeleton className="w-24" />
                           ) : selectedNetwork.chain.name === "Starknet" ? (
                             `$${(activeBalance?.total ?? 0).toFixed(2)}`
@@ -329,7 +347,7 @@ export const WalletDetails = () => {
                           className="rounded-lg p-2 transition-colors hover:bg-accent-gray disabled:opacity-50 dark:hover:bg-white/10"
                         >
                           <RefreshIcon
-                            className={`size-5 text-outline-gray dark:text-white/50 ${isLoading ? "animate-spin" : ""}`}
+                            className={`size-5 text-outline-gray dark:text-white/50 ${isLoading || isRefreshing ? "animate-spin" : ""}`}
                           />
                         </button>
                       </div>
@@ -402,7 +420,7 @@ export const WalletDetails = () => {
                             exit="exit"
                             className="h-full space-y-6 overflow-y-auto pb-16"
                           >
-                            {isLoading ? (
+                            {showBalanceSkeleton ? (
                               <CrossChainBalanceSkeleton />
                             ) : (
                               sortedCrossChainBalances.map((entry) => {
@@ -417,8 +435,13 @@ export const WalletDetails = () => {
                                 // For other networks: only show non-zero balances
                                 const filteredBalances = isSelectedNetwork
                                   ? balanceEntries
-                                  : balanceEntries.filter(
-                                      ([, balance]) => balance > 0,
+                                  : balanceEntries.filter(([t, balance]) =>
+                                      tokenBalanceRowVisible(
+                                        entry.balances.rawBalances,
+                                        t,
+                                        balance,
+                                        isSelectedNetwork,
+                                      ),
                                     );
 
                                 // Skip networks with no balances to show
@@ -440,13 +463,19 @@ export const WalletDetails = () => {
                                     <div className="space-y-4">
                                       {filteredBalances.map(
                                         ([token, balance]) => {
+                                          const isCngn =
+                                            token === "CNGN" ||
+                                            token === "cNGN";
                                           const displayBalance =
-                                            token === "CNGN" || token === "cNGN"
+                                            isCngn
                                               ? (entry.balances.rawBalances?.[
                                                   token
                                                 ] ?? balance)
                                               : balance;
                                           const usdEquivalent = balance;
+                                          const cngnUnknown =
+                                            isCngn &&
+                                            entry.balances.cngnUsdUnknown;
 
                                           return (
                                             <div
@@ -482,20 +511,32 @@ export const WalletDetails = () => {
                                                   </span>
                                                   <span className="text-text-secondary dark:text-white/50">
                                                     {displayBalance}
+                                                    {cngnUnknown ? (
+                                                      <span className="block text-xs text-text-disabled dark:text-white/40">
+                                                        NGN-pegged · USD quote
+                                                        unavailable
+                                                      </span>
+                                                    ) : null}
                                                   </span>
                                                 </div>
                                               </div>
                                               <div className="flex flex-col items-end">
-                                                <span
-                                                  className={`${
-                                                    usdEquivalent === 0 &&
-                                                    displayBalance > 0
-                                                      ? "text-red-500"
-                                                      : "text-text-body dark:text-white/80"
-                                                  }`}
-                                                >
-                                                  ${usdEquivalent.toFixed(2)}
-                                                </span>
+                                                {cngnUnknown ? (
+                                                  <span className="text-text-secondary dark:text-white/45">
+                                                    —
+                                                  </span>
+                                                ) : (
+                                                  <span
+                                                    className={`${
+                                                      usdEquivalent === 0 &&
+                                                      displayBalance > 0
+                                                        ? "text-red-500"
+                                                        : "text-text-body dark:text-white/80"
+                                                    }`}
+                                                  >
+                                                    ${usdEquivalent.toFixed(2)}
+                                                  </span>
+                                                )}
                                               </div>
                                             </div>
                                           );

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -11,7 +11,7 @@ import {
   RefreshIcon,
 } from "hugeicons-react";
 import { CrossChainBalanceSkeleton } from "../BalanceSkeleton";
-import { classNames, getNetworkImageUrl } from "../../utils";
+import { classNames, getNetworkImageUrl, tokenBalanceRowVisible } from "../../utils";
 import type { CrossChainBalanceEntry } from "../../context";
 
 const Divider = () => (
@@ -40,6 +40,7 @@ interface WalletViewProps {
   onHistory: () => void;
   setSelectedNetwork: (network: any) => void;
   onRefreshBalance: () => void;
+  isRefreshing?: boolean;
 }
 
 export const WalletView: React.FC<WalletViewProps> = ({
@@ -62,7 +63,10 @@ export const WalletView: React.FC<WalletViewProps> = ({
   onClose,
   onHistory,
   onRefreshBalance,
+  isRefreshing = false,
 }) => {
+  const showBalanceSkeleton = isLoading && !isRefreshing;
+
   return (
     <div className="mb-[1.5rem] space-y-4">
       <div className="flex items-center justify-between">
@@ -111,13 +115,13 @@ export const WalletView: React.FC<WalletViewProps> = ({
             className="rounded-lg p-1.5 transition-colors hover:bg-accent-gray disabled:opacity-50 dark:hover:bg-white/10"
           >
             <RefreshIcon
-              className={`size-4 text-outline-gray dark:text-white/50 ${isLoading ? "animate-spin" : ""}`}
+              className={`size-4 text-outline-gray dark:text-white/50 ${isLoading || isRefreshing ? "animate-spin" : ""}`}
             />
           </button>
         </div>
 
         <div className="space-y-4">
-          {isLoading ? (
+          {showBalanceSkeleton ? (
             <CrossChainBalanceSkeleton isMobile />
           ) : (
             crossChainBalances.map((entry) => {
@@ -131,7 +135,14 @@ export const WalletView: React.FC<WalletViewProps> = ({
               // For other networks: only show non-zero balances
               const filteredBalances = isSelectedNetwork
                 ? balanceEntries
-                : balanceEntries.filter(([, balance]) => balance > 0);
+                : balanceEntries.filter(([t, balance]) =>
+                    tokenBalanceRowVisible(
+                      entry.balances.rawBalances,
+                      t,
+                      balance,
+                      isSelectedNetwork,
+                    ),
+                  );
 
               // Skip networks with no balances to show
               if (filteredBalances.length === 0) return null;
@@ -195,7 +206,7 @@ export const WalletView: React.FC<WalletViewProps> = ({
           )}
         </div>
 
-        {!isInjectedWallet && !isLoading && (
+        {!isInjectedWallet && !showBalanceSkeleton && (
           <div className="grid grid-cols-2 gap-4">
             <button
               type="button"

--- a/app/context/BalanceContext.tsx
+++ b/app/context/BalanceContext.tsx
@@ -356,7 +356,9 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
     try {
       const resolvedCngnRate =
         cngnRate ??
-        (await getCNGNRateForNetwork(CNGN_CROSS_CHAIN_QUOTE_NETWORK));
+        (await getCNGNRateForNetwork(CNGN_CROSS_CHAIN_QUOTE_NETWORK, {
+          bypassCache,
+        }));
 
       if (selectedNetwork.chain.name === "Starknet") {
         if (starknetAddress) {

--- a/app/context/BalanceContext.tsx
+++ b/app/context/BalanceContext.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import {
@@ -14,7 +15,12 @@ import {
   calculateCorrectedTotalBalance,
   getNetworkTokens,
 } from "../utils";
-import { useCNGNRate, getCNGNRateForNetwork } from "../hooks/useCNGNRate";
+import {
+  useCNGNRate,
+  getCNGNRateForNetwork,
+  CNGN_CROSS_CHAIN_QUOTE_NETWORK,
+} from "../hooks/useCNGNRate";
+import { logBalanceTelemetry } from "../lib/balanceTelemetry";
 import { useMigrationStatus } from "./MigrationStatusContext";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
 import { useNetwork } from "./NetworksContext";
@@ -33,11 +39,13 @@ const MIGRATION_RELEVANT_CHAIN_IDS = new Set(
   migrationChecklistNetworks.map((n) => n.chain.id),
 );
 
-interface WalletBalances {
+export interface WalletBalances {
   total: number;
   balances: Record<string, number>;
   rawBalances?: Record<string, number>; // Raw balances before CNGN conversion
   balancesUsd?: Record<string, number>; // USD value for each token (e.g. Starknet)
+  /** True when user holds CNGN but no USD/NGN rate was available for conversion. */
+  cngnUsdUnknown?: boolean;
 }
 
 // Cross-chain balance entry for a single network
@@ -96,6 +104,34 @@ function applyCNGNBalanceConversion(
   return correctedBalances;
 }
 
+function hasPositiveCngn(raw: Record<string, number>): boolean {
+  for (const k of ["CNGN", "cNGN"] as const) {
+    const v = raw[k];
+    if (typeof v === "number" && !isNaN(v) && v > 0) return true;
+  }
+  return false;
+}
+
+function buildWalletBalancesFromRaw(
+  rawBalances: Record<string, number>,
+  rate: number | null,
+): WalletBalances {
+  const rawTotal = Object.values(rawBalances).reduce(
+    (s, v) => s + (typeof v === "number" && !isNaN(v) ? v : 0),
+    0,
+  );
+  const rawResult = { total: rawTotal, balances: rawBalances };
+  const correctedTotal = calculateCorrectedTotalBalance(rawResult, rate);
+  const correctedBalances = applyCNGNBalanceConversion(rawBalances, rate);
+  return {
+    total: correctedTotal,
+    balances: correctedBalances,
+    rawBalances: { ...rawBalances },
+    cngnUsdUnknown:
+      hasPositiveCngn(rawBalances) && !(rate != null && rate > 0),
+  };
+}
+
 interface BalanceContextProps {
   smartWalletBalance: WalletBalances | null;
   externalWalletBalance: WalletBalances | null;
@@ -120,8 +156,28 @@ interface BalanceContextProps {
     totalMigrationRelevant: number;
   } | null;
   smartWalletRemainingTotal: number;
-  refreshBalance: () => void;
+  /** Manual refresh: bypasses RPC cache so users see authoritative balances. */
+  refreshBalance: () => Promise<void>;
+  /** Background/SWR refresh: respects RPC cache, reuses cached snapshots when fresh. */
+  softRefresh: () => Promise<void>;
   isLoading: boolean;
+  /** True when a refresh is in flight but cached balances for the current identity are already shown. */
+  isRefreshing: boolean;
+}
+
+type IdentityKeyInput = {
+  isInjectedWallet: boolean;
+  injectedAddress: string | null;
+  embeddedAddr: string | undefined;
+  smartAddr: string | undefined;
+  starknetAddress: string | null;
+  isStarknetSelected: boolean;
+};
+
+function buildIdentityKey(o: IdentityKeyInput): string {
+  if (o.isInjectedWallet) return `inj:${o.injectedAddress ?? ""}`;
+  if (o.isStarknetSelected) return `stk:${o.starknetAddress ?? ""}`;
+  return `evm:${o.smartAddr ?? ""}|${o.embeddedAddr ?? ""}`;
 }
 
 const BalanceContext = createContext<BalanceContextProps | undefined>(
@@ -156,34 +212,46 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [starknetWalletBalance, setStarknetWalletBalance] =
     useState<WalletBalances | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const bypassCacheNextFetchRef = useRef(false);
+  /** Identity (addresses) for the last fetch that reached its finally block. Drives isRefreshing on wallet swap. */
+  const lastFetchedKeyRef = useRef<string>("");
 
-  // Hook for CNGN rate to correct total balances
+  // CNGN rate for balance correction: same corridor as cross-chain batch (stable NGN↔USD quote).
   const { rate: cngnRate } = useCNGNRate({
-    network: selectedNetwork.chain.name,
-    dependencies: [selectedNetwork],
+    network: CNGN_CROSS_CHAIN_QUOTE_NETWORK,
+    dependencies: [],
   });
 
   // Cannot use useShouldUseEOA here (it uses useBalance and would create a circular dependency)
   const { isMigrationComplete, isLoading: isMigrationLoading } = useMigrationStatus();
 
-  const applicableNetworks = networks;
-  const evmBalanceNetworks = applicableNetworks.filter(
+  const evmBalanceNetworks = networks.filter(
     (n) => n.chain.name !== "Starknet",
   );
 
   /**
-   * Shared helper: fetches cross-chain balance entries for an address.
-   * All networks are fetched in parallel and the CNGN rate is resolved once
-   * upfront to avoid redundant API calls.
+   * Cross-chain entries: fetches RPC balances in parallel with the CNGN rate
+   * (same wall time as the slower of the two), then applies correction.
    */
   const fetchCrossChainEntriesForAddress = async (
     address: string,
+    options?: { bypassCache?: boolean },
   ): Promise<CrossChainBalanceEntry[]> => {
-    const cngnRateValue = await getCNGNRateForNetwork(
-      applicableNetworks[0]?.chain.name ?? "Base",
-    );
+    const tBatch = performance.now();
+    const rateStarted = performance.now();
+    const ratePromise = getCNGNRateForNetwork(CNGN_CROSS_CHAIN_QUOTE_NETWORK, {
+      bypassCache: options?.bypassCache,
+    }).then((r) => {
+      logBalanceTelemetry("cngn_rate_cross_chain", {
+        ms: Math.round(performance.now() - rateStarted),
+        nullRate: r == null,
+        corridor: CNGN_CROSS_CHAIN_QUOTE_NETWORK,
+        bypassCache: !!options?.bypassCache,
+      });
+      return r;
+    });
 
-    const results = await Promise.allSettled(
+    const chainsPromise = Promise.allSettled(
       evmBalanceNetworks.map(async (network) => {
         const rpcUrl = getRpcUrl(network.chain.name);
         const evmChain = network.chain as Chain;
@@ -191,38 +259,72 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           chain: evmChain,
           transport: http(rpcUrl),
         });
-        const rawResult = await fetchWalletBalance(publicClient, address);
-        const rawBalances = { ...rawResult.balances };
-        const correctedTotal = calculateCorrectedTotalBalance(
-          rawResult,
-          cngnRateValue,
-        );
-        const correctedBalances = applyCNGNBalanceConversion(
-          rawResult.balances,
-          cngnRateValue,
-        );
+        const rawResult = await fetchWalletBalance(publicClient, address, {
+          bypassCache: options?.bypassCache,
+        });
         return {
           network,
-          balances: {
-            total: correctedTotal,
-            balances: correctedBalances,
-            rawBalances,
-          },
+          rawResult,
         };
       }),
     );
 
-    return results
+    const [cngnRateValue, settled] = await Promise.all([
+      ratePromise,
+      chainsPromise,
+    ]);
+
+    logBalanceTelemetry("cross_chain_batch", {
+      totalMs: Math.round(performance.now() - tBatch),
+      fulfilled: settled.filter((s) => s.status === "fulfilled").length,
+      chainCount: evmBalanceNetworks.length,
+      bypassCache: !!options?.bypassCache,
+    });
+
+    return settled
       .filter((r) => r.status === "fulfilled")
-      .map((r) => (r as PromiseFulfilledResult<CrossChainBalanceEntry>).value);
+      .map((r) => {
+        const { network, rawResult } = (
+          r as PromiseFulfilledResult<{
+            network: Network;
+            rawResult: Awaited<ReturnType<typeof fetchWalletBalance>>;
+          }>
+        ).value;
+        const rawBalances = { ...rawResult.balances };
+        return {
+          network,
+          balances: buildWalletBalancesFromRaw(rawBalances, cngnRateValue),
+        };
+      });
   };
 
-  const fetchCrossChainBalances = async (address: string) => {
-    const entries = await fetchCrossChainEntriesForAddress(address);
+  const fetchCrossChainBalances = async (
+    address: string,
+    opts?: { bypassCache?: boolean },
+  ) => {
+    const entries = await fetchCrossChainEntriesForAddress(address, opts);
     setCrossChainBalances(entries);
   };
 
   const fetchBalances = async () => {
+    const bypassCache = bypassCacheNextFetchRef.current;
+    bypassCacheNextFetchRef.current = false;
+
+    const smartWalletAccountForKey = user?.linkedAccounts.find(
+      (account) => account.type === "smart_wallet",
+    ) as { address?: string } | undefined;
+    const embeddedWalletAccountForKey = wallets.find(
+      (wallet) => wallet.walletClientType === "privy",
+    );
+    const fetchIdentityKey = buildIdentityKey({
+      isInjectedWallet,
+      injectedAddress: injectedAddress ?? null,
+      embeddedAddr: embeddedWalletAccountForKey?.address,
+      smartAddr: smartWalletAccountForKey?.address,
+      starknetAddress: starknetAddress ?? null,
+      isStarknetSelected: selectedNetwork.chain.name === "Starknet",
+    });
+
     const clearAllWalletBalances = () => {
       setSmartWalletBalance(null);
       setExternalWalletBalance(null);
@@ -253,7 +355,8 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
     try {
       const resolvedCngnRate =
-        cngnRate ?? (await getCNGNRateForNetwork(selectedNetwork.chain.name));
+        cngnRate ??
+        (await getCNGNRateForNetwork(CNGN_CROSS_CHAIN_QUOTE_NETWORK));
 
       if (selectedNetwork.chain.name === "Starknet") {
         if (starknetAddress) {
@@ -340,11 +443,13 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
           // Fetch EOA cross-chain and SCW remaining in parallel
           const eoaCrossChainPromise =
-            fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
+            fetchCrossChainEntriesForAddress(embeddedWalletAccount.address, {
+              bypassCache,
+            });
           const scwRemainingPromise = smartWalletAccount
-            ? fetchCrossChainEntriesForAddress(smartWalletAccount.address).then(
-                (entries) => sumMigrationRelevantTotals(entries),
-              )
+            ? fetchCrossChainEntriesForAddress(smartWalletAccount.address, {
+                bypassCache,
+              }).then((entries) => sumMigrationRelevantTotals(entries))
             : Promise.resolve(0);
 
           const [eoaEntries, remaining] = await Promise.all([
@@ -365,17 +470,18 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
             const result = await fetchWalletBalance(
               publicClient,
               embeddedWalletAccount.address,
+              { bypassCache },
             );
-            const correctedTotal = calculateCorrectedTotalBalance(
-              result,
-              resolvedCngnRate,
+            setExternalWalletBalance(
+              buildWalletBalancesFromRaw({ ...result.balances }, resolvedCngnRate),
             );
-            setExternalWalletBalance({ ...result, total: correctedTotal });
           }
         } else if (smartWalletAccount) {
           // Not migrated: fetch SCW cross-chain first to determine total and selected-network balance
           const scwCrossChainEntries =
-            await fetchCrossChainEntriesForAddress(smartWalletAccount.address);
+            await fetchCrossChainEntriesForAddress(smartWalletAccount.address, {
+              bypassCache,
+            });
           const scwCrossChainTotalMigrationRelevant =
             sumMigrationRelevantTotals(scwCrossChainEntries);
           const scwTotalAll = sumAllChainTotals(scwCrossChainEntries);
@@ -394,21 +500,20 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
             const result = await fetchWalletBalance(
               publicClient,
               smartWalletAccount.address,
+              { bypassCache },
             );
             const rawBalances = { ...result.balances };
-            const correctedTotal = calculateCorrectedTotalBalance(result, resolvedCngnRate);
-            const correctedBalances = applyCNGNBalanceConversion(result.balances, resolvedCngnRate);
-            setSmartWalletBalance({
-              total: correctedTotal,
-              balances: correctedBalances,
-              rawBalances,
-            });
+            setSmartWalletBalance(
+              buildWalletBalancesFromRaw(rawBalances, resolvedCngnRate),
+            );
           }
 
           if (scwCrossChainTotalMigrationRelevant === 0 && embeddedWalletAccount) {
             primaryIsEOA = true;
             const eoaEntries =
-              await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
+              await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address, {
+                bypassCache,
+              });
             setCrossChainBalances(eoaEntries);
 
             const eoaSelectedEntry = eoaEntries.find(
@@ -420,9 +525,14 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
               const eoaResult = await fetchWalletBalance(
                 publicClient,
                 embeddedWalletAccount.address,
+                { bypassCache },
               );
-              const eoaCorrected = calculateCorrectedTotalBalance(eoaResult, resolvedCngnRate);
-              setExternalWalletBalance({ ...eoaResult, total: eoaCorrected });
+              setExternalWalletBalance(
+                buildWalletBalancesFromRaw(
+                  { ...eoaResult.balances },
+                  resolvedCngnRate,
+                ),
+              );
             }
           } else {
             setExternalWalletBalance(null);
@@ -435,7 +545,9 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           setSmartWalletCrossChainTotals(null);
 
           const eoaEntries =
-            await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address);
+            await fetchCrossChainEntriesForAddress(embeddedWalletAccount.address, {
+              bypassCache,
+            });
 
           setCrossChainBalances(eoaEntries);
           setSmartWalletRemainingTotal(0);
@@ -449,21 +561,12 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
             const result = await fetchWalletBalance(
               publicClient,
               embeddedWalletAccount.address,
+              { bypassCache },
             );
             const rawBalances = { ...result.balances };
-            const correctedTotal = calculateCorrectedTotalBalance(
-              result,
-              resolvedCngnRate,
+            setExternalWalletBalance(
+              buildWalletBalancesFromRaw(rawBalances, resolvedCngnRate),
             );
-            const correctedBalances = applyCNGNBalanceConversion(
-              result.balances,
-              resolvedCngnRate,
-            );
-            setExternalWalletBalance({
-              total: correctedTotal,
-              balances: correctedBalances,
-              rawBalances,
-            });
           }
         } else {
           clearAllWalletBalances();
@@ -477,27 +580,15 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           const result = await fetchWalletBalance(
             publicClient,
             externalWalletAccount.address,
+            { bypassCache },
           );
 
           // Store raw balances BEFORE any modifications
           const rawBalances = { ...result.balances };
 
-          // Apply cNGN conversion correction
-          const correctedTotal = calculateCorrectedTotalBalance(
-            result,
-            resolvedCngnRate,
+          setExternalWalletBalance(
+            buildWalletBalancesFromRaw(rawBalances, resolvedCngnRate),
           );
-          // Apply CNGN balance conversion and use returned value
-          const correctedBalances = applyCNGNBalanceConversion(
-            result.balances,
-            resolvedCngnRate,
-          );
-
-          setExternalWalletBalance({
-            total: correctedTotal,
-            balances: correctedBalances,
-            rawBalances: rawBalances,
-          });
         }
 
         setInjectedWalletBalance(null);
@@ -517,30 +608,18 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
           const result = await fetchWalletBalance(
             publicClient,
             injectedAddress,
+            { bypassCache },
           );
 
           // Store raw balances BEFORE any modifications
           const rawBalances = { ...result.balances };
 
-          // Apply cNGN conversion correction
-          const correctedTotal = calculateCorrectedTotalBalance(
-            result,
-            resolvedCngnRate,
+          setInjectedWalletBalance(
+            buildWalletBalancesFromRaw(rawBalances, resolvedCngnRate),
           );
-          // Apply CNGN balance conversion and use returned value
-          const correctedBalances = applyCNGNBalanceConversion(
-            result.balances,
-            resolvedCngnRate,
-          );
-
-          setInjectedWalletBalance({
-            total: correctedTotal,
-            balances: correctedBalances,
-            rawBalances: rawBalances,
-          });
 
           // Fetch cross-chain balances for injected wallet
-          await fetchCrossChainBalances(injectedAddress);
+          await fetchCrossChainBalances(injectedAddress, { bypassCache });
 
           setSmartWalletBalance(null);
           setExternalWalletBalance(null);
@@ -556,6 +635,7 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
       // and address don't flip to zero-balance UI when switching networks causes RPC errors
       clearPerNetworkBalances();
     } finally {
+      lastFetchedKeyRef.current = fetchIdentityKey;
       setIsLoading(false);
     }
   };
@@ -572,10 +652,33 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
     injectedReady,
     injectedAddress,
     starknetAddress,
-    cngnRate,
     isMigrationComplete,
     isMigrationLoading,
   ]);
+
+  useEffect(() => {
+    if (cngnRate == null || !(cngnRate > 0)) return;
+
+    const patch = (w: WalletBalances | null) =>
+      w?.rawBalances ? buildWalletBalancesFromRaw(w.rawBalances, cngnRate) : w;
+
+    setCrossChainBalances((prev) =>
+      prev.map((e) =>
+        e.balances.rawBalances
+          ? {
+              ...e,
+              balances: buildWalletBalancesFromRaw(
+                e.balances.rawBalances,
+                cngnRate,
+              ),
+            }
+          : e,
+      ),
+    );
+    setSmartWalletBalance((prev) => patch(prev));
+    setExternalWalletBalance((prev) => patch(prev));
+    setInjectedWalletBalance((prev) => patch(prev));
+  }, [cngnRate]);
 
   useEffect(() => {
     if (!user && !isInjectedWallet && !starknetAddress) {
@@ -604,6 +707,37 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const crossChainTotalMigrationRelevant =
     sumMigrationRelevantTotals(crossChainBalances);
 
+  const hasCachedBalances =
+    crossChainBalances.length > 0 ||
+    smartWalletBalance != null ||
+    externalWalletBalance != null ||
+    injectedWalletBalance != null ||
+    starknetWalletBalance != null;
+
+  const currentIdentityKey = buildIdentityKey({
+    isInjectedWallet,
+    injectedAddress: injectedAddress ?? null,
+    embeddedAddr: wallets.find((w) => w.walletClientType === "privy")?.address,
+    smartAddr: (
+      user?.linkedAccounts.find(
+        (a) => a.type === "smart_wallet",
+      ) as { address?: string } | undefined
+    )?.address,
+    starknetAddress: starknetAddress ?? null,
+    isStarknetSelected: selectedNetwork.chain.name === "Starknet",
+  });
+  const identityMatchesLastFetch =
+    lastFetchedKeyRef.current !== "" &&
+    lastFetchedKeyRef.current === currentIdentityKey;
+  const isRefreshing =
+    isLoading && hasCachedBalances && identityMatchesLastFetch;
+
+  const refreshBalance = (): Promise<void> => {
+    bypassCacheNextFetchRef.current = true;
+    return fetchBalances();
+  };
+  const softRefresh = (): Promise<void> => fetchBalances();
+
   return (
     <BalanceContext.Provider
       value={{
@@ -617,8 +751,10 @@ export const BalanceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         crossChainTotalMigrationRelevant,
         smartWalletCrossChainTotals,
         smartWalletRemainingTotal,
-        refreshBalance: fetchBalances,
+        refreshBalance,
+        softRefresh,
         isLoading,
+        isRefreshing,
       }}
     >
       {children}

--- a/app/hooks/useCNGNRate.ts
+++ b/app/hooks/useCNGNRate.ts
@@ -9,6 +9,9 @@ const CNGN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
 const PRIMARY_TIMEOUT = 5000; // 5 seconds for primary network attempts
 const FALLBACK_TIMEOUT = 3000; // 3 seconds for fallback network attempts
 const RELIABLE_NETWORKS = ["Base", "BNB Smart Chain"]; // Most reliable networks for rate fallback
+
+/** NGN↔USD-stable quote corridor for cross-chain balance correction (not tied to selected chain). */
+export const CNGN_CROSS_CHAIN_QUOTE_NETWORK = RELIABLE_NETWORKS[0] ?? "Base";
 const CNGN_CACHE_KEY = "cngn_last_rate";
 const CNGN_CACHE_TIME_KEY = "cngn_cache_time";
 
@@ -130,10 +133,13 @@ async function fetchFallbackRate(primaryNetwork: string): Promise<number | null>
 
 async function fetchCNGNRateWithFallback(
   network: string,
+  options: { bypassCache?: boolean } = {},
 ): Promise<CNGNRateFetchResult> {
-  const freshCachedRate = getFreshCachedRate();
-  if (freshCachedRate !== null) {
-    return { rate: freshCachedRate, source: "fresh-cache" };
+  if (!options.bypassCache) {
+    const freshCachedRate = getFreshCachedRate();
+    if (freshCachedRate !== null) {
+      return { rate: freshCachedRate, source: "fresh-cache" };
+    }
   }
 
   const primaryRate = await fetchRateWithTimeout(network, PRIMARY_TIMEOUT);
@@ -250,11 +256,12 @@ export function useCNGNRate({
  */
 export async function getCNGNRateForNetwork(
   network: string,
+  options: { bypassCache?: boolean } = {},
 ): Promise<number | null> {
   if (!network) return null;
   if (network.toLowerCase().includes("starknet")) {
     return null;
   }
-  const result = await fetchCNGNRateWithFallback(network);
+  const result = await fetchCNGNRateWithFallback(network, options);
   return result.rate;
 }

--- a/app/lib/balanceTelemetry.ts
+++ b/app/lib/balanceTelemetry.ts
@@ -1,0 +1,31 @@
+/**
+ * Lightweight balance/rate observability.
+ *
+ * Dev: opt-in via `localStorage.setItem("balance_debug", "1")`.
+ *      The default-on dev mode produced ~9 logs per refresh, which drowned other
+ *      output, so verbose logging is gated behind a flag.
+ * Prod: ~2% sample.
+ */
+const SAMPLE_RATE = 0.02;
+
+function shouldLog(): boolean {
+  if (process.env.NODE_ENV === "development") {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage?.getItem("balance_debug") === "1";
+    } catch {
+      return false;
+    }
+  }
+  return Math.random() < SAMPLE_RATE;
+}
+
+export function logBalanceTelemetry(
+  event: string,
+  payload: Record<string, unknown>,
+): void {
+  if (!shouldLog()) return;
+  if (typeof console !== "undefined" && typeof console.debug === "function") {
+    console.debug(`[balance:${event}]`, payload);
+  }
+}

--- a/app/lib/walletBalanceCache.ts
+++ b/app/lib/walletBalanceCache.ts
@@ -1,0 +1,65 @@
+/**
+ * Client-only in-memory cache for wallet balance snapshots.
+ *
+ * Important: this module relies on module-level Maps. It is safe in the Next.js
+ * client bundle (per-tab, per-client) but MUST NOT be imported from a Node
+ * server runtime where it would become a process-wide cross-user cache.
+ */
+const TTL_MS = 60_000;
+
+const cache = new Map<string, { t: number; data: unknown }>();
+const inflight = new Map<string, Promise<unknown>>();
+
+export function walletBalanceCacheKey(
+  chainId: number | undefined,
+  address: string,
+): string {
+  return `${chainId ?? "?"}:${address.toLowerCase()}`;
+}
+
+function cloneForCache<T>(data: T): T {
+  return structuredClone(data) as T;
+}
+
+/**
+ * Returns cached snapshot when fresh, dedupes concurrent fetches by key.
+ *
+ * Each consumer receives a fresh `structuredClone` so accidental mutation of
+ * returned balances cannot poison the cache or other in-flight callers.
+ */
+export async function getCachedOrFetchEvmBalances<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  opts: { bypassCache?: boolean } = {},
+): Promise<T> {
+  if (!opts.bypassCache) {
+    const hit = cache.get(key);
+    if (hit && Date.now() - hit.t < TTL_MS) {
+      return cloneForCache(hit.data as T);
+    }
+  }
+
+  let p = inflight.get(key) as Promise<T> | undefined;
+  if (!p) {
+    p = fetcher()
+      .then((data) => {
+        cache.set(key, { t: Date.now(), data });
+        inflight.delete(key);
+        return data;
+      })
+      .catch((err) => {
+        inflight.delete(key);
+        throw err;
+      }) as Promise<T>;
+    inflight.set(key, p);
+  }
+
+  return p.then((data) => cloneForCache(data));
+}
+
+export function invalidateWalletBalanceCacheForAddress(address: string): void {
+  const suffix = `:${address.toLowerCase()}`;
+  for (const k of [...cache.keys()]) {
+    if (k.endsWith(suffix)) cache.delete(k);
+  }
+}

--- a/app/lib/walletBalanceCache.ts
+++ b/app/lib/walletBalanceCache.ts
@@ -26,6 +26,8 @@ function cloneForCache<T>(data: T): T {
  *
  * Each consumer receives a fresh `structuredClone` so accidental mutation of
  * returned balances cannot poison the cache or other in-flight callers.
+ * When bypassCache is true, skips both the TTL snapshot and in-flight
+ * deduplication so a manual refresh does not join an older pending request.
  */
 export async function getCachedOrFetchEvmBalances<T>(
   key: string,
@@ -40,7 +42,7 @@ export async function getCachedOrFetchEvmBalances<T>(
   }
 
   let p = inflight.get(key) as Promise<T> | undefined;
-  if (!p) {
+  if (!p || opts.bypassCache) {
     const myP = fetcher()
       .then((data) => {
         if (inflight.get(key) !== myP) {

--- a/app/lib/walletBalanceCache.ts
+++ b/app/lib/walletBalanceCache.ts
@@ -41,16 +41,22 @@ export async function getCachedOrFetchEvmBalances<T>(
 
   let p = inflight.get(key) as Promise<T> | undefined;
   if (!p) {
-    p = fetcher()
+    const myP = fetcher()
       .then((data) => {
+        if (inflight.get(key) !== myP) {
+          return data;
+        }
         cache.set(key, { t: Date.now(), data });
         inflight.delete(key);
         return data;
       })
       .catch((err) => {
-        inflight.delete(key);
+        if (inflight.get(key) === myP) {
+          inflight.delete(key);
+        }
         throw err;
       }) as Promise<T>;
+    p = myP;
     inflight.set(key, p);
   }
 
@@ -59,7 +65,11 @@ export async function getCachedOrFetchEvmBalances<T>(
 
 export function invalidateWalletBalanceCacheForAddress(address: string): void {
   const suffix = `:${address.toLowerCase()}`;
-  for (const k of [...cache.keys()]) {
-    if (k.endsWith(suffix)) cache.delete(k);
+  const keys = [...cache.keys(), ...inflight.keys()].filter((k) =>
+    k.endsWith(suffix),
+  );
+  for (const k of new Set(keys)) {
+    cache.delete(k);
+    inflight.delete(k);
   }
 }

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -735,26 +735,24 @@ async function fetchEvmBalancesUnifiedUncached(
         });
       } catch (error) {
         console.error("ERC-20 multicall failed, falling back to sequential", error);
-        await Promise.all(
-          erc20Tokens.map(async (token: Token) => {
-            try {
-              const balanceInWei = await client.readContract({
-                address: token.address as `0x${string}`,
-                abi: erc20Abi,
-                functionName: "balanceOf",
-                args: [address as `0x${string}`],
-              });
-              fillBalancesFromWei(token, balanceInWei as bigint);
-            } catch (err) {
-              console.error(
-                `Error fetching balance for ${token.symbol}:`,
-                err,
-              );
-              balances[token.symbol] = 0;
-              balancesInWei[token.symbol] = BigInt(0);
-            }
-          }),
-        );
+        for (const token of erc20Tokens) {
+          try {
+            const balanceInWei = await client.readContract({
+              address: token.address as `0x${string}`,
+              abi: erc20Abi,
+              functionName: "balanceOf",
+              args: [address as `0x${string}`],
+            });
+            fillBalancesFromWei(token, balanceInWei as bigint);
+          } catch (err) {
+            console.error(
+              `Error fetching balance for ${token.symbol}:`,
+              err,
+            );
+            balances[token.symbol] = 0;
+            balancesInWei[token.symbol] = BigInt(0);
+          }
+        }
       }
     }
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -687,24 +687,29 @@ async function fetchEvmBalancesUnifiedUncached(
       (t: Token) => !(t.isNative && t.address === ""),
     );
 
-    await Promise.all(
-      nativeTokens.map(async (token: Token) => {
-        try {
-          const balanceInWei = await client.getBalance({ address });
-          fillBalancesFromWei(token, balanceInWei);
-        } catch (error) {
-          console.error(
-            `Error fetching native balance for ${token.symbol}:`,
-            error,
-          );
-          balances[token.symbol] = 0;
-          balancesInWei[token.symbol] = BigInt(0);
-        }
-      }),
-    );
-
     let usedMulticall = false;
-    if (erc20Tokens.length > 0) {
+
+    const nativePromise =
+      nativeTokens.length === 0
+        ? Promise.resolve()
+        : Promise.all(
+            nativeTokens.map(async (token: Token) => {
+              try {
+                const balanceInWei = await client.getBalance({ address });
+                fillBalancesFromWei(token, balanceInWei);
+              } catch (error) {
+                console.error(
+                  `Error fetching native balance for ${token.symbol}:`,
+                  error,
+                );
+                balances[token.symbol] = 0;
+                balancesInWei[token.symbol] = BigInt(0);
+              }
+            }),
+          );
+
+    const erc20Promise = (async () => {
+      if (erc20Tokens.length === 0) return;
       try {
         const contracts = erc20Tokens.map((token: Token) => ({
           address: token.address as `0x${string}`,
@@ -734,7 +739,10 @@ async function fetchEvmBalancesUnifiedUncached(
           }
         });
       } catch (error) {
-        console.error("ERC-20 multicall failed, falling back to sequential", error);
+        console.error(
+          "ERC-20 multicall failed, falling back to sequential",
+          error,
+        );
         for (const token of erc20Tokens) {
           try {
             const balanceInWei = await client.readContract({
@@ -754,7 +762,9 @@ async function fetchEvmBalancesUnifiedUncached(
           }
         }
       }
-    }
+    })();
+
+    await Promise.all([nativePromise, erc20Promise]);
 
     for (const token of supportedTokens) {
       if (balances[token.symbol] === undefined) {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -27,10 +27,6 @@ import {
   localTransferFeePercent,
   localTransferFeeCap,
 } from "./lib/config";
-import {
-  getCachedOrFetchEvmBalances,
-  walletBalanceCacheKey,
-} from "./lib/walletBalanceCache";
 import { logBalanceTelemetry } from "./lib/balanceTelemetry";
 
 /**
@@ -813,13 +809,22 @@ async function fetchEvmBalancesUnifiedUncached(
 }
 
 /**
- * Cached, deduped EVM balance fetch (per chain + address). Pass bypassCache on manual refresh.
+ * Cached, deduped EVM balance fetch (per chain + address).
+ * `bypassCache: true` skips the TTL snapshot and does not join an in-flight
+ * request (forces a fresh RPC batch); use for manual refresh.
  */
 export async function fetchEvmBalancesForAddress(
   client: any,
   address: string,
   options?: { bypassCache?: boolean },
 ): Promise<UnifiedWalletBalances> {
+  /** Client-only: avoid loading walletBalanceCache in Node/server bundles. */
+  if (typeof window === "undefined") {
+    return fetchEvmBalancesUnifiedUncached(client, address);
+  }
+  const { walletBalanceCacheKey, getCachedOrFetchEvmBalances } = await import(
+    "./lib/walletBalanceCache"
+  );
   const chainId =
     typeof client.chain?.id === "number" ? client.chain.id : undefined;
   const key = walletBalanceCacheKey(chainId, address);

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -27,6 +27,11 @@ import {
   localTransferFeePercent,
   localTransferFeeCap,
 } from "./lib/config";
+import {
+  getCachedOrFetchEvmBalances,
+  walletBalanceCacheKey,
+} from "./lib/walletBalanceCache";
+import { logBalanceTelemetry } from "./lib/balanceTelemetry";
 
 /**
  * Type predicate to narrow RecipientDetails to bank/mobile_money types.
@@ -643,10 +648,12 @@ export type FetchBalancesForChainArgs =
       tokens?: Token[];
     };
 
-async function fetchEvmBalancesUnified(
+async function fetchEvmBalancesUnifiedUncached(
   client: any,
   address: string,
 ): Promise<UnifiedWalletBalances> {
+  const t0 =
+    typeof performance !== "undefined" ? performance.now() : Date.now();
   const supportedTokens = await getNetworkTokens(client.chain?.name);
   const chainName = client.chain?.name ?? "Unknown";
   const chainId =
@@ -663,41 +670,103 @@ async function fetchEvmBalancesUnified(
 
   if (!supportedTokens) return empty();
 
-  let totalBalance = 0;
   const balances: Record<string, number> = {};
   const balancesInWei: Record<string, bigint> = {};
 
+  const fillBalancesFromWei = (token: Token, balanceInWei: bigint) => {
+    balancesInWei[token.symbol] = balanceInWei;
+    const balance = Number(balanceInWei) / Math.pow(10, token.decimals);
+    balances[token.symbol] = isNaN(balance) ? 0 : balance;
+  };
+
   try {
-    const balancePromises = supportedTokens.map(async (token: Token) => {
-      try {
-        if (token.isNative && token.address === "") {
+    const nativeTokens = supportedTokens.filter(
+      (t: Token) => t.isNative && t.address === "",
+    );
+    const erc20Tokens = supportedTokens.filter(
+      (t: Token) => !(t.isNative && t.address === ""),
+    );
+
+    await Promise.all(
+      nativeTokens.map(async (token: Token) => {
+        try {
           const balanceInWei = await client.getBalance({ address });
-          balancesInWei[token.symbol] = balanceInWei;
-          const balance = Number(balanceInWei) / Math.pow(10, token.decimals);
-          balances[token.symbol] = isNaN(balance) ? 0 : balance;
-          return balances[token.symbol];
+          fillBalancesFromWei(token, balanceInWei);
+        } catch (error) {
+          console.error(
+            `Error fetching native balance for ${token.symbol}:`,
+            error,
+          );
+          balances[token.symbol] = 0;
+          balancesInWei[token.symbol] = BigInt(0);
         }
-        const balanceInWei = await client.readContract({
+      }),
+    );
+
+    let usedMulticall = false;
+    if (erc20Tokens.length > 0) {
+      try {
+        const contracts = erc20Tokens.map((token: Token) => ({
           address: token.address as `0x${string}`,
           abi: erc20Abi,
-          functionName: "balanceOf",
+          functionName: "balanceOf" as const,
           args: [address as `0x${string}`],
+        }));
+        type MulticallEntry =
+          | { status: "success"; result: bigint }
+          | { status: "failure"; error: Error; result?: undefined };
+        const multicallResults = (await client.multicall({
+          contracts,
+          allowFailure: true,
+        })) as MulticallEntry[];
+        usedMulticall = true;
+        multicallResults.forEach((res, i) => {
+          const token = erc20Tokens[i];
+          if (res.status === "success") {
+            fillBalancesFromWei(token, res.result);
+          } else {
+            console.error(
+              `Multicall balanceOf failed for ${token.symbol}:`,
+              res.error,
+            );
+            balances[token.symbol] = 0;
+            balancesInWei[token.symbol] = BigInt(0);
+          }
         });
-        balancesInWei[token.symbol] = balanceInWei as bigint;
-        const balance = Number(balanceInWei) / Math.pow(10, token.decimals);
-        balances[token.symbol] = isNaN(balance) ? 0 : balance;
-        return balances[token.symbol];
       } catch (error) {
-        console.error(`Error fetching balance for ${token.symbol}:`, error);
+        console.error("ERC-20 multicall failed, falling back to sequential", error);
+        await Promise.all(
+          erc20Tokens.map(async (token: Token) => {
+            try {
+              const balanceInWei = await client.readContract({
+                address: token.address as `0x${string}`,
+                abi: erc20Abi,
+                functionName: "balanceOf",
+                args: [address as `0x${string}`],
+              });
+              fillBalancesFromWei(token, balanceInWei as bigint);
+            } catch (err) {
+              console.error(
+                `Error fetching balance for ${token.symbol}:`,
+                err,
+              );
+              balances[token.symbol] = 0;
+              balancesInWei[token.symbol] = BigInt(0);
+            }
+          }),
+        );
+      }
+    }
+
+    for (const token of supportedTokens) {
+      if (balances[token.symbol] === undefined) {
         balances[token.symbol] = 0;
         balancesInWei[token.symbol] = BigInt(0);
-        return 0;
       }
-    });
+    }
 
-    const tokenBalances = await Promise.all(balancePromises);
-    totalBalance = tokenBalances.reduce(
-      (acc: number, curr: number) => (acc || 0) + (curr || 0),
+    const totalBalance = supportedTokens.reduce(
+      (acc, token) => acc + (balances[token.symbol] ?? 0),
       0,
     );
 
@@ -711,6 +780,17 @@ async function fetchEvmBalancesUnified(
       balanceWei: balancesInWei[token.symbol],
     }));
 
+    const elapsed =
+      (typeof performance !== "undefined" ? performance.now() : Date.now()) - t0;
+    logBalanceTelemetry("evm_balances_ms", {
+      chainId,
+      chainName,
+      ms: Math.round(elapsed),
+      tokenCount: supportedTokens.length,
+      erc20Count: erc20Tokens.length,
+      usedMulticall,
+    });
+
     return {
       chainName,
       chainId,
@@ -722,6 +802,24 @@ async function fetchEvmBalancesUnified(
   } catch {
     return empty();
   }
+}
+
+/**
+ * Cached, deduped EVM balance fetch (per chain + address). Pass bypassCache on manual refresh.
+ */
+export async function fetchEvmBalancesForAddress(
+  client: any,
+  address: string,
+  options?: { bypassCache?: boolean },
+): Promise<UnifiedWalletBalances> {
+  const chainId =
+    typeof client.chain?.id === "number" ? client.chain.id : undefined;
+  const key = walletBalanceCacheKey(chainId, address);
+  return getCachedOrFetchEvmBalances(
+    key,
+    () => fetchEvmBalancesUnifiedUncached(client, address),
+    { bypassCache: options?.bypassCache },
+  );
 }
 
 async function fetchStarknetBalancesUnified(
@@ -817,7 +915,7 @@ export async function fetchBalancesForChain(
     const tokens = args.tokens ?? (await getNetworkTokens("Starknet"));
     return fetchStarknetBalancesUnified(args.walletAddress, tokens);
   }
-  return fetchEvmBalancesUnified(args.client, args.walletAddress);
+  return fetchEvmBalancesForAddress(args.client, args.walletAddress);
 }
 
 /**
@@ -846,13 +944,26 @@ export async function fetchStarknetBalance(
 export async function fetchWalletBalance(
   client: any,
   address: string,
+  options?: { bypassCache?: boolean },
 ): Promise<{ total: number; balances: Record<string, number>; balancesInWei: Record<string, bigint> }> {
-  const u = await fetchEvmBalancesUnified(client, address);
+  const u = await fetchEvmBalancesForAddress(client, address, options);
   return {
     total: u.total,
     balances: u.balances,
     balancesInWei: u.balancesInWei ?? {},
   };
+}
+
+/** Whether a cross-chain token row should be listed for a non-selected network. */
+export function tokenBalanceRowVisible(
+  rawBalances: Record<string, number> | undefined,
+  token: string,
+  balance: number,
+  isSelectedNetwork: boolean,
+): boolean {
+  if (isSelectedNetwork) return true;
+  const raw = rawBalances?.[token];
+  return (typeof raw === "number" && raw > 0) || balance > 0;
 }
 
 /**
@@ -900,6 +1011,7 @@ export function calculateCorrectedTotalBalance(
 export async function fetchBalanceForNetwork(
   network: { chain: any },
   walletAddress: string,
+  options?: { bypassCache?: boolean },
 ): Promise<UnifiedWalletBalances> {
   const { createPublicClient, http } = await import("viem");
 
@@ -910,7 +1022,7 @@ export async function fetchBalanceForNetwork(
     transport: http(rpcUrl),
   });
 
-  return fetchEvmBalancesUnified(publicClient, walletAddress);
+  return fetchEvmBalancesForAddress(publicClient, walletAddress, options);
 }
 
 /**


### PR DESCRIPTION
### Description

Wallet balances felt slow and the per-token row went **red `$0.00`** whenever the cNGN ↔ USD rate was unavailable, which read as "worthless." This PR rewires the balance pipeline for speed and fixes the CNGN UX:

**Speed**
- `BalanceContext.fetchCrossChainEntriesForAddress` now runs `getCNGNRateForNetwork` in parallel with cross-chain balance fetches, so wall time is `max(rate, RPC)` instead of `rate + RPC`.
- `fetchEvmBalancesUnifiedUncached` (in `app/utils.ts`) replaces the per-token `readContract` loop with a single viem `multicall` per chain (with `allowFailure: true`) and a sequential fallback for chains/RPCs that don't expose multicall3. Native `getBalance` and ERC-20 multicall run concurrently per chain.
- New `app/lib/walletBalanceCache.ts` — client-only TTL (60s) + single-flight cache keyed by `chainId+address`. Multiple components hitting `refreshBalance` no longer trigger duplicate RPC fan-outs.

**CNGN UX**
- `WalletBalances.cngnUsdUnknown` is set when the user holds CNGN but no positive rate is available. `WalletDetails` and `WalletView` render `—` (instead of red `$0.00`) and a muted "NGN-pegged · USD quote unavailable" caption while still showing the raw token amount.
- A separate `useEffect([cngnRate])` re-applies the CNGN correction in place when the rate later resolves, so balances don't have to be refetched.
- Cross-chain CNGN quotes use a fixed corridor (`CNGN_CROSS_CHAIN_QUOTE_NETWORK`, currently Base) for consistency across chains; per-network rate quoting is preserved at the component level.
- `tokenBalanceRowVisible` keeps non-zero CNGN raw rows visible on non-selected chains even when the USD slot is `0`.

**API surface (BalanceContext)**
- `refreshBalance: () => Promise<void>` — manual refresh, bypasses RPC + rate cache.
- `softRefresh: () => Promise<void>` — SWR-style refresh, respects caches (used by drawer focus refresh).
- `isRefreshing: boolean` — true only when the cached snapshot belongs to the **current wallet identity**, so account swaps render a skeleton instead of stale balances.

**Observability**
- `app/lib/balanceTelemetry.ts` — opt-in dev logging (`localStorage.balance_debug = "1"`), 2% sample in prod. Per-fetch fields: chain, ms, multicall used, ERC-20 count, batch totals, rate corridor, null-rate occurrences.

**Breaking changes / migration**
- None for callers. `refreshBalance` was previously typed `() => void`; now `() => Promise<void>` (callers that already used `await refreshBalance()` benefit; fire-and-forget callers are unaffected).

**Alternatives considered**
- A backend/indexer that returns all chains × tokens in one call (Alchemy/Covalent style). Out of scope here; tracked separately so we can ship client-side wins now.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

Automated:

```
NEXT_PUBLIC_FEE_RECIPIENT_ADDRESS=0x0000000000000000000000000000000000000001 \
  pnpm exec jest __tests__/calculateCorrectedTotalBalance.test.ts __tests__/tokenBalanceRowVisible.test.ts
```

- `__tests__/tokenBalanceRowVisible.test.ts` (new) covers the row-visibility helper.
- Existing `__tests__/calculateCorrectedTotalBalance.test.ts` continues to pass.

Manual:

1. Open the wallet drawer with a multi-chain EOA — totals should appear noticeably faster (single multicall per chain visible in network tab; rate request runs in parallel with RPCs).
2. Block aggregator rate requests in DevTools → drawer should show CNGN with raw token amount and `—` for USD (no red `$0.00`); other tokens render normally.
3. Unblock the rate → CNGN row updates in place (no full re-fetch).
4. Click the drawer's Refresh button → bypasses both RPC cache and rate cache.
5. Re-open the drawer within 60s → `softRefresh` returns from cache (no RPC fan-out).
6. Switch wallets → drawer renders skeleton, never the previous wallet's numbers.

Environment: TypeScript / Next.js 15 (Node 22.x) / pnpm 10. Verified in Chrome.

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side wallet balance cache with 60s TTL, deduped fetches, and optional bypass-cache hard-refresh; soft-refresh API and auto-refresh when sidebar opens
  * Explicit refreshing state surfaced to UI so views can distinguish loading vs refreshing

* **Bug Fixes**
  * Clearer loading-state behavior and spinner logic during refreshes
  * Improved token row visibility for non-selected networks
  * Better handling when a currency quote is unavailable (note/placeholder)

* **Tests**
  * Added tests covering token visibility logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->