### PR TITLE
refactor(referral): enhance claim qualification logic and error handling

### DIFF
--- a/app/api/referral/claim/route.ts
+++ b/app/api/referral/claim/route.ts
@@ -97,12 +97,23 @@ async function checkPartyQualification(
   if (hasCngn) {
     try {
       const rateUrl = `${process.env.NEXT_PUBLIC_AGGREGATOR_URL}/rates/USDC/1/NGN`;
-      const rateRes = await fetch(rateUrl);
+      const rateRes = await fetch(rateUrl, { signal: AbortSignal.timeout(5000) });
+      if (!rateRes.ok) {
+        throw new Error(`rate lookup failed with status ${rateRes.status}`);
+      }
       const rateJson = (await rateRes.json()) as { data?: string };
       const parsed = Number(rateJson?.data);
-      if (parsed > 0) ngnPerUsd = parsed;
+      if (parsed > 0) {
+        ngnPerUsd = parsed;
+      } else {
+        throw new Error("invalid NGN rate payload");
+      }
     } catch {
-      // If rate fetch fails, cNGN txs will be skipped (counted as 0).
+      return {
+        ok: false,
+        code: "VERIFICATION_ERROR",
+        message: "Unable to verify qualifying transaction volume. Please try again later.",
+      };
     }
   }
 
@@ -159,25 +170,7 @@ async function tryClaimOne(
     };
   }
 
-  const qualificationChecks = isReferrerClaim
-    ? [
-        checkPartyQualification(referrerWallet, referralCreatedAt, "claimant"),
-        checkPartyQualification(referredWallet, referralCreatedAt, "referee"),
-      ]
-    : [checkPartyQualification(referredWallet, referralCreatedAt, "claimant")];
-
-  for (const check of qualificationChecks) {
-    const qualification = await check;
-    if (!qualification.ok) {
-      return {
-        success: false,
-        code: qualification.code,
-        message: qualification.message,
-      };
-    }
-  }
-
-  // ── Idempotency ─────────────────────────────────────────────────────────────
+  // ── Idempotency — short-circuit before expensive KYC/volume checks ──────────
   const { data: existingClaim, error: existingClaimError } = await supabaseAdmin
     .from("referral_claims")
     .select("*")
@@ -199,6 +192,24 @@ async function tryClaimOne(
       txHash: existingClaim.tx_hash,
       amount: existingClaim.reward_amount,
     };
+  }
+
+  const qualificationChecks = isReferrerClaim
+    ? [
+        checkPartyQualification(referrerWallet, referralCreatedAt, "claimant"),
+        checkPartyQualification(referredWallet, referralCreatedAt, "referee"),
+      ]
+    : [checkPartyQualification(referredWallet, referralCreatedAt, "claimant")];
+
+  for (const check of qualificationChecks) {
+    const qualification = await check;
+    if (!qualification.ok) {
+      return {
+        success: false,
+        code: qualification.code,
+        message: qualification.message,
+      };
+    }
   }
 
   let pendingClaimRow: typeof existingClaim;

--- a/app/api/referral/claim/route.ts
+++ b/app/api/referral/claim/route.ts
@@ -31,26 +31,22 @@ type ClaimSuccess = { success: true; txHash: string; amount: number };
 type ClaimFailure = { success: false; code: string; message: string };
 type ClaimResult = ClaimSuccess | ClaimFailure;
 
-// ─── Core claim logic (shared by GET auto-claim and POST manual claim) ─────────
+type QualificationResult =
+  | { ok: true; totalUsd: number }
+  | { ok: false; code: string; message: string };
 
