### PR TITLE
Audit of the entire kYC | Earn | Referral flow

### DIFF
--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -111,35 +111,9 @@ export async function POST(request: NextRequest) {
 
   const jobId: string = String(partnerParams.job_id ?? "");
 
-  // ── Check job outcome ───────────────────────────────────────────────────────
-  const jobComplete = body.job_complete === true || body.job_complete === "true";
-  const jobSuccessRaw = body.job_success === true || body.job_success === "true";
-
-  // Support both top-level and nested result shapes SmileID may send.
-  const result = body.result ?? body.Result ?? {};
-  const actions = result.Actions ?? result.actions ?? body.Actions ?? {};
-  const isEnhancedKyc = actions.Verify_ID_Number !== undefined;
-
-  let verificationSuccess = false;
-  if (isEnhancedKyc) {
-    verificationSuccess = actions.Verify_ID_Number === "Verified";
-  } else {
-    verificationSuccess = jobComplete && jobSuccessRaw;
-  }
-
-  if (!verificationSuccess) {
-    // SmileID may still send a callback for failed/incomplete jobs. Acknowledge
-    // with 200 so SmileID doesn't keep retrying, but take no action.
-    console.log("[smile-id/callback] Job not verified, no action taken", {
-      walletAddress,
-      jobId,
-      jobComplete,
-      jobSuccessRaw,
-      ResultCode: result.ResultCode,
-      ResultText: result.ResultText,
-    });
-    return NextResponse.json({ status: "ok", action: "none" });
-  }
+  // The body is NOT covered by the callback signature, so it is used for
+  // routing only (which user/job to look up). The job outcome and any profile
+  // enrichment below come exclusively from SmileID's signed job_status API.
 
   // ── Update KYC profile ─────────────────────────────────────────────────────
   // Fetch current profile to avoid overwriting a higher tier or clobbering
@@ -177,6 +151,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ status: "ok", action: "none" });
   }
 
