### PR TITLE
fix(referral): gate modal on server-side referral status to prevent cross-device reappearance and delayed load

### DIFF
--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -657,16 +657,22 @@ export function MainPageContent() {
   // Fetch server-side referral data to gate the referral modal
   useEffect(
     function fetchReferralData() {
+      let isMounted = true;
+
       async function checkReferralStatus() {
         if (!authenticated || !ready || isInjectedWallet || !walletAddress) {
-          setIsReferralDataChecked(true);
+          if (isMounted) setIsReferralDataChecked(true);
           return;
         }
 
         try {
           const accessToken = await getAccessToken();
+          if (!isMounted) return;
+
           if (accessToken) {
             const response = await getReferralData(accessToken, walletAddress);
+            if (!isMounted) return;
+
             if (response.success && response.data && Array.isArray(response.data.referrals)) {
               const hasReferred = response.data.referrals.some(
                 (r) => r.role === "referred",
@@ -677,18 +683,25 @@ export function MainPageContent() {
               setHasExistingReferral(true);
             }
           } else {
-            setHasExistingReferral(true);
+            if (isMounted) setHasExistingReferral(true);
           }
         } catch (error) {
+          if (!isMounted) return;
           console.error("Failed to fetch referral data:", error);
           // Safe default on error: assume they have been referred to prevent showing the modal inappropriately
           setHasExistingReferral(true);
         } finally {
-          setIsReferralDataChecked(true);
+          if (isMounted) {
+            setIsReferralDataChecked(true);
+          }
         }
       }
 
       checkReferralStatus();
+
+      return () => {
+        isMounted = false;
+      };
     },
     [authenticated, ready, isInjectedWallet, walletAddress, getAccessToken],
   );

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -60,6 +60,23 @@ import {
 import { getPreferredNetworkForBalances } from "../lib/getPreferredNetworkForBalances";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 
+/**
+ * PageLayout component renders the main page structure including modals,
+ * disclaimers, cookie consent, and the transaction form or status view.
+ *
+ * @param props - The layout properties.
+ * @param props.authenticated - Whether the user is authenticated.
+ * @param props.ready - Whether the auth state is ready.
+ * @param props.currentStep - The current transaction step.
+ * @param props.transactionFormComponent - The transaction form or status component to render.
+ * @param props.isRecipientFormOpen - Whether the recipient form is open.
+ * @param props.isOnramp - Whether the current mode is on-ramp.
+ * @param props.isBlockFestReferral - Whether the user is a BlockFest referral.
+ * @param props.showReferralModal - Whether to show the referral input modal.
+ * @param props.onReferralModalClose - Callback when the referral modal is closed.
+ * @param props.onNetworkSelected - Callback when a network is selected.
+ * @returns The rendered page layout.
+ */
 const PageLayout = ({
   authenticated,
   ready,
@@ -137,9 +154,17 @@ const PageLayout = ({
 };
 
 /**
+ * Calculates the token amount to use for on-ramp rate queries.
+ *
  * v2 `/rates/.../{token}/{amount}/{fiat}` expects `amount` in token units. On-ramp, the receive
  * (token) field is often 0 until a rate exists — use a peg-aware fiat-sized probe instead of `1`
  * so provider min/max match the user's order (e.g. CNGN ↔ NGN).
+ *
+ * @param token - The token symbol (e.g., "CNGN").
+ * @param currency - The fiat currency (e.g., "NGN").
+ * @param sentN - The amount sent in fiat units.
+ * @param recvN - The amount received in token units.
+ * @returns The calculated token amount for the rate query.
  */
 function onrampRateQueryTokenAmount(
   token: string,
@@ -156,6 +181,14 @@ function onrampRateQueryTokenAmount(
   return 1;
 }
 
+/**
+ * MainPageContent is the primary component for the home page.
+ * It manages the transaction flow, including form state, rate fetching,
+ * institution fetching, network selection, and referral modal gating.
+ * It also handles user authentication state and KYC verification.
+ *
+ * @returns The rendered main page content.
+ */
 export function MainPageContent() {
   const searchParams = useSearchParams();
   const { authenticated, ready, getAccessToken, user } = usePrivy();

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -25,6 +25,7 @@ import {
   fetchRate,
   fetchSupportedInstitutions,
   migrateLocalStorageRecipients,
+  getReferralData,
 } from "../api/aggregator";
 import {
   normalizeNetworkForRateFetch,
@@ -173,6 +174,8 @@ export function MainPageContent() {
   const [isFetchingRate, setIsFetchingRate] = useState(false);
   const [isFetchingInstitutions, setIsFetchingInstitutions] = useState(false);
   const [showReferralModal, setShowReferralModal] = useState(false);
+  const [hasExistingReferral, setHasExistingReferral] = useState(false);
+  const [isReferralDataChecked, setIsReferralDataChecked] = useState(false);
 
   const [rate, setRate] = useState<number>(0);
   const [formValues, setFormValues] = useState<FormData>({} as FormData);
@@ -306,35 +309,57 @@ export function MainPageContent() {
 
   const walletAddress = useWalletAddress();
 
-  const showReferralIfEligible = useCallback((fromNetworkSelected = false) => {
-    if (!ready || !authenticated || !walletAddress || isInjectedWallet) {
-      return;
-    }
-
-    // Only show referral modal to new users (account created within the last 30 days).
-    // Existing users who predate the referral feature should not be prompted.
-    if (user?.createdAt) {
-      const accountAgeDays = (Date.now() - new Date(user.createdAt).getTime()) / (1000 * 60 * 60 * 24);
-      if (accountAgeDays > 30) {
+  const showReferralIfEligible = useCallback(
+    (fromNetworkSelected = false) => {
+      if (!ready || !authenticated || !walletAddress || isInjectedWallet) {
         return;
       }
-    }
 
-    // For new users, the network selection modal opens at the same time as this
-    // check would fire. Defer to handleNetworkSelected so the referral modal only
-    // shows after they've picked a network — not underneath it.
-    if (!fromNetworkSelected && user?.wallet?.address) {
-      const networkModalKey = `hasSeenNetworkModal-${user.wallet.address}`;
-      if (!localStorage.getItem(networkModalKey)) {
+      if (!isReferralDataChecked) {
         return;
       }
-    }
 
-    const referralStorageKey = `hasSeenReferralModal-${walletAddress.toLowerCase()}`;
-    if (!localStorage.getItem(referralStorageKey)) {
-      setShowReferralModal(true);
-    }
-  }, [ready, authenticated, walletAddress, isInjectedWallet, user?.wallet?.address, user?.createdAt]);
+      if (hasExistingReferral) {
+        return;
+      }
+
+      // Only show referral modal to new users (account created within the last 30 days).
+      // Existing users who predate the referral feature should not be prompted.
+      if (user?.createdAt) {
+        const accountAgeDays =
+          (Date.now() - new Date(user.createdAt).getTime()) /
+          (1000 * 60 * 60 * 24);
+        if (accountAgeDays > 30) {
+          return;
+        }
+      }
+
+      // For new users, the network selection modal opens at the same time as this
+      // check would fire. Defer to handleNetworkSelected so the referral modal only
+      // shows after they've picked a network — not underneath it.
+      if (!fromNetworkSelected && user?.wallet?.address) {
+        const networkModalKey = `hasSeenNetworkModal-${user.wallet.address}`;
+        if (!localStorage.getItem(networkModalKey)) {
+          return;
+        }
+      }
+
+      const referralStorageKey = `hasSeenReferralModal-${walletAddress.toLowerCase()}`;
+      if (!localStorage.getItem(referralStorageKey)) {
+        setShowReferralModal(true);
+      }
+    },
+    [
+      ready,
+      authenticated,
+      walletAddress,
+      isInjectedWallet,
+      user?.wallet?.address,
+      user?.createdAt,
+      isReferralDataChecked,
+      hasExistingReferral,
+    ],
+  );
 
   const handleNetworkSelected = useCallback(() => {
     showReferralIfEligible(true);
@@ -342,7 +367,7 @@ export function MainPageContent() {
 
   useEffect(() => {
     showReferralIfEligible();
-  }, [showReferralIfEligible]);
+  }, [showReferralIfEligible, isReferralDataChecked]);
 
   const handleReferralModalClose = useCallback(() => {
     setShowReferralModal(false);
@@ -594,6 +619,45 @@ export function MainPageContent() {
       runMigration();
     },
     [authenticated, ready, isInjectedWallet, getAccessToken],
+  );
+
+  // Fetch server-side referral data to gate the referral modal
+  useEffect(
+    function fetchReferralData() {
+      async function checkReferralStatus() {
+        if (!authenticated || !ready || isInjectedWallet || !walletAddress) {
+          setIsReferralDataChecked(true);
+          return;
+        }
+
+        try {
+          const accessToken = await getAccessToken();
+          if (accessToken) {
+            const response = await getReferralData(accessToken, walletAddress);
+            if (response.success && response.data && Array.isArray(response.data.referrals)) {
+              const hasReferred = response.data.referrals.some(
+                (r) => r.role === "referred",
+              );
+              setHasExistingReferral(hasReferred);
+            } else {
+              // Safe default: if we can't confirm they haven't been referred, assume they have
+              setHasExistingReferral(true);
+            }
+          } else {
+            setHasExistingReferral(true);
+          }
+        } catch (error) {
+          console.error("Failed to fetch referral data:", error);
+          // Safe default on error: assume they have been referred to prevent showing the modal inappropriately
+          setHasExistingReferral(true);
+        } finally {
+          setIsReferralDataChecked(true);
+        }
+      }
+
+      checkReferralStatus();
+    },
+    [authenticated, ready, isInjectedWallet, walletAddress, getAccessToken],
   );
 
   const handleFormSubmit = useCallback(


### PR DESCRIPTION
## Description

This PR fixes two related issues with the referral modal:
1. **Cross-device reappearance**: The modal was showing again on subsequent logins across different devices because the visibility gate relied solely on client-side `localStorage`.
2. **Delayed load on desktop**: The modal required a page refresh to appear on the first load for new accounts due to a race condition with the network modal and auth state resolution.

## Root Cause

The `showReferralIfEligible` function in `MainPageContent.tsx` was checking `localStorage` to determine if the user had already seen the modal. This is device-specific and does not reflect the server-side truth of whether the user has already submitted a referral code. Additionally, the check was racing with the network modal's `localStorage` state, causing it to be permanently blocked in some initial load scenarios.

## Solution

1. Added a `useEffect` hook to fetch the user's referral status from the server (`/api/referral/referral-data`) when the user is authenticated and ready.
2. Introduced `hasExistingReferral` and `isReferralDataChecked` state variables to gate the modal based on this server-side truth.
3. If the API confirms the user has already been referred (`referrals.some(r => r.role === 'referred')`), the modal is prevented from showing, regardless of `localStorage`.
4. Implemented a "fail-closed" approach: if the API call fails or returns an unexpected structure, the state defaults to `hasExistingReferral = true` to prevent inappropriately showing the modal.
5. Retained the `localStorage` check as a secondary, session-level debounce to prevent rapid re-showing while the API call is pending, and to maintain the UX sequence (referral modal appears *after* network selection).

## Testing

- [x] Verified that a new user (< 30 days old) with no existing referrals sees the network modal, and upon selection, the referral modal appears automatically without a page refresh.
- [x] Verified that after submitting a referral code, logging in on a different device or in an incognito window does NOT show the modal (validating server-side gating).
- [x] Verified that clearing `localStorage` and logging in again still does NOT show the modal.
- [x] Verified that existing users (> 30 days old) do not see the modal.
- [x] Verified that closing the modal sets the `localStorage` flag and prevents it from reappearing in the same session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Referral modal now waits for a server eligibility check before showing, preventing premature display.
  * Users with an existing referral or when eligibility data is missing/unavailable will not see the modal.
  * Previous gating rules (signed-in/non-injected wallet, account age ≤30 days) and deferral until network-selection completion remain enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->