### PR TITLE
fix(swap): rename ramp toggle to Buy/Sell and trim rate suffix

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -847,7 +847,7 @@ export const TransactionForm = ({
                     : "border border-transparent text-neutral-900/40 dark:text-white/40",
                 ].join(" ")}
               >
-                On-ramp
+                Buy
               </button>
 
               {/* Off-ramp button */}
@@ -866,7 +866,7 @@ export const TransactionForm = ({
                     : "border border-transparent text-neutral-900/40 dark:text-white/40",
                 ].join(" ")}
               >
-                Off-ramp
+                Sell
               </button>
             </div>
           </div>

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -267,7 +267,7 @@ export const TransactionPreview = ({
     ? {
       amount: `${currencySymbol}${formatNumberWithCommas(amountSent ?? 0)}`,
       totalValue: `${formatNumberWithCommas(amountReceived ?? 0)} ${token}`,
-      rate: `${currencySymbol}${formatNumberWithCommas(rate)} ~ 1 ${token}`,
+      rate: `${currencySymbol}${formatNumberWithCommas(rate)}`,
       ...(isCNGNOnramp && localTransferFeePercent > 0
         ? {
           fee: `${localTransferFeePercent}%`,


### PR DESCRIPTION
## Summary
- Replace the **On-ramp** / **Off-ramp** toggle labels in the swap modal with **Buy** / **Sell**.
- Drop the ` ~ 1 {token}` suffix from the rate shown in the transaction preview, so it reads e.g. `₦1,390.43` instead of `₦1,390.43 ~ 1 USDC`.

## Changes
- `app/pages/TransactionForm.tsx` — toggle button labels.
- `app/pages/TransactionPreview.tsx` — on-ramp rate string format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)