-/**
- * Verifies KYC + volume for the invitee, handles idempotency, and executes the
- * on-chain USDC transfer to `walletAddress` (caller EOA).
- * Volume is counted only from the date the referral code was entered.
- */
-async function tryClaimOne(
-  walletAddress: string,
-  referral: Record<string, unknown>,
-): Promise<ClaimResult> {
-  const referralId = String(referral.id);
-  const referralCreatedAt = new Date(String(referral.created_at)).toISOString();
+const USD_STABLE = new Set(["USDC", "USDT"]);
+const CNGN_SYMBOLS = new Set(["cNGN", "CNGN"]);
 
-  // Each party qualifies independently based on their OWN KYC + volume.
-  // The referrer gets paid when they meet the requirements; the referred gets
-  // paid when they meet the requirements — neither blocks the other.
-  const qualifyingWallet = walletAddress.toLowerCase();
+type QualificationSubject = "claimant" | "referee";
 
-  // ── KYC check — requires Tier 1 (phone verified) in Supabase ────────────────
+async function checkPartyQualification(
+  wallet: string,
+  referralCreatedAt: string,
+  subject: QualificationSubject,
+): Promise<QualificationResult> {
+  const qualifyingWallet = wallet.toLowerCase();
+
   const { data: kycProfile, error: kycError } = await supabaseAdmin
     .from("user_kyc_profiles")
     .select("tier")
@@ -59,7 +55,7 @@ async function tryClaimOne(
 
   if (kycError) {
     return {
-      success: false,
+      ok: false,
       code: "KYC_CHECK_FAILED",
       message: "Unable to verify KYC status. Please try again later.",
     };
@@ -67,13 +63,15 @@ async function tryClaimOne(
 
   if (!kycProfile || Number(kycProfile.tier ?? 0) < 1) {
     return {
-      success: false,
+      ok: false,
       code: "KYC_REQUIRED",
-      message: "You must verify your phone number before claiming your referral reward.",
+      message:
+        subject === "referee"
+          ? "Your referee must verify their phone number before you can claim your referral reward."
+          : "You must verify your phone number before claiming your referral reward.",
     };
   }
 
-  // ── Volume check — caller's own txs from the day the code was applied ───────
   const { data: volTxs, error: volTxError } = await supabaseAdmin
     .from("transactions")
     .select("amount_sent, from_currency")
@@ -83,26 +81,24 @@ async function tryClaimOne(
 
   if (volTxError) {
     return {
-      success: false,
+      ok: false,
       code: "VERIFICATION_ERROR",
       message: `Failed to fetch transactions: ${volTxError.message}`,
     };
   }
 
-  // USD-pegged stables count 1:1; cNGN requires conversion via the NGN/USD rate.
-  const USD_STABLE = new Set(["USDC", "USDT"]);
-  const CNGN_SYMBOLS = new Set(["cNGN", "CNGN"]);
-
-  const txList = (volTxs || []) as Array<{ amount_sent: string | number; from_currency: string }>;
+  const txList = (volTxs || []) as Array<{
+    amount_sent: string | number;
+    from_currency: string;
+  }>;
   const hasCngn = txList.some((tx) => CNGN_SYMBOLS.has(tx.from_currency));
 
-  // Fetch NGN → USD rate only when needed (1 USD = rate NGN).
   let ngnPerUsd: number | null = null;
   if (hasCngn) {
     try {
       const rateUrl = `${process.env.NEXT_PUBLIC_AGGREGATOR_URL}/rates/USDC/1/NGN`;
       const rateRes = await fetch(rateUrl);
-      const rateJson = await rateRes.json() as { data?: string };
+      const rateJson = (await rateRes.json()) as { data?: string };
       const parsed = Number(rateJson?.data);
       if (parsed > 0) ngnPerUsd = parsed;
     } catch {
@@ -118,16 +114,67 @@ async function tryClaimOne(
     if (CNGN_SYMBOLS.has(tx.from_currency) && ngnPerUsd && ngnPerUsd > 0) {
       return sum + amount / ngnPerUsd;
     }
-    // Other currencies: skip (not yet supported for volume calculation).
     return sum;
   }, 0);
 
   if (totalUsd < referralMinQualifyingVolumeUsd) {
     return {
-      success: false,
+      ok: false,
       code: "VOLUME_NOT_MET",
-      message: `Your transaction volume $${totalUsd.toFixed(2)} is less than the required $${referralMinQualifyingVolumeUsd}.`,
+      message:
+        subject === "referee"
+          ? `Your referee's transaction volume $${totalUsd.toFixed(2)} is less than the required $${referralMinQualifyingVolumeUsd}.`
+          : `Your transaction volume $${totalUsd.toFixed(2)} is less than the required $${referralMinQualifyingVolumeUsd}.`,
     };
+  }
+
+  return { ok: true, totalUsd };
+}
+
+// ─── Core claim logic (shared by GET auto-claim and POST manual claim) ─────────
+
+/**
+ * Verifies KYC + volume, handles idempotency, and executes the on-chain USDC
+ * transfer to `walletAddress` (referrer or referred claimant).
+ * - Referee reward: referee must meet KYC + volume.
+ * - Referrer reward: referrer AND referee must each meet KYC + volume.
+ * Volume is counted only from the date the referral code was entered.
+ */
+async function tryClaimOne(
+  walletAddress: string,
+  referral: Record<string, unknown>,
+): Promise<ClaimResult> {
+  const referralId = String(referral.id);
+  const referralCreatedAt = new Date(String(referral.created_at)).toISOString();
+  const referrerWallet = String(referral.referrer_wallet_address).toLowerCase();
+  const referredWallet = String(referral.referred_wallet_address).toLowerCase();
+  const claimant = walletAddress.toLowerCase();
+  const isReferrerClaim = referrerWallet === claimant;
+
+  if (claimant !== referrerWallet && claimant !== referredWallet) {
+    return {
+      success: false,
+      code: "UNAUTHORIZED_REFERRAL",
+      message: "You are not authorized to claim this referral reward.",
+    };
+  }
+
+  const qualificationChecks = isReferrerClaim
+    ? [
+        checkPartyQualification(referrerWallet, referralCreatedAt, "claimant"),
+        checkPartyQualification(referredWallet, referralCreatedAt, "referee"),
+      ]
+    : [checkPartyQualification(referredWallet, referralCreatedAt, "claimant")];
+
+  for (const check of qualificationChecks) {
+    const qualification = await check;
+    if (!qualification.ok) {
+      return {
+        success: false,
+        code: qualification.code,
+        message: qualification.message,
+      };
+    }
   }
 
   // ── Idempotency ─────────────────────────────────────────────────────────────
@@ -327,9 +374,9 @@ async function tryClaimOne(
 // ─── GET — auto-claim all eligible pending referrals ─────────────────────────
 //
 // Called automatically when the referral dashboard loads. The server checks
-// KYC + volume (from referral created_at) for every pending referral and pays
-// out any that qualify. Silent skips for KYC_REQUIRED / VOLUME_NOT_MET are
-// expected until the invitee meets requirements.
+// KYC + volume (from referral created_at) for each claimant; referrers must
+// also have a qualified referee. Silent skips for KYC_REQUIRED / VOLUME_NOT_MET
+// are expected until requirements are met.
 
 export const GET = withRateLimit(async (request: NextRequest) => {
   const start = Date.now();

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -661,9 +661,10 @@ export function MainPageContent() {
 
       async function checkReferralStatus() {
         if (!authenticated || !ready || isInjectedWallet || !walletAddress) {
-          if (isMounted) setIsReferralDataChecked(true);
           return;
         }
+
+        if (isMounted) setIsReferralDataChecked(false);
 
         try {
           const accessToken = await getAccessToken();


### PR DESCRIPTION
### Description

Fixes referral payout rules so rewards align with product spec: a referrer should not be paid until the referred user qualifies, and the referrer must also meet their own requirements.

**Problem:** `tryClaimOne` treated referrer and referee as fully independent — each party only needed their own KYC (Tier 1) and qualifying transaction volume. A referrer could receive $1 USDC even when their referee had not verified phone or completed enough volume.

**Solution:** Introduced `checkPartyQualification()` to centralize KYC + volume checks per wallet. Updated `tryClaimOne` to apply different rules by role:

| Claimant | Requirements to receive reward |
|----------|-------------------------------|
| **Referee (invitee)** | Own Tier 1 KYC + ≥ min volume (`NEXT_PUBLIC_REFERRAL_MIN_QUALIFYING_VOLUME_USD`, default $20) since the referral code was applied |
| **Referrer** | Own Tier 1 KYC + ≥ min volume **and** referee Tier 1 KYC + ≥ min volume (same volume window from `referrals.created_at`) |

Error messages distinguish **claimant** vs **referee** failures (e.g. *"Your referee must verify their phone number..."* vs *"You must verify your phone number..."*).

**Impacts:**
- Server-only change in `app/api/referral/claim/route.ts` (GET auto-claim + POST manual claim)
- No API contract changes — same endpoints and response shapes; failed claims still return `KYC_REQUIRED` / `VOLUME_NOT_MET`
- Referrers who previously auto-claimed before their referee qualified will no longer be paid until both parties meet requirements
- Payout mechanics unchanged: $1 USDC on Base per completed `referral_claims` row

**Alternatives considered:**
- Referee-only gate (referrer needs no own KYC/volume) — rejected per product requirement that referrer must also qualify
- Independent qualification (original behavior) — rejected; allowed premature referrer payouts

### References

N/A — internal referral program behavior fix.

### Testing

**Manual (staging or local with Supabase + rewards wallet configured):**

1. **Referee only qualifies** — B applies A’s code, B completes phone KYC + $20+ volume, A has not → B receives $1 on referral hub load; A stays pending.
2. **Referrer only qualifies** — A has KYC + volume, B has not → neither receives payout; A sees referee-specific skip/errors on auto-claim.
3. **Both qualify** — A and B each meet KYC + volume → both receive $1 USDC; `total_earned` updates in referral hub.
4. **Idempotency** — reopen referral hub after successful claim → no duplicate payouts (`referral_claims` per wallet).

No unit tests added — claim logic is server-side with Supabase + on-chain dependencies; covered by manual QA above.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral claims can be initiated by either the referrer or the referred party.
  * Eligibility now enforces KYC and transaction-volume checks with clearer, subject-specific failure messages.
  * Multi-currency referral volumes are converted and validated (reducing silent failures).

* **Bug Fixes**
  * Fixed referral modal eligibility flow to wait for full referral-status checks before marking as checked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->