### PR TITLE
fix(ui): show correct address and networks in wallet copy modal

### DIFF
--- a/app/components/CopyAddressWarningModal.tsx
+++ b/app/components/CopyAddressWarningModal.tsx
@@ -38,7 +38,7 @@ export const CopyAddressWarningModal: React.FC<
   /** EVM deposits use a different address format — never imply Starknet deposits work on Ethereum/Base/etc. */
   const supportedNetworksDisplayed = isStarknet
     ? networks.filter((n) => n.chain.name === "Starknet")
-    : networks;
+    : networks.filter((n) => n.chain.name !== "Starknet");
 
   const modalTitle = "You just copied your wallet address!";
 

--- a/app/components/KycModal.tsx
+++ b/app/components/KycModal.tsx
@@ -793,6 +793,8 @@ export const KycModal = ({
           await refreshStatus(true);
           setIsUserVerified(true);
           setIsKycModalOpen(false);
+          // SmileID camera displaces the document scroll position — restore after dialog unmounts
+          requestAnimationFrame(() => window.scrollTo({ top: 0, behavior: "instant" }));
         }}
       >
         Let&apos;s go!

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -27,6 +27,7 @@ import {
 } from "hugeicons-react";
 import { toast } from "sonner";
 import { useInjectedWallet } from "../context";
+import { useNetwork } from "../context/NetworksContext";
 import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
@@ -43,6 +44,8 @@ export const SettingsDropdown = () => {
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
+  const { selectedNetwork } = useNetwork();
+  const isStarknet = selectedNetwork?.chain?.name === "Starknet";
   const shouldUseEOA = useShouldUseEOA();
   const hookWalletAddress = useWalletAddress();
 
@@ -65,15 +68,17 @@ export const SettingsDropdown = () => {
     (account) => account.type === "smart_wallet",
   );
 
-  // Prefer the network-aware address (handles Starknet Ready account); fall back to
-  // migration-based EVM logic (after migration: EOA with funds; before: SCW).
+  // Prefer the network-aware address; fall back to EVM-only logic only when not on Starknet,
+  // to avoid showing an EVM address while Starknet is active.
   const walletAddress =
     hookWalletAddress ??
-    (isInjectedWallet
-      ? injectedAddress
-      : shouldUseEOA
-        ? embeddedWallet?.address
-        : smartWallet?.address);
+    (isStarknet
+      ? undefined
+      : isInjectedWallet
+        ? injectedAddress
+        : shouldUseEOA
+          ? embeddedWallet?.address
+          : smartWallet?.address);
 
   const handleCopyAddress = async () => {
     if (!walletAddress) return;

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -30,19 +30,16 @@ import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 import ProfileDrawer from "./ProfileDrawer";
 import { ThemeSwitch } from "./ThemeSwitch";
-import { useWallets } from "@privy-io/react-auth";
-import { useShouldUseEOA } from "../hooks/useEIP7702Account";
+import { useWalletAddress } from "../hooks/useWalletAddress";
 import { useHandleExportEmbeddedWallet } from "../hooks/useHandleExportEmbeddedWallet";
 import { clearUserSessionData } from "../lib/session-cleanup";
 
 export const SettingsDropdown = () => {
   const { user, updateEmail } = usePrivy();
   const handleExportEmbeddedWallet = useHandleExportEmbeddedWallet();
-  const { wallets } = useWallets();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const { isInjectedWallet, injectedAddress } = useInjectedWallet();
-  const shouldUseEOA = useShouldUseEOA();
+  const { isInjectedWallet } = useInjectedWallet();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isAddressCopied, setIsAddressCopied] = useState(false);
@@ -55,25 +52,11 @@ export const SettingsDropdown = () => {
     handler: () => setIsOpen(false),
   });
 
-  // Get embedded wallet (EOA) and smart wallet (SCW)
-  const embeddedWallet = wallets.find(
-    (wallet) => wallet.walletClientType === "privy",
-  );
-  const smartWallet = user?.linkedAccounts.find(
-    (account) => account.type === "smart_wallet",
-  );
-
-  // Determine active wallet based on migration status
-  // After migration: show EOA (new wallet with funds)
-  // Before migration: show SCW (old wallet)
-  const walletAddress = isInjectedWallet
-    ? injectedAddress
-    : shouldUseEOA
-      ? embeddedWallet?.address
-      : smartWallet?.address;
+  const walletAddress = useWalletAddress();
 
   const handleCopyAddress = async () => {
-    const ok = await copyToClipboard(walletAddress ?? "", "Address");
+    if (!walletAddress) return;
+    const ok = await copyToClipboard(walletAddress, "Address");
     if (!ok) return;
     setIsAddressCopied(true);
     setTimeout(() => setIsAddressCopied(false), 2000);
@@ -214,13 +197,14 @@ export const SettingsDropdown = () => {
               >
                 <button
                   type="button"
-                  className="group flex w-full items-center justify-between gap-4"
+                  className="group flex w-full items-center justify-between gap-4 disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={handleCopyAddress}
+                  disabled={!walletAddress}
                 >
                   <div className="flex items-center gap-2.5">
                     <Wallet01Icon className="size-5 text-icon-outline-secondary dark:text-white/50" />
                     <p className="max-w-60 break-words">
-                      {shortenAddress(walletAddress ?? "", 10)}
+                      {walletAddress ? shortenAddress(walletAddress, 10) : "—"}
                     </p>
                   </div>
                   {isAddressCopied ? (


### PR DESCRIPTION
## Summary

- **SettingsDropdown**: replaced manual EVM-only `walletAddress` derivation with `useWalletAddress()` hook — the Starknet address is now shown and copied when on Starknet network, instead of always showing the EVM address
- **CopyAddressWarningModal**: filter Starknet out of the supported networks list when the active network is EVM — prevents Starknet from appearing as a valid deposit destination for an EVM address
- **KycModal**: restore scroll position after "Let's go!" closes the dialog — SmileID's camera component displaces `document.scrollY`; a `requestAnimationFrame` + `scrollTo({ top: 0, behavior: "instant" })` fires after Headless UI unlocks scroll, returning the user to the top of the page

## Test plan

- [ ] Connect with Privy on an EVM network (Base, Arbitrum, etc.) → open settings dropdown → address shown is the EVM address → click copy → modal shows EVM-only networks (no Starknet)
- [ ] Switch to Starknet network → open settings dropdown → address shown is the Starknet address → click copy → modal shows only Starknet in supported networks, and warning text "This is a Starknet address…" appears
- [ ] Complete KYC identity verification (Tier 2 SmileID flow) → click "Let's go!" → modal closes → page stays at top, no scroll to marketing content below hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warning modal no longer shows Starknet as a supported network when another network is selected.
  * After completing KYC Tier 2, the page scrolls back to the top once the success dialog closes to restore the user's view.
  * Settings dropdown disables the copy-address action and shows a placeholder when no wallet address is available, preventing empty copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->