+  let signedIdInfo: Record<string, any> = {};
   try {
     const jobStatus = await getSmileIdJobStatus(rawUserId, jobId);
     const statusActions = jobStatus?.result?.Actions ?? {};
@@ -188,18 +163,20 @@ export async function POST(request: NextRequest) {
       : flag(jobStatus?.job_complete) && flag(jobStatus?.job_success);
 
     if (!confirmed) {
-      console.warn(
-        "[smile-id/callback] Callback claimed success but job_status did not confirm — no action",
-        {
-          walletAddress,
-          jobId,
-          job_complete: jobStatus?.job_complete,
-          job_success: jobStatus?.job_success,
-          ResultCode: jobStatus?.result?.ResultCode,
-        },
-      );
+      // Covers failed/incomplete jobs too: SmileID sends callbacks for those,
+      // and the signed status is the only outcome we act on.
+      console.log("[smile-id/callback] job_status did not confirm verification — no action", {
+        walletAddress,
+        jobId,
+        job_complete: jobStatus?.job_complete,
+        job_success: jobStatus?.job_success,
+        ResultCode: jobStatus?.result?.ResultCode,
+      });
       return NextResponse.json({ status: "ok", action: "none" });
     }
+
+    const statusResult = (jobStatus?.result ?? {}) as Record<string, any>;
+    signedIdInfo = statusResult.id_info ?? statusResult.ID_Info ?? {};
   } catch (e) {
     console.error("[smile-id/callback] job_status confirmation failed", {
       walletAddress,
@@ -223,8 +200,8 @@ export async function POST(request: NextRequest) {
   const currentTier = Number(existing.tier) || 0;
   const newTier = currentTier >= 1 ? Math.max(currentTier, 2) : currentTier;
 
-  // Optionally enrich with personal info if SmileID included it in the callback.
-  const smileIdInfo = result.id_info ?? result.ID_Info ?? {};
+  // Optionally enrich with personal info from the signed job_status response.
+  const smileIdInfo = signedIdInfo;
   const derivedFullName =
     smileIdInfo.full_name ||
     (smileIdInfo.first_name && smileIdInfo.last_name

--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -1,5 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
+import { getSmileIdJobStatus } from "@/app/lib/smileID";
+
+// The callback signature only covers timestamp + partner_id (per SmileID's
+// protocol), NOT the body. A captured (timestamp, signature) pair could be
+// replayed with an arbitrary body, so two extra defenses below:
+//  1. reject callbacks whose timestamp is outside MAX_CALLBACK_AGE_MS, and
+//  2. before any profile update, confirm the job outcome via SmileID's signed
+//     job_status API instead of trusting body fields.
+const MAX_CALLBACK_AGE_MS = 60 * 60 * 1000; // generous: SmileID retries failed deliveries
+
+function parseSmileTimestampMs(timestamp: string): number | null {
+  // smile-identity-core signs ISO-8601 timestamps; tolerate epoch seconds/millis too.
+  if (/^\d{13}$/.test(timestamp)) return Number(timestamp);
+  if (/^\d{10}$/.test(timestamp)) return Number(timestamp) * 1000;
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : parsed;
+}
 
 // SmileID sends callbacks signed with HMAC-SHA256.
 // Algorithm: base64(HMAC-SHA256(timestamp + partnerId + "sid_request", apiKey))
@@ -59,6 +76,19 @@ export async function POST(request: NextRequest) {
     console.warn("[smile-id/callback] Signature verification failed", { timestamp });
     return NextResponse.json(
       { status: "error", message: "Invalid signature" },
+      { status: 401 },
+    );
+  }
+
+  // Freshness check: the signature is replayable, so cap how old a callback may be.
+  const timestampMs = parseSmileTimestampMs(String(timestamp));
+  if (
+    timestampMs === null ||
+    Math.abs(Date.now() - timestampMs) > MAX_CALLBACK_AGE_MS
+  ) {
+    console.warn("[smile-id/callback] Stale or unparseable timestamp", { timestamp });
+    return NextResponse.json(
+      { status: "error", message: "Stale callback" },
       { status: 401 },
     );
   }
@@ -135,6 +165,50 @@ export async function POST(request: NextRequest) {
   if (existing.verified && Number(existing.tier) >= 2) {
     console.log("[smile-id/callback] Profile already verified, skipping", { walletAddress });
     return NextResponse.json({ status: "ok", action: "already_verified" });
+  }
+
+  // ── Confirm the outcome with SmileID before trusting it ────────────────────
+  // Body fields are not covered by the callback signature; only proceed if
+  // SmileID's signed job_status API reports the same success.
+  if (!jobId) {
+    console.warn("[smile-id/callback] Missing job_id, cannot confirm job — no action", {
+      walletAddress,
+    });
+    return NextResponse.json({ status: "ok", action: "none" });
+  }
+
+  try {
+    const jobStatus = await getSmileIdJobStatus(rawUserId, jobId);
+    const statusActions = jobStatus?.result?.Actions ?? {};
+    const statusIsEnhancedKyc = statusActions.Verify_ID_Number !== undefined;
+    const confirmed = statusIsEnhancedKyc
+      ? statusActions.Verify_ID_Number === "Verified"
+      : jobStatus?.job_complete === true && jobStatus?.job_success === true;
+
+    if (!confirmed) {
+      console.warn(
+        "[smile-id/callback] Callback claimed success but job_status did not confirm — no action",
+        {
+          walletAddress,
+          jobId,
+          job_complete: jobStatus?.job_complete,
+          job_success: jobStatus?.job_success,
+          ResultCode: jobStatus?.result?.ResultCode,
+        },
+      );
+      return NextResponse.json({ status: "ok", action: "none" });
+    }
+  } catch (e) {
+    console.error("[smile-id/callback] job_status confirmation failed", {
+      walletAddress,
+      jobId,
+      error: e instanceof Error ? e.message : e,
+    });
+    // 500 so SmileID retries once the status API is reachable again.
+    return NextResponse.json(
+      { status: "error", message: "Unable to confirm job status" },
+      { status: 500 },
+    );
   }
 
   // Build updated platform array, replacing any prior "id" entry.

--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -181,9 +181,11 @@ export async function POST(request: NextRequest) {
     const jobStatus = await getSmileIdJobStatus(rawUserId, jobId);
     const statusActions = jobStatus?.result?.Actions ?? {};
     const statusIsEnhancedKyc = statusActions.Verify_ID_Number !== undefined;
+    // SmileID returns booleans or "true"/"false" strings depending on surface
+    const flag = (v: unknown) => v === true || v === "true";
     const confirmed = statusIsEnhancedKyc
       ? statusActions.Verify_ID_Number === "Verified"
-      : jobStatus?.job_complete === true && jobStatus?.job_success === true;
+      : flag(jobStatus?.job_complete) && flag(jobStatus?.job_success);
 
     if (!confirmed) {
       console.warn(

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -268,7 +268,10 @@ export async function POST(request: NextRequest) {
 
     // One verified identity per ID document: the same document must not back
     // multiple wallet profiles (each would get its own monthly limit).
-    const idNumberToStore = smileIdInfo.id_number || id_info.id_number || null;
+    // `undefined` (not null) when absent: supabase-js drops undefined keys from
+    // the update, preserving any previously stored id_number.
+    const idNumberToStore: string | undefined =
+      smileIdInfo.id_number || id_info.id_number || undefined;
     if (idNumberToStore) {
       const { data: idOwner, error: idOwnerError } = await supabaseAdmin
         .from("user_kyc_profiles")

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -266,6 +266,39 @@ export async function POST(request: NextRequest) {
         : null) ||
       null;
 
+    // One verified identity per ID document: the same document must not back
+    // multiple wallet profiles (each would get its own monthly limit).
+    const idNumberToStore = smileIdInfo.id_number || id_info.id_number || null;
+    if (idNumberToStore) {
+      const { data: idOwner, error: idOwnerError } = await supabaseAdmin
+        .from("user_kyc_profiles")
+        .select("wallet_address")
+        .eq("id_country", id_info.country)
+        .eq("id_type", id_info.id_type)
+        .eq("id_number", idNumberToStore)
+        .gte("tier", 2)
+        .neq("wallet_address", walletAddress)
+        .limit(1)
+        .maybeSingle();
+
+      if (idOwnerError) {
+        return NextResponse.json(
+          { status: "error", message: "Failed to save KYC data" },
+          { status: 500 },
+        );
+      }
+      if (idOwner) {
+        return NextResponse.json(
+          {
+            status: "error",
+            message:
+              "This ID document is already verified on another account. Please contact support if you believe this is an error.",
+          },
+          { status: 409 },
+        );
+      }
+    }
+
     const { data: updatedProfile, error: supabaseError } = await supabaseAdmin
       .from("user_kyc_profiles")
       .update({
@@ -273,7 +306,7 @@ export async function POST(request: NextRequest) {
         ...(email && { email_address: email }),
         // ID Document fields from id_info or Smile ID response
         id_type: id_info.id_type,
-        id_number: smileIdInfo.id_number || id_info.id_number,
+        id_number: idNumberToStore,
         id_country: id_info.country,
         // Personal info from Smile ID response — only overwrite if SmileID returned a name
         ...(derivedFullName ? { full_name: derivedFullName } : {}),
@@ -287,6 +320,18 @@ export async function POST(request: NextRequest) {
       .select("wallet_address");
 
     if (supabaseError) {
+      // 23505: partial unique index on verified ID documents (concurrent
+      // verification of the same document on another wallet).
+      if (supabaseError.code === "23505") {
+        return NextResponse.json(
+          {
+            status: "error",
+            message:
+              "This ID document is already verified on another account. Please contact support if you believe this is an error.",
+          },
+          { status: 409 },
+        );
+      }
       return NextResponse.json(
         {
           status: "error",

--- a/app/api/phone/send-otp/route.ts
+++ b/app/api/phone/send-otp/route.ts
@@ -131,9 +131,7 @@ export async function POST(request: NextRequest) {
     const { data: existingProfile, error: profileFetchError } =
       await supabaseAdmin
         .from("user_kyc_profiles")
-        .select(
-          "tier, verified, verified_at, id_country, id_type, platform, full_name, phone_number",
-        )
+        .select("tier, id_country, id_type, platform, full_name")
         .eq("wallet_address", walletAddress)
         .maybeSingle();
 
@@ -165,6 +163,42 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // One verified identity per phone number: refuse before spending an SMS.
+    const { data: phoneOwner, error: phoneOwnerError } = await supabaseAdmin
+      .from("user_kyc_profiles")
+      .select("wallet_address")
+      .eq("phone_number", validation.e164Format)
+      .gte("tier", 1)
+      .neq("wallet_address", walletAddress)
+      .limit(1)
+      .maybeSingle();
+
+    if (phoneOwnerError) {
+      logSupabaseError("Supabase phone uniqueness check failed", phoneOwnerError);
+      return NextResponse.json(
+        { success: false, error: "Failed to validate phone number" },
+        { status: 500 },
+      );
+    }
+
+    if (phoneOwner) {
+      trackApiError(
+        request,
+        "/api/phone/send-otp",
+        "POST",
+        new Error("Phone number already verified on another account"),
+        409,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "This phone number is already verified on another account. Please use a different number.",
+        },
+        { status: 409 },
+      );
+    }
+
     const isNigerian = validation.isNigerian;
     const expiresAt = new Date(Date.now() + (isNigerian ? 5 : 10) * 60 * 1000); // 5 min KudiSMS, 10 min Twilio Verify
 
@@ -172,11 +206,7 @@ export async function POST(request: NextRequest) {
     const otp = isNigerian ? generateOtpCode() : null;
     const otpHash = otp ? hashOTP(otp) : null;
 
-    const phoneNumberChanged =
-      existingProfile?.phone_number != null &&
-      existingProfile.phone_number !== validation.e164Format;
-
-    // Send OTP via provider BEFORE persisting — do not de-verify or overwrite active
+    // Send OTP via provider BEFORE persisting — do not overwrite active
     // phone state if the provider call fails.
     let result;
     if (isNigerian) {
@@ -207,7 +237,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Provider confirmed: now persist the pending OTP state.
+    // Provider confirmed: persist the pending OTP state. The number stays in
+    // pending_phone_number until verify-otp confirms it — phone_number (and the
+    // verified flag) only ever reflect a number that passed OTP verification.
     const { error: dbError } = await supabaseAdmin
       .from("user_kyc_profiles")
       .upsert(
@@ -215,15 +247,9 @@ export async function POST(request: NextRequest) {
           wallet_address: walletAddress,
           user_id: userId?.trim() ? userId.trim() : null,
           full_name: name || existingProfile?.full_name || null,
-          phone_number: validation.e164Format,
+          pending_phone_number: validation.e164Format,
           otp_code: otpHash,
           expires_at: expiresAt.toISOString(),
-          verified: phoneNumberChanged
-            ? false
-            : existingProfile?.verified || false,
-          verified_at: phoneNumberChanged
-            ? null
-            : existingProfile?.verified_at || null,
           tier: clampKycTier(existingProfile?.tier),
           id_country: existingProfile?.id_country || null,
           id_type: existingProfile?.id_type || null,

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -61,10 +61,15 @@ async function promoteVerifiedPhone(
     updateData.tier = 1;
   }
 
-  const { error: updateError } = await supabaseAdmin
+  // Guard on the pending number too: a concurrent send-otp may have replaced
+  // it after our read, and a stale OTP must not promote the old number.
+  const { data: updatedRow, error: updateError } = await supabaseAdmin
     .from("user_kyc_profiles")
     .update(updateData)
-    .eq("wallet_address", walletAddress);
+    .eq("wallet_address", walletAddress)
+    .eq("pending_phone_number", e164)
+    .select("wallet_address")
+    .maybeSingle();
 
   if (updateError) {
     if (updateError.code === "23505") {
@@ -74,6 +79,15 @@ async function promoteVerifiedPhone(
       ok: false,
       status: 500,
       error: "Failed to update verification status",
+    };
+  }
+
+  if (!updatedRow) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "This verification was superseded by a newer request. Please use the most recent code.",
     };
   }
 

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -12,8 +12,72 @@ import { rateLimit } from "@/app/lib/rate-limit";
 
 const MAX_ATTEMPTS = 3;
 
+const PHONE_IN_USE_ERROR =
+  "This phone number is already verified on another account. Please use a different number.";
+
 function hashOTP(otp: string): string {
   return createHash("sha256").update(otp).digest("hex");
+}
+
+/**
+ * Promotes the pending number to the verified phone_number. Enforces one
+ * verified identity per phone (friendly pre-check + 23505 from the partial
+ * unique index for the concurrent case).
+ */
+async function promoteVerifiedPhone(
+  walletAddress: string,
+  e164: string,
+  currentTier: number,
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  const { data: phoneOwner, error: ownerError } = await supabaseAdmin
+    .from("user_kyc_profiles")
+    .select("wallet_address")
+    .eq("phone_number", e164)
+    .gte("tier", 1)
+    .neq("wallet_address", walletAddress)
+    .limit(1)
+    .maybeSingle();
+
+  if (ownerError) {
+    return {
+      ok: false,
+      status: 500,
+      error: "Failed to update verification status",
+    };
+  }
+  if (phoneOwner) {
+    return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
+  }
+
+  const updateData: Record<string, unknown> = {
+    phone_number: e164,
+    pending_phone_number: null,
+    verified: true,
+    verified_at: new Date().toISOString(),
+    otp_code: null,
+    otp_attempts: 0,
+  };
+  if (currentTier === 0) {
+    updateData.tier = 1;
+  }
+
+  const { error: updateError } = await supabaseAdmin
+    .from("user_kyc_profiles")
+    .update(updateData)
+    .eq("wallet_address", walletAddress);
+
+  if (updateError) {
+    if (updateError.code === "23505") {
+      return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
+    }
+    return {
+      ok: false,
+      status: 500,
+      error: "Failed to update verification status",
+    };
+  }
+
+  return { ok: true };
 }
 
 export async function POST(request: NextRequest) {
@@ -80,12 +144,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get verification record using normalized E.164 format
+    // Get the profile; the pending number lives in pending_phone_number until
+    // the OTP is confirmed (phone_number only ever holds verified numbers).
     const { data: verification, error: fetchError } = await supabaseAdmin
       .from("user_kyc_profiles")
-      .select("verified, provider, tier, expires_at, otp_attempts, otp_code")
+      .select(
+        "verified, provider, tier, expires_at, otp_attempts, otp_code, phone_number, pending_phone_number",
+      )
       .eq("wallet_address", walletAddress)
-      .eq("phone_number", validation.e164Format)
       .maybeSingle();
 
     if (fetchError) {
@@ -96,7 +162,25 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!verification) {
+    // Already verified with this exact number — nothing to do.
+    if (
+      verification &&
+      verification.phone_number === validation.e164Format &&
+      (verification.tier >= 1 || verification.verified)
+    ) {
+      const responseTime = Date.now() - startTime;
+      trackApiResponse("/api/phone/verify-otp", "POST", 200, responseTime);
+      return NextResponse.json({
+        success: true,
+        message: "Phone number already verified",
+        verified: true,
+      });
+    }
+
+    if (
+      !verification ||
+      verification.pending_phone_number !== validation.e164Format
+    ) {
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -108,17 +192,6 @@ export async function POST(request: NextRequest) {
         { success: false, error: "Verification record not found" },
         { status: 404 },
       );
-    }
-
-    // Check if already verified
-    if (verification.verified) {
-      const responseTime = Date.now() - startTime;
-      trackApiResponse("/api/phone/verify-otp", "POST", 200, responseTime);
-      return NextResponse.json({
-        success: true,
-        message: "Phone number already verified",
-        verified: true,
-      });
     }
 
     // Twilio Verify path: validate code via Twilio (no DB OTP comparison)
@@ -145,31 +218,23 @@ export async function POST(request: NextRequest) {
           { status: 400 },
         );
       }
-      // Twilio approved: update profile (same as below)
-      const updateData: Record<string, unknown> = {
-        verified: true,
-        verified_at: new Date().toISOString(),
-        otp_code: null,
-        otp_attempts: 0,
-      };
-      if (verification.tier === 0) {
-        updateData.tier = 1;
-      }
-      const { error: updateError } = await supabaseAdmin
-        .from("user_kyc_profiles")
-        .update(updateData)
-        .eq("wallet_address", walletAddress);
-      if (updateError) {
+      // Twilio approved: promote the pending number (same as below)
+      const promotion = await promoteVerifiedPhone(
+        walletAddress,
+        validation.e164Format,
+        Number(verification.tier) || 0,
+      );
+      if (!promotion.ok) {
         trackApiError(
           request,
           "/api/phone/verify-otp",
           "POST",
-          updateError,
-          500,
+          new Error(promotion.error),
+          promotion.status,
         );
         return NextResponse.json(
-          { success: false, error: "Failed to update verification status" },
-          { status: 500 },
+          { success: false, error: promotion.error },
+          { status: promotion.status },
         );
       }
       const responseTime = Date.now() - startTime;
@@ -258,29 +323,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Mark as verified - preserve existing tier if higher than 1
-    const updateData: Record<string, unknown> = {
-      verified: true,
-      verified_at: new Date().toISOString(),
-      otp_code: null, // Clear OTP hash after successful verification
-      otp_attempts: 0,
-    };
-
-    // Only set tier to 1 if current tier is 0 (unverified)
-    if (verification.tier === 0) {
-      updateData.tier = 1;
-    }
-
-    const { error: updateError } = await supabaseAdmin
-      .from("user_kyc_profiles")
-      .update(updateData)
-      .eq("wallet_address", walletAddress);
-
-    if (updateError) {
-      trackApiError(request, "/api/phone/verify-otp", "POST", updateError, 500);
+    // Promote the pending number to the verified phone_number (sets tier 1
+    // only when current tier is 0; clears OTP state).
+    const promotion = await promoteVerifiedPhone(
+      walletAddress,
+      validation.e164Format,
+      Number(verification.tier) || 0,
+    );
+    if (!promotion.ok) {
+      trackApiError(
+        request,
+        "/api/phone/verify-otp",
+        "POST",
+        new Error(promotion.error),
+        promotion.status,
+      );
       return NextResponse.json(
-        { success: false, error: "Failed to update verification status" },
-        { status: 500 },
+        { success: false, error: promotion.error },
+        { status: promotion.status },
       );
     }
 

--- a/app/api/referral/referral-data/route.ts
+++ b/app/api/referral/referral-data/route.ts
@@ -183,6 +183,14 @@ export const GET = withRateLimit(async (request: NextRequest) => {
             (myClaims || []).forEach((c) => claimedReferralIds.add(c.referral_id));
         }
 
+        // Postgres `numeric` columns deserialize as strings via PostgREST, so
+        // coerce to Number — otherwise the totals below concatenate strings
+        // (e.g. "0" + "1" → "01") and the Pending/Earned cards show wrong values.
+        const toAmount = (value: unknown): number => {
+            const n = Number(value ?? 1.0);
+            return Number.isFinite(n) ? n : 1.0;
+        };
+
         // Combine both lists and format
         const allReferrals = [
             // When user is referrer: show who they referred
@@ -193,7 +201,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
                 wallet_address_short: `${r.referred_wallet_address.slice(0, 6)}...${r.referred_wallet_address.slice(-4)}`,
                 // Per-user status: "earned" only if THIS user has a completed claim
                 status: claimedReferralIds.has(r.id) ? "earned" : "pending",
-                amount: r.reward_amount ?? 1.0,
+                amount: toAmount(r.reward_amount),
                 created_at: r.created_at,
                 completed_at: r.completed_at,
             })),
@@ -205,7 +213,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
                 wallet_address_short: `${r.referrer_wallet_address.slice(0, 6)}...${r.referrer_wallet_address.slice(-4)}`,
                 // Per-user status: "earned" only if THIS user has a completed claim
                 status: claimedReferralIds.has(r.id) ? "earned" : "pending",
-                amount: r.reward_amount ?? 1.0,
+                amount: toAmount(r.reward_amount),
                 created_at: r.created_at,
                 completed_at: r.completed_at,
             })),

--- a/app/components/AnimatedComponents.tsx
+++ b/app/components/AnimatedComponents.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import type { AnimatedComponentProps } from "../types";
@@ -297,6 +298,13 @@ type AnimatedModalProps = {
   contentClassName?: string;
   showGradientHeader?: boolean;
   backgroundImagePath?: string;
+  /**
+   * Restore the page scroll position (captured when the modal opened) once the
+   * exit animation completes. Needed for content that displaces the document
+   * scroll while open (e.g. the SmileID camera in KycModal); covers every close
+   * path — buttons, backdrop, and Esc.
+   */
+  restoreScrollOnClose?: boolean;
 };
 
 /**
@@ -339,8 +347,26 @@ export const AnimatedModal = ({
   contentClassName,
   showGradientHeader = false,
   backgroundImagePath,
-}: AnimatedModalProps) => (
-  <AnimatePresence>
+  restoreScrollOnClose = false,
+}: AnimatedModalProps) => {
+  const openScrollYRef = useRef(0);
+
+  useEffect(() => {
+    if (isOpen) {
+      openScrollYRef.current = window.scrollY;
+    }
+  }, [isOpen]);
+
+  // onExitComplete runs after the dialog (and its scroll lock) has unmounted,
+  // so the restore cannot race the close animation or component teardown.
+  const handleExitComplete = () => {
+    if (restoreScrollOnClose) {
+      window.scrollTo({ top: openScrollYRef.current, behavior: "instant" });
+    }
+  };
+
+  return (
+  <AnimatePresence onExitComplete={handleExitComplete}>
     {isOpen && (
       <Dialog open={isOpen} onClose={onClose} className="relative z-[55]">
         <motion.div
@@ -422,4 +448,5 @@ export const AnimatedModal = ({
       </Dialog>
     )}
   </AnimatePresence>
-);
+  );
+};

--- a/app/components/KycModal.tsx
+++ b/app/components/KycModal.tsx
@@ -139,7 +139,6 @@ export const KycModal = ({
   const cameraHostRef = useRef<HTMLElement | null>(null);
   const smileListenerCleanupRef = useRef<(() => void) | null>(null);
   const smileThemeObserverCleanupRef = useRef<(() => void) | null>(null);
-  const scrollRestoreTimeoutRef = useRef<number | null>(null);
   const stepRef = useRef(step);
   stepRef.current = step;
   const [smileIdLoaded, setSmileIdLoaded] = useState(false);
@@ -226,24 +225,6 @@ export const KycModal = ({
     smileListenerCleanupRef.current?.();
     smileListenerCleanupRef.current = null;
   };
-
-  const scheduleScrollRestoreAfterClose = () => {
-    if (scrollRestoreTimeoutRef.current) {
-      window.clearTimeout(scrollRestoreTimeoutRef.current);
-    }
-    scrollRestoreTimeoutRef.current = window.setTimeout(() => {
-      window.scrollTo({ top: 0, behavior: "instant" });
-      scrollRestoreTimeoutRef.current = null;
-    }, 500);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (scrollRestoreTimeoutRef.current) {
-        window.clearTimeout(scrollRestoreTimeoutRef.current);
-      }
-    };
-  }, []);
 
   const handleSmilePublish = async (event: Event) => {
     if (smileIdSubmitInFlightRef.current) {
@@ -777,7 +758,6 @@ export const KycModal = ({
           onClick={async () => {
             await refreshStatus(true);
             setIsKycModalOpen(false);
-            scheduleScrollRestoreAfterClose();
           }}
         >
           Got it
@@ -808,9 +788,6 @@ export const KycModal = ({
           await refreshStatus(true);
           setIsUserVerified(true);
           setIsKycModalOpen(false);
-          // SmileID camera displaces the document scroll position — restore after the exit
-          // animation (spring stiffness 300 / damping 30 ≈ 500 ms) fully unmounts the camera.
-          scheduleScrollRestoreAfterClose();
         }}
       >
         Let&apos;s go!
@@ -1435,6 +1412,10 @@ export const KycModal = ({
       // user is already in — a useEffect was calling fetchStatus on every `step`
       // change and forcing TERMS, which bounced users out of ID_INFO / capture.
       if (tier >= 2) {
+        // This fetch is local to the modal — push the upgrade into KYCContext too,
+        // so profile/limit UIs don't keep showing the old tier (and its 30s cache
+        // window) while the success screen is visible.
+        void refreshStatus(true);
         setStep(STEPS.STATUS.SUCCESS);
         trackEvent("Account verification", {
           "Verification status": "Success",

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -356,15 +356,19 @@ export function MainPageContent() {
         return;
       }
 
-      // Only show referral modal to new users (account created within the last 30 days).
-      // Existing users who predate the referral feature should not be prompted.
-      if (user?.createdAt) {
-        const accountAgeDays =
-          (Date.now() - new Date(user.createdAt).getTime()) /
-          (1000 * 60 * 60 * 24);
-        if (accountAgeDays > 30) {
-          return;
-        }
+      // Only show the referral modal to genuinely new users (account created
+      // within the last 30 days). If the account age is unknown, do NOT prompt —
+      // the previous code skipped the check entirely when createdAt was missing,
+      // which let existing users through.
+      const createdAtMs = user?.createdAt
+        ? new Date(user.createdAt).getTime()
+        : null;
+      if (createdAtMs === null || Number.isNaN(createdAtMs)) {
+        return;
+      }
+      const accountAgeDays = (Date.now() - createdAtMs) / (1000 * 60 * 60 * 24);
+      if (accountAgeDays > 30) {
+        return;
       }
 
       // For new users, the network selection modal opens at the same time as this
@@ -675,10 +679,13 @@ export function MainPageContent() {
             if (!isMounted) return;
 
             if (response.success && response.data && Array.isArray(response.data.referrals)) {
-              const hasReferred = response.data.referrals.some(
-                (r) => r.role === "referred",
-              );
-              setHasExistingReferral(hasReferred);
+              // Suppress the modal for anyone with ANY referral relationship —
+              // whether they were referred OR have referred others. The previous
+              // check only looked at role === "referred", so existing users who
+              // had referred people still saw the modal.
+              const hasAnyReferralRelationship =
+                response.data.referrals.length > 0;
+              setHasExistingReferral(hasAnyReferralRelationship);
             } else {
               // Safe default: if we can't confirm they haven't been referred, assume they have
               setHasExistingReferral(true);

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -58,6 +58,7 @@ import {
   useKYC,
 } from "../context";
 import { getPreferredNetworkForBalances } from "../lib/getPreferredNetworkForBalances";
+import { hasSeenNetworkModalFlag } from "../lib/networkModalStore";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 
 /**
@@ -374,11 +375,12 @@ export function MainPageContent() {
       // For new users, the network selection modal opens at the same time as this
       // check would fire. Defer to handleNetworkSelected so the referral modal only
       // shows after they've picked a network — not underneath it.
-      if (!fromNetworkSelected && user?.wallet?.address) {
-        const networkModalKey = `hasSeenNetworkModal-${user.wallet.address}`;
-        if (!localStorage.getItem(networkModalKey)) {
-          return;
-        }
+      if (
+        !fromNetworkSelected &&
+        user?.wallet?.address &&
+        !hasSeenNetworkModalFlag(user.wallet.address)
+      ) {
+        return;
       }
 
       const referralStorageKey = `hasSeenReferralModal-${walletAddress.toLowerCase()}`;

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -27,6 +27,7 @@ import Image from "next/image";
 import { useNetwork } from "../context/NetworksContext";
 import { useInjectedWallet } from "../context";
 import { useActualTheme } from "../hooks/useActualTheme";
+import { clearNetworkModalSeen } from "../lib/networkModalStore";
 import { useWallets } from "@privy-io/react-auth";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
 import { useWalletAddress } from "../hooks/useWalletAddress";
@@ -78,7 +79,7 @@ export const Navbar = () => {
         localStorage.setItem("userId", user.wallet.address);
 
         if (isNewUser) {
-          localStorage.removeItem(`hasSeenNetworkModal-${user.wallet.address.toLowerCase()}`);
+          clearNetworkModalSeen(user.wallet.address);
 
           trackEvent("Sign up completed", {
             "Login method": loginMethod,

--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -17,6 +17,11 @@ import {
 } from "../utils";
 import { useSearchParams } from "next/navigation";
 import { useActualTheme } from "../hooks/useActualTheme";
+import {
+  hasSeenNetworkModalFlag,
+  markNetworkModalSeen,
+  markNetworkModalDismissed,
+} from "../lib/networkModalStore";
 
 interface NetworkSelectionModalProps {
   onNetworkSelected?: () => void;
@@ -48,8 +53,7 @@ export const NetworkSelectionModal = ({
     const walletAddress = user?.wallet?.address;
     if (!walletAddress) return; // wait for the address; effect re-runs when it lands
 
-    const storageKey = `hasSeenNetworkModal-${walletAddress}`;
-    if (!localStorage.getItem(storageKey)) {
+    if (!hasSeenNetworkModalFlag(walletAddress)) {
       setIsOpen(true);
     }
     setHasCheckedStorage(true);
@@ -64,10 +68,11 @@ export const NetworkSelectionModal = ({
   // };
 
   const handleClose = () => {
-    if (user?.wallet?.address) {
-      const storageKey = `hasSeenNetworkModal-${user.wallet.address}`;
-      localStorage.setItem(storageKey, "true");
-    }
+    markNetworkModalSeen(user?.wallet?.address);
+    // Live in-session signal for MigrationBannerWrapper — this call was never
+    // wired up, so migration UI gated on it could only appear after a reload
+    // (and the storage fallback's key casing didn't match either).
+    markNetworkModalDismissed();
     setIsOpen(false);
 
     // Trigger callback when modal closes after network selection

--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -32,21 +32,28 @@ export const NetworkSelectionModal = ({
   const [hasCheckedStorage, setHasCheckedStorage] = useState(false);
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { ensureWalletExists } = useStarknet();
-  const { authenticated, user } = usePrivy();
+  const { authenticated, user, ready } = usePrivy();
   const useInjectedWallet = shouldUseInjectedWallet(searchParams);
   const isDark = useActualTheme();
 
+  // Wait for Privy to finish hydrating before deciding whether to open. On a
+  // fresh signup the embedded wallet address arrives a tick after `authenticated`
+  // flips true; gating on `ready` (and re-running when the address settles)
+  // avoids the case where the modal evaluated too early and never opened until a
+  // manual refresh — which also blocked the referral modal that chains off it.
   useEffect(() => {
-    if (!hasCheckedStorage && authenticated && user?.wallet?.address) {
-      const storageKey = `hasSeenNetworkModal-${user.wallet.address}`;
-      const hasSeenModal = localStorage.getItem(storageKey);
+    if (hasCheckedStorage) return;
+    if (!ready || !authenticated) return;
 
-      if (!hasSeenModal) {
-        setIsOpen(true);
-      }
-      setHasCheckedStorage(true);
+    const walletAddress = user?.wallet?.address;
+    if (!walletAddress) return; // wait for the address; effect re-runs when it lands
+
+    const storageKey = `hasSeenNetworkModal-${walletAddress}`;
+    if (!localStorage.getItem(storageKey)) {
+      setIsOpen(true);
     }
-  }, [hasCheckedStorage, authenticated, user?.wallet?.address]);
+    setHasCheckedStorage(true);
+  }, [hasCheckedStorage, ready, authenticated, user?.wallet?.address]);
 
   // const handleClose = () => {
   //   if (user?.wallet?.address) {

--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -2,7 +2,7 @@
 import { DialogTitle } from "@headlessui/react";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { PiCheck } from "react-icons/pi";
 import { HelpCircleIcon, ArrowLeft02Icon, Cancel01Icon } from "hugeicons-react";
 import { usePrivy } from "@privy-io/react-auth";
@@ -34,7 +34,9 @@ export const NetworkSelectionModal = ({
   const searchParams = useSearchParams();
   const [isOpen, setIsOpen] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
-  const [hasCheckedStorage, setHasCheckedStorage] = useState(false);
+  // Wallet-scoped sentinel: a plain boolean stayed sticky across logout/login
+  // or wallet switches, so the modal never re-evaluated for the next account.
+  const checkedWalletRef = useRef<string | null>(null);
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { ensureWalletExists } = useStarknet();
   const { authenticated, user, ready } = usePrivy();
@@ -47,17 +49,17 @@ export const NetworkSelectionModal = ({
   // avoids the case where the modal evaluated too early and never opened until a
   // manual refresh — which also blocked the referral modal that chains off it.
   useEffect(() => {
-    if (hasCheckedStorage) return;
     if (!ready || !authenticated) return;
 
-    const walletAddress = user?.wallet?.address;
+    const walletAddress = user?.wallet?.address?.toLowerCase();
     if (!walletAddress) return; // wait for the address; effect re-runs when it lands
+    if (checkedWalletRef.current === walletAddress) return;
 
     if (!hasSeenNetworkModalFlag(walletAddress)) {
       setIsOpen(true);
     }
-    setHasCheckedStorage(true);
-  }, [hasCheckedStorage, ready, authenticated, user?.wallet?.address]);
+    checkedWalletRef.current = walletAddress;
+  }, [ready, authenticated, user?.wallet?.address]);
 
   // const handleClose = () => {
   //   if (user?.wallet?.address) {

--- a/app/components/PhoneVerificationModal.tsx
+++ b/app/components/PhoneVerificationModal.tsx
@@ -459,7 +459,7 @@ export default function PhoneVerificationModal({
                   ),
                 )
               }
-              placeholder="enter your phone number"
+              placeholder="Enter your phone number"
               className="min-h-12 w-full rounded-xl border border-border-input bg-transparent py-3 pl-24 pr-4 text-sm text-neutral-900 transition-all placeholder:text-text-placeholder focus-within:border-gray-400 focus:outline-none disabled:cursor-not-allowed dark:bg-black2 dark:text-white/80 dark:placeholder:text-white/30 dark:border-white/20 dark:focus-within:border-white/40"
               style={{
                 paddingLeft: `${selectedCountry.code.length * 8 + 60}px`,

--- a/app/components/ProfileDrawer.tsx
+++ b/app/components/ProfileDrawer.tsx
@@ -56,11 +56,13 @@ export default function ProfileDrawer({ isOpen, onClose }: ProfileDrawerProps) {
       ? (transactionSummary.monthlySpent / monthlyLimit) * 100
       : 0;
 
-  // Refresh KYC status when drawer opens so profile stays in sync with Get started / limit modal
+  // Refresh KYC status when drawer opens so profile stays in sync with Get started / limit modal.
+  // force=true: a tier upgrade can land (via the SmileID webhook) seconds after the last fetch,
+  // and the non-forced path would serve the stale cached tier for up to 30s.
   useEffect(() => {
     if (isOpen) {
       setIsLoading(true);
-      refreshStatus().finally(() => setIsLoading(false));
+      refreshStatus(true).finally(() => setIsLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: omit refreshStatus to avoid refetch loop
   }, [isOpen]);

--- a/app/components/TransactionLimitModal.tsx
+++ b/app/components/TransactionLimitModal.tsx
@@ -47,10 +47,12 @@ export default function TransactionLimitModal({
   const upgradeStep = getKycUpgradeStep(tier);
   const tier1Limits = KYC_TIERS[1]?.limits.monthly;
 
+  // force=true: skip the context's 30s staleness cache — this modal opens right
+  // when the user's tier/spend may have just changed (post-upgrade, post-swap).
   useEffect(() => {
     if (isOpen) {
       setIsLoading(true);
-      refreshStatus().finally(() => setIsLoading(false));
+      refreshStatus(true).finally(() => setIsLoading(false));
     }
   }, [isOpen, refreshStatus]);
 
@@ -235,8 +237,9 @@ export default function TransactionLimitModal({
     </motion.div>
   );
 
-  if (!isOpen) return null;
-
+  // No early `return null` on !isOpen: unmounting here would tear down the KYC
+  // AnimatedModal before its exit animation and scroll restore can run. Each
+  // child below gates itself on isOpen / its own flag instead.
   const showLimitDialog = isOpen && !isPhoneModalOpen && !isKycModalOpen;
 
   return (
@@ -261,39 +264,39 @@ export default function TransactionLimitModal({
       </AnimatePresence>
 
       <PhoneVerificationModal
-        isOpen={isPhoneModalOpen}
+        isOpen={isOpen && isPhoneModalOpen}
         onClose={() => {
           setIsPhoneModalOpen(false);
         }}
         onVerified={handlePhoneVerified}
       />
 
-      <AnimatePresence>
-        {isKycModalOpen && tier >= 1 && (
-          <AnimatedModal
-            isOpen={isKycModalOpen}
-            onClose={() => {
-              setIsKycModalOpen(false);
-              onClose();
-            }}
-          >
-            <KycModal
-              setIsKycModalOpen={(value) => {
-                setIsKycModalOpen(value);
-                if (!value) onClose();
-              }}
-              setIsUserVerified={(verified) => {
-                if (verified) {
-                  void refreshStatus(true);
-                }
-                setIsKycModalOpen(false);
-                onClose();
-              }}
-              targetTier={getKycModalTargetTier(tier)}
-            />
-          </AnimatedModal>
-        )}
-      </AnimatePresence>
+      {/* No outer AnimatePresence/conditional: AnimatedModal manages its own
+          presence, and an outer conditional removes it before the exit
+          animation (and the scroll restore in onExitComplete) can run. */}
+      <AnimatedModal
+        isOpen={isOpen && isKycModalOpen && tier >= 1}
+        onClose={() => {
+          setIsKycModalOpen(false);
+          onClose();
+        }}
+        restoreScrollOnClose
+      >
+        <KycModal
+          setIsKycModalOpen={(value) => {
+            setIsKycModalOpen(value);
+            if (!value) onClose();
+          }}
+          setIsUserVerified={(verified) => {
+            if (verified) {
+              void refreshStatus(true);
+            }
+            setIsKycModalOpen(false);
+            onClose();
+          }}
+          targetTier={getKycModalTargetTier(tier)}
+        />
+      </AnimatedModal>
     </>
   );
 };

--- a/app/components/wallet-mobile-modal/ReferralHubView.tsx
+++ b/app/components/wallet-mobile-modal/ReferralHubView.tsx
@@ -119,7 +119,7 @@ export const ReferralHubView: React.FC<ReferralHubViewProps> = ({
               Earned
             </p>
             <p className="text-lg font-semibold text-text-body dark:text-white">
-              {referralData?.total_earned?.toFixed(1) ?? "0.0"} USDC
+              {Number(referralData?.total_earned ?? 0).toFixed(1)} USDC
             </p>
           </div>
           <div className="bg-transparent p-4">
@@ -127,7 +127,7 @@ export const ReferralHubView: React.FC<ReferralHubViewProps> = ({
               Pending
             </p>
             <p className="text-lg font-semibold text-text-body dark:text-white">
-              {referralData?.total_pending?.toFixed(0) ?? "0"} USDC
+              {Number(referralData?.total_pending ?? 0).toFixed(1)} USDC
             </p>
           </div>
         </div>

--- a/app/context/MigrationContext.tsx
+++ b/app/context/MigrationContext.tsx
@@ -6,15 +6,10 @@ import { WalletMigrationBanner } from "../components/WalletMigrationBanner";
 import { MigrationZeroBalanceModal } from "../components/MigrationZeroBalanceModal";
 import { usePrivy } from "@privy-io/react-auth";
 import { useInjectedWallet } from "./InjectedWalletContext";
-import { useIsNetworkModalDismissed } from "../lib/networkModalStore";
-
-const NETWORK_MODAL_STORAGE_KEY_PREFIX = "hasSeenNetworkModal-";
-
-function hasSeenNetworkModal(walletAddress: string | undefined): boolean {
-    if (typeof window === "undefined" || !walletAddress) return false;
-    const key = `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`;
-    return localStorage.getItem(key) === "true";
-}
+import {
+    useIsNetworkModalDismissed,
+    hasSeenNetworkModalFlag,
+} from "../lib/networkModalStore";
 
 export const MigrationBannerWrapper = () => {
     const { user } = usePrivy();
@@ -31,7 +26,7 @@ export const MigrationBannerWrapper = () => {
     // Live: useSyncExternalStore re-renders the instant NetworkSelectionModal calls markNetworkModalDismissed()
     const dismissedViaStore = useIsNetworkModalDismissed();
     // Fallback: covers page-reload when localStorage already has the key
-    const dismissedViaStorage = hasSeenNetworkModal(walletAddress);
+    const dismissedViaStorage = hasSeenNetworkModalFlag(walletAddress);
 
     const canShowMigrationModal =
         !isInjectedWallet && (dismissedViaStore || dismissedViaStorage);

--- a/app/hooks/useEarnAccess.ts
+++ b/app/hooks/useEarnAccess.ts
@@ -1,11 +1,13 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
 import { hasEarnConsent, setEarnConsentAccepted } from "../lib/earnConsent";
 
 export type EarnAccessAction = "earn-modal" | "earn-tab" | "earn-hub";
 
 export function useEarnAccess() {
+  const { user } = usePrivy();
   const [isConsentModalOpen, setIsConsentModalOpen] = useState(false);
   const pendingRef = useRef<EarnAccessAction | null>(null);
 
@@ -17,23 +19,23 @@ export function useEarnAccess() {
 
   const requestEarnAccess = useCallback(
     (action: EarnAccessAction, onAction: (action: EarnAccessAction) => void) => {
-      if (hasEarnConsent()) {
+      if (hasEarnConsent(user?.id)) {
         onAction(action);
         return;
       }
       pendingRef.current = action;
       setIsConsentModalOpen(true);
     },
-    [],
+    [user?.id],
   );
 
   const handleConsentAccepted = useCallback(
     (onAction: (action: EarnAccessAction) => void) => {
-      setEarnConsentAccepted();
+      setEarnConsentAccepted(user?.id);
       setIsConsentModalOpen(false);
       runPending(onAction);
     },
-    [runPending],
+    [runPending, user?.id],
   );
 
   const dismissConsent = useCallback(() => {

--- a/app/lib/earnConsent.ts
+++ b/app/lib/earnConsent.ts
@@ -24,4 +24,4 @@ export function setEarnConsentAccepted(userId: string | undefined): void {
 
 /** Earn / Vesu risk disclosure article. */
 export const EARN_LEARN_MORE_URL =
-  "https://docs.google.com/document/d/13_C1VoNiWXl0gOzcLGuOF_sz_2dEKhuKkIAjwfzC654/edit?tab=t.0#heading=h.vabjr2kta3us";
+  "https://noblocks.xyz/blog/noblocks-earn-feature-disclosure";

--- a/app/lib/earnConsent.ts
+++ b/app/lib/earnConsent.ts
@@ -1,14 +1,25 @@
-/** Persists one-time acceptance of the Earn (Vesu / third-party) risk disclosure. */
-const EARN_CONSENT_STORAGE_KEY = "noblocksEarnConsentAccepted";
+/**
+ * Persists one-time acceptance of the Earn (Vesu / third-party) risk disclosure.
+ *
+ * Keyed per user: the previous device-global key meant the first account that
+ * accepted suppressed the disclosure for every other account on the same
+ * device (including brand-new signups). The legacy global key is intentionally
+ * ignored so each user confirms the disclosure once themselves.
+ */
+const EARN_CONSENT_STORAGE_PREFIX = "noblocksEarnConsentAccepted";
 
-export function hasEarnConsent(): boolean {
-  if (typeof window === "undefined") return false;
-  return localStorage.getItem(EARN_CONSENT_STORAGE_KEY) === "true";
+function earnConsentKey(userId: string): string {
+  return `${EARN_CONSENT_STORAGE_PREFIX}-${userId}`;
 }
 
-export function setEarnConsentAccepted(): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(EARN_CONSENT_STORAGE_KEY, "true");
+export function hasEarnConsent(userId: string | undefined): boolean {
+  if (typeof window === "undefined" || !userId) return false;
+  return localStorage.getItem(earnConsentKey(userId)) === "true";
+}
+
+export function setEarnConsentAccepted(userId: string | undefined): void {
+  if (typeof window === "undefined" || !userId) return;
+  localStorage.setItem(earnConsentKey(userId), "true");
 }
 
 /** Earn / Vesu risk disclosure article. */

--- a/app/lib/networkModalStore.ts
+++ b/app/lib/networkModalStore.ts
@@ -2,6 +2,32 @@ import { useSyncExternalStore } from "react";
 
 const NETWORK_MODAL_STORAGE_KEY_PREFIX = "hasSeenNetworkModal-";
 
+// localStorage can throw in restricted environments (storage disabled,
+// private modes, quota); modal gating must degrade gracefully, not crash.
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore storage errors
+  }
+}
+
 /**
  * Canonical "has seen the network modal" persistence. The key is lowercased:
  * the modal used to write the checksummed address while MigrationContext and
@@ -13,12 +39,10 @@ export function hasSeenNetworkModalFlag(
 ): boolean {
   if (typeof window === "undefined" || !walletAddress) return false;
   return (
-    localStorage.getItem(
+    safeGetItem(
       `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
     ) !== null ||
-    localStorage.getItem(
-      `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`,
-    ) !== null
+    safeGetItem(`${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`) !== null
   );
 }
 
@@ -26,7 +50,7 @@ export function markNetworkModalSeen(
   walletAddress: string | undefined,
 ): void {
   if (typeof window === "undefined" || !walletAddress) return;
-  localStorage.setItem(
+  safeSetItem(
     `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
     "true",
   );
@@ -37,12 +61,10 @@ export function clearNetworkModalSeen(
   walletAddress: string | undefined,
 ): void {
   if (typeof window === "undefined" || !walletAddress) return;
-  localStorage.removeItem(
+  safeRemoveItem(
     `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
   );
-  localStorage.removeItem(
-    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`,
-  );
+  safeRemoveItem(`${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`);
 }
 
 let dismissed = false;

--- a/app/lib/networkModalStore.ts
+++ b/app/lib/networkModalStore.ts
@@ -1,5 +1,50 @@
 import { useSyncExternalStore } from "react";
 
+const NETWORK_MODAL_STORAGE_KEY_PREFIX = "hasSeenNetworkModal-";
+
+/**
+ * Canonical "has seen the network modal" persistence. The key is lowercased:
+ * the modal used to write the checksummed address while MigrationContext and
+ * session-cleanup read/removed the lowercased form, so they never matched.
+ * Legacy checksummed keys are still honored on read.
+ */
+export function hasSeenNetworkModalFlag(
+  walletAddress: string | undefined,
+): boolean {
+  if (typeof window === "undefined" || !walletAddress) return false;
+  return (
+    localStorage.getItem(
+      `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
+    ) !== null ||
+    localStorage.getItem(
+      `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`,
+    ) !== null
+  );
+}
+
+export function markNetworkModalSeen(
+  walletAddress: string | undefined,
+): void {
+  if (typeof window === "undefined" || !walletAddress) return;
+  localStorage.setItem(
+    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
+    "true",
+  );
+}
+
+/** Removes both canonical and legacy key forms (e.g. fresh-signup reset). */
+export function clearNetworkModalSeen(
+  walletAddress: string | undefined,
+): void {
+  if (typeof window === "undefined" || !walletAddress) return;
+  localStorage.removeItem(
+    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
+  );
+  localStorage.removeItem(
+    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`,
+  );
+}
+
 let dismissed = false;
 const listeners = new Set<() => void>();
 

--- a/app/lib/smileID.ts
+++ b/app/lib/smileID.ts
@@ -22,6 +22,75 @@ export {
   type SmileIDIdInfo,
 };
 
+/** Resolves the SmileID server mode (0 = sandbox, 1 = production) from env. */
+export function resolveSmileIdServerConfig(): {
+  sidServerMode: "0" | "1";
+  hasServerConfig: boolean;
+} {
+  const serverModeOverride = process.env.SMILE_IDENTITY_SERVER_MODE?.trim();
+  const serverRaw = process.env.SMILE_IDENTITY_SERVER?.trim();
+
+  const hasServerConfig =
+    serverModeOverride === "0" ||
+    serverModeOverride === "1" ||
+    Boolean(serverRaw);
+
+  const sidServerMode: "0" | "1" = (() => {
+    if (serverModeOverride === "1") return "1";
+    if (serverModeOverride === "0") return "0";
+    if (serverRaw === "1") return "1";
+    if (serverRaw === "0") return "0";
+    if (serverRaw && /^https?:\/\//i.test(serverRaw)) {
+      return /testapi|sandbox/i.test(serverRaw) ? "0" : "1";
+    }
+    return "0";
+  })();
+
+  return { sidServerMode, hasServerConfig };
+}
+
+export interface SmileIdJobStatusResult {
+  job_complete?: boolean;
+  job_success?: boolean;
+  result?: {
+    Actions?: Record<string, string>;
+    ResultCode?: string;
+    ResultText?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Authoritative job status straight from the SmileID API (signed response,
+ * verified by smile-identity-core). Callbacks must be confirmed through this
+ * before any tier promotion: the callback HMAC only covers
+ * timestamp+partner_id, not the body, so body fields alone are forgeable.
+ */
+export async function getSmileIdJobStatus(
+  userId: string,
+  jobId: string,
+): Promise<SmileIdJobStatusResult> {
+  const partnerId = process.env.SMILE_IDENTITY_PARTNER_ID;
+  const apiKey = process.env.SMILE_IDENTITY_API_KEY;
+  const { sidServerMode, hasServerConfig } = resolveSmileIdServerConfig();
+
+  if (!partnerId || !apiKey || !hasServerConfig) {
+    throw new Error(
+      "Missing SmileID environment variables (SMILE_IDENTITY_PARTNER_ID, SMILE_IDENTITY_API_KEY, and SMILE_IDENTITY_SERVER / SMILE_IDENTITY_SERVER_MODE)",
+    );
+  }
+
+  const SIDCore = await import("smile-identity-core");
+  const UtilitiesClass = (SIDCore.default as any).Utilities;
+  const utilities = new UtilitiesClass(partnerId, apiKey, sidServerMode);
+
+  return (await utilities.get_job_status(userId, jobId, {
+    return_history: false,
+    return_images: false,
+  })) as SmileIdJobStatusResult;
+}
+
 export async function submitSmileIDJob({
   images,
   partner_params,
@@ -41,24 +110,7 @@ export async function submitSmileIDJob({
   const partnerId = process.env.SMILE_IDENTITY_PARTNER_ID;
   const callbackUrl = process.env.SMILE_ID_CALLBACK_URL?.trim() ?? "";
   const apiKey = process.env.SMILE_IDENTITY_API_KEY;
-  const serverModeOverride = process.env.SMILE_IDENTITY_SERVER_MODE?.trim();
-  const serverRaw = process.env.SMILE_IDENTITY_SERVER?.trim();
-
-  const hasServerConfig =
-    serverModeOverride === "0" ||
-    serverModeOverride === "1" ||
-    Boolean(serverRaw);
-
-  const sidServerMode: "0" | "1" = (() => {
-    if (serverModeOverride === "1") return "1";
-    if (serverModeOverride === "0") return "0";
-    if (serverRaw === "1") return "1";
-    if (serverRaw === "0") return "0";
-    if (serverRaw && /^https?:\/\//i.test(serverRaw)) {
-      return /testapi|sandbox/i.test(serverRaw) ? "0" : "1";
-    }
-    return "0";
-  })();
+  const { sidServerMode, hasServerConfig } = resolveSmileIdServerConfig();
 
   if (!partnerId || !apiKey || !callbackUrl || !hasServerConfig) {
     throw new Error(

--- a/app/lib/smileID.ts
+++ b/app/lib/smileID.ts
@@ -50,8 +50,9 @@ export function resolveSmileIdServerConfig(): {
 }
 
 export interface SmileIdJobStatusResult {
-  job_complete?: boolean;
-  job_success?: boolean;
+  // SmileID inconsistently returns booleans or "true"/"false" strings
+  job_complete?: boolean | string;
+  job_success?: boolean | string;
   result?: {
     Actions?: Record<string, string>;
     ResultCode?: string;

--- a/app/lib/smileID.ts
+++ b/app/lib/smileID.ts
@@ -22,7 +22,12 @@ export {
   type SmileIDIdInfo,
 };
 
-/** Resolves the SmileID server mode (0 = sandbox, 1 = production) from env. */
+/**
+ * Resolves the SmileID server mode (0 = sandbox, 1 = production) from env.
+ * Only "0"/"1" (or a legacy http(s) API URL) are recognized — anything else
+ * reports hasServerConfig=false so callers fail with a clear configuration
+ * error instead of silently running against sandbox in production.
+ */
 export function resolveSmileIdServerConfig(): {
   sidServerMode: "0" | "1";
   hasServerConfig: boolean;
@@ -30,23 +35,25 @@ export function resolveSmileIdServerConfig(): {
   const serverModeOverride = process.env.SMILE_IDENTITY_SERVER_MODE?.trim();
   const serverRaw = process.env.SMILE_IDENTITY_SERVER?.trim();
 
-  const hasServerConfig =
-    serverModeOverride === "0" ||
-    serverModeOverride === "1" ||
-    Boolean(serverRaw);
+  if (serverModeOverride === "0" || serverModeOverride === "1") {
+    return { sidServerMode: serverModeOverride, hasServerConfig: true };
+  }
+  if (serverRaw === "0" || serverRaw === "1") {
+    return { sidServerMode: serverRaw, hasServerConfig: true };
+  }
+  if (serverRaw && /^https?:\/\//i.test(serverRaw)) {
+    return {
+      sidServerMode: /testapi|sandbox/i.test(serverRaw) ? "0" : "1",
+      hasServerConfig: true,
+    };
+  }
 
-  const sidServerMode: "0" | "1" = (() => {
-    if (serverModeOverride === "1") return "1";
-    if (serverModeOverride === "0") return "0";
-    if (serverRaw === "1") return "1";
-    if (serverRaw === "0") return "0";
-    if (serverRaw && /^https?:\/\//i.test(serverRaw)) {
-      return /testapi|sandbox/i.test(serverRaw) ? "0" : "1";
-    }
-    return "0";
-  })();
-
-  return { sidServerMode, hasServerConfig };
+  if (serverModeOverride || serverRaw) {
+    console.error(
+      "[smileID] Unrecognized SMILE_IDENTITY_SERVER / SMILE_IDENTITY_SERVER_MODE value — expected 0, 1, or an http(s) URL",
+    );
+  }
+  return { sidServerMode: "0", hasServerConfig: false };
 }
 
 export interface SmileIdJobStatusResult {

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -1253,20 +1253,20 @@ export const TransactionForm = ({
             )}
         </AnimatePresence>
 
-        <AnimatePresence>
-          {isKycModalOpen && tier >= 1 && (
-            <AnimatedModal
-              isOpen={isKycModalOpen}
-              onClose={() => setIsKycModalOpen(false)}
-            >
-              <KycModal
-                setIsKycModalOpen={setIsKycModalOpen}
-                setIsUserVerified={setIsUserVerified}
-                targetTier={getKycModalTargetTier(tier)}
-              />
-            </AnimatedModal>
-          )}
-        </AnimatePresence>
+        {/* No outer AnimatePresence/conditional: AnimatedModal manages its own
+            presence, and an outer conditional removes it before the exit
+            animation (and the scroll restore in onExitComplete) can run. */}
+        <AnimatedModal
+          isOpen={isKycModalOpen && tier >= 1}
+          onClose={() => setIsKycModalOpen(false)}
+          restoreScrollOnClose
+        >
+          <KycModal
+            setIsKycModalOpen={setIsKycModalOpen}
+            setIsUserVerified={setIsUserVerified}
+            targetTier={getKycModalTargetTier(tier)}
+          />
+        </AnimatedModal>
 
         <TransactionLimitModal
           isOpen={isLimitModalOpen}

--- a/supabase/migrations/20260611120000_kyc_identity_hardening.sql
+++ b/supabase/migrations/20260611120000_kyc_identity_hardening.sql
@@ -21,10 +21,10 @@ UPDATE public.user_kyc_profiles
    AND phone_number IS NOT NULL;
 
 -- ─── 2. Verified-identity uniqueness ──────────────────────────────────────────
--- Created conditionally: if historical duplicates exist they need a manual,
--- compliance-reviewed cleanup first — a migration must not decide which wallet
--- keeps the identity. The app also enforces this at verification time, so new
--- duplicates cannot be created either way.
+-- Fails the migration (and deploy) if historical duplicates exist: they need a
+-- manual, compliance-reviewed cleanup first — a migration must not decide which
+-- wallet keeps the identity, and shipping without the indexes would leave a
+-- concurrent-verification race open. Re-run after cleanup.
 
 DO $$
 BEGIN
@@ -36,12 +36,12 @@ BEGIN
      GROUP BY phone_number
     HAVING COUNT(*) > 1
   ) THEN
-    RAISE WARNING 'user_kyc_profiles: duplicate verified phone numbers exist; uniq_user_kyc_profiles_verified_phone NOT created. Clean up duplicates and re-run.';
-  ELSE
-    CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_phone
-        ON public.user_kyc_profiles (phone_number)
-     WHERE phone_number IS NOT NULL AND tier >= 1;
+    RAISE EXCEPTION 'user_kyc_profiles: duplicate verified phone numbers exist; clean up duplicates, then re-run this migration to create uniq_user_kyc_profiles_verified_phone.';
   END IF;
+
+  CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_phone
+      ON public.user_kyc_profiles (phone_number)
+   WHERE phone_number IS NOT NULL AND tier >= 1;
 
   IF EXISTS (
     SELECT 1
@@ -51,10 +51,10 @@ BEGIN
      GROUP BY id_country, id_type, id_number
     HAVING COUNT(*) > 1
   ) THEN
-    RAISE WARNING 'user_kyc_profiles: duplicate verified ID documents exist; uniq_user_kyc_profiles_verified_id NOT created. Clean up duplicates and re-run.';
-  ELSE
-    CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_id
-        ON public.user_kyc_profiles (id_country, id_type, id_number)
-     WHERE id_number IS NOT NULL AND tier >= 2;
+    RAISE EXCEPTION 'user_kyc_profiles: duplicate verified ID documents exist; clean up duplicates, then re-run this migration to create uniq_user_kyc_profiles_verified_id.';
   END IF;
+
+  CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_id
+      ON public.user_kyc_profiles (id_country, id_type, id_number)
+   WHERE id_number IS NOT NULL AND tier >= 2;
 END $$;

--- a/supabase/migrations/20260611120000_kyc_identity_hardening.sql
+++ b/supabase/migrations/20260611120000_kyc_identity_hardening.sql
@@ -1,0 +1,60 @@
+-- KYC identity hardening:
+--  1. `pending_phone_number` staging column so `phone_number` only ever holds a
+--     number that passed OTP verification (previously an unverified replacement
+--     number overwrote the verified one and was reported as verified).
+--  2. Uniqueness for verified identities so one phone number / ID document
+--     cannot back multiple wallet profiles (each wallet previously got its own
+--     full monthly limit from the same identity).
+
+-- ─── 1. Pending phone staging ─────────────────────────────────────────────────
+
+ALTER TABLE public.user_kyc_profiles
+    ADD COLUMN IF NOT EXISTS pending_phone_number text;
+
+-- Backfill: `verified = true` is only ever set after a successful phone OTP or
+-- a SmileID pass (which itself requires a verified phone), so an unverified
+-- profile's phone_number has never been OTP-confirmed — stage it instead.
+UPDATE public.user_kyc_profiles
+   SET pending_phone_number = phone_number,
+       phone_number         = NULL
+ WHERE COALESCE(verified, false) = false
+   AND phone_number IS NOT NULL;
+
+-- ─── 2. Verified-identity uniqueness ──────────────────────────────────────────
+-- Created conditionally: if historical duplicates exist they need a manual,
+-- compliance-reviewed cleanup first — a migration must not decide which wallet
+-- keeps the identity. The app also enforces this at verification time, so new
+-- duplicates cannot be created either way.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM public.user_kyc_profiles
+     WHERE phone_number IS NOT NULL
+       AND tier >= 1
+     GROUP BY phone_number
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE WARNING 'user_kyc_profiles: duplicate verified phone numbers exist; uniq_user_kyc_profiles_verified_phone NOT created. Clean up duplicates and re-run.';
+  ELSE
+    CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_phone
+        ON public.user_kyc_profiles (phone_number)
+     WHERE phone_number IS NOT NULL AND tier >= 1;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.user_kyc_profiles
+     WHERE id_number IS NOT NULL
+       AND tier >= 2
+     GROUP BY id_country, id_type, id_number
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE WARNING 'user_kyc_profiles: duplicate verified ID documents exist; uniq_user_kyc_profiles_verified_id NOT created. Clean up duplicates and re-run.';
+  ELSE
+    CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_kyc_profiles_verified_id
+        ON public.user_kyc_profiles (id_country, id_type, id_number)
+     WHERE id_number IS NOT NULL AND tier >= 2;
+  END IF;
+END $$;


### PR DESCRIPTION
### Description

This PR is a result fo the audit of the entire Tiered KYC , Earn Feature and Referral flow, taking into account all product feedback from testing and also catching some obscure edge cases in the code and security implications, the fixes here are designed to make these 3 features robust and production ready. 

Summary
Four commits addressing reported UX bugs in the tiered-KYC flow ([#281](https://github.com/paycrest/noblocks/issues/281)/#282/#283 follow-ups), two high-severity identity/limit enforcement gaps, a SmileID callback replay vector, and the referral/earn modal complaints.

Changes

1. KYC verification UX (cbd46e0)
Page landing at the footer after Tier 2 verification: scroll restoration moved out of KycModal's 500 ms timer (which was cancelled by its own unmount cleanup, racing the ~500 ms exit animation, and only covered 2 of the modal's close paths) into AnimatedModal via AnimatePresence onExitComplete — deterministic, covers buttons/backdrop/Esc, and restores the position captured at open instead of jumping to top. Opt-in via restoreScrollOnClose; other AnimatedModal consumers unaffected. Removed the outer AnimatePresence wrappers and TransactionLimitModal's early return null, both of which unmounted the modal before the exit animation (and restore) could run.
Tier status stale for up to 30s after upgrading: ProfileDrawer and TransactionLimitModal now force-refresh KYC status on open (bypassing the context's 30 s staleness cache), and KycModal's poller pushes the upgrade into KYCContext the moment it detects tier ≥ 2 (previously the modal could show "successful" while the rest of the app showed the old tier).

2. KYC identity hardening (e3d6f5c) — includes a DB migration
One verified identity per phone number and per ID document. Previously user_kyc_profiles was keyed on wallet address with no uniqueness on phone_number/id_number, so one phone could verify unlimited wallets — each receiving its own full monthly limit. Now enforced via pre-checks in send-otp (before spending an SMS), a promotion guard in verify-otp, an ID check in the SmileID route, 23505 race handling, and partial unique indexes.
pending_phone_number staging. send-otp no longer overwrites the verified phone_number or touches verified; the number is staged and only promoted by verify-otp after the OTP is confirmed. Closes the hole where a user who started (but never finished) verifying a replacement number kept their tier and the API reported the unverified number as verified.
SmileID callback replay protection. The callback HMAC only covers timestamp + partner_id — not the body — so a captured signature could be replayed with an arbitrary body to promote any wallet to Tier 2. The route now rejects timestamps older than 1 hour and, before any tier promotion, confirms the job outcome via SmileID's signed job_status API instead of trusting body fields.

3. Referral & Earn fixes (cbf8a9d)
Referral modal shown to existing users: now suppressed for any referral relationship (the old check only looked at role === "referred", so users who had referred others still saw it), and a missing/invalid createdAt now blocks the modal instead of skipping the 30-day new-user check.
Network selector (and the referral modal chained behind it) not appearing until refresh: the open trigger now waits for Privy ready and re-evaluates when the embedded wallet address settles.
Pending card showing wrong/zero totals: reward_amount is coerced to Number in the API (Postgres numeric deserializes as a string via PostgREST, so the totals reduce was string-concatenating), and the cards guard against non-numeric values.
Earn disclaimer missing for new accounts on shared devices: the "seen" flag is now keyed per Privy user id instead of one device-global key, so a second user (or fresh signup) on the same device sees the risk disclosure instead of inheriting the first user's acceptance. Existing users will see the disclaimer once more — intentional, compliance-positive.

4. Verification-pass corrections (18b2672)
SmileID route: keep idNumberToStore as undefined (not null) when SmileID returns no ID number, so updates don't erase a previously stored id_number.
SmileID callback: accept string "true" job flags when confirming job_status.
Network-modal dismissal: wired the never-called markNetworkModalDismissed() into NetworkSelectionModal.handleClose and centralized the hasSeenNetworkModal- key (canonical lowercase, legacy checksummed keys honored on read). Both of MigrationBannerWrapper's gates were dead — the live store signal never fired and the storage fallback read a lowercased key written checksummed — so migration UI gated on network-modal dismissal couldn't appear in-session.

Deploy notes
⚠️ Apply [supabase/migrations/20260611120000_kyc_identity_hardening.sql](https://github.com/paycrest/noblocks/blob/claude/funny-keller-7yja82/supabase/migrations/20260611120000_kyc_identity_hardening.sql) together with this deploy. It adds pending_phone_number, backfills unverified numbers into it, and creates the partial unique indexes. If historical duplicate identities exist, the indexes are skipped with a RAISE WARNING (app-level checks still block new duplicates) — clean up duplicates and re-run to get the index protection.
An OTP requested on the old code and verified on the new code before the migration runs returns a recoverable 404 ("request a new code").


### References




### Testing
tsc --noEmit clean; ESLint clean on all touched files; Jest 15/15 passing.
All flows verified by code-path tracing; recommend one live QA pass on: fresh signup → network selector → referral modal sequence, and a Tier 2 verification end-to-end (scroll position + status freshness).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed referral reward numeric handling and totals
  * Prevented stale KYC tier displays by forcing fresh status refreshes
  * Hardened phone verification flow and uniqueness checks to avoid cross-account conflicts

* **New Features**
  * Confirm remote identity job status before accepting KYC callbacks
  * Enforce single verified identity per ID document across wallets
  * Phone ownership validation before sending OTPs; pending-phone staging for OTP flow
  * Modals consistently mounted with optional scroll-position restoration
  * Per-user consent tracking and persistent network-modal state

* **Chores**
  * DB migration to stage pending phones and enforce verified-identity uniqueness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->