### PR TITLE
feat(MobileDropdown): reset nested views on sheet close

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -246,6 +246,17 @@ export const MobileDropdown = ({
     if (currentView !== "history") clearTransactions();
   }, [currentView, clearTransactions]);
 
+  // Reset nested views when the sheet closes so reopening always starts on Wallet
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentView("wallet");
+      setSelectedEarnActivity(null);
+      setEarnActivityReturnView("wallet");
+      setSelectedTransaction(null);
+      setIsNetworkListOpen(false);
+    }
+  }, [isOpen]);
+
   const { client } = useSmartWallets();
 
   const showEarnUi = isEarnUiVisible(selectedNetwork.chain.name);


### PR DESCRIPTION
### Description

Fixes a mobile-only navigation bug where reopening the wallet sheet after an Earn Deposit or Withdraw flow showed the wrong screen (e.g. Deposit) instead of the main Wallet view.

**Problem:** `MobileDropdown` keeps an internal `currentView` (`wallet`, `earn-deposit`, `settings`, etc.). Closing the sheet only set `isOpen` to false in the parent; `currentView` was left unchanged. After a successful Earn transaction, tapping **Close** returned users to the home page, but tapping the wallet address again reopened the sheet on `earn-deposit` / `earn-withdraw` instead of `wallet`.

**Solution:** Added a `useEffect` that runs when `isOpen` becomes `false` and resets:

- `currentView` → `"wallet"`
- `selectedEarnActivity` → `null`
- `earnActivityReturnView` → `"wallet"`
- `selectedTransaction` → `null`
- `isNetworkListOpen` → `false`

Reopening the sheet always starts on the Wallet screen (Balances / Transactions, Transfer, Fund, Earn).

**Impacts:**

- Mobile wallet UX only; desktop `WalletDetails` is unchanged
- No API, contract, or database changes
- No breaking changes

**Alternatives considered:**

- Reset only on Earn success **Close** — would miss header X, backdrop dismiss, and other sub-views (Settings, Transfer, Fund)
- Wrap `onClose` with a custom handler — same outcome, but `useEffect` on `isOpen` covers every close path in one place

### References

N/A — internal UX bug found during Earn mobile testing.

### Testing

**Manual (mobile viewport or real device):**

1. Open wallet from header → confirm Wallet screen appears.
2. Wallet → Earn → Deposit → complete a transaction → **Close** on success.
3. Tap wallet address again → confirm **Wallet** opens (not Deposit).
4. Repeat with **Withdraw**.
5. Open Earn → Deposit → dismiss via header **X** or backdrop → reopen wallet → confirm Wallet screen.
6. Wallet → Settings → close sheet → reopen → confirm Wallet (not Settings).

**Environment:** Noblocks dev, mobile viewport (Chrome DevTools) or physical device; Starknet network with Earn enabled.

No unit tests added — UI state reset in a client component; covered by manual QA above.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile dropdown now resets all UI state when closed, returning to the default wallet view and clearing previous selections. This ensures that activity selections, transaction history views, and network settings don't persist when reopening the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->