### PR TITLE
fix(ux): stop network modal re-opening on login and pin body scroll behind locked modals

### DIFF
--- a/app/components/AnimatedComponents.tsx
+++ b/app/components/AnimatedComponents.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { ReactNode } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import type { AnimatedComponentProps } from "../types";
@@ -311,14 +311,35 @@ type AnimatedModalProps = {
 // Module-level refcount: overlapping locked modals share one body pin, and only
 // the final release restores the scroll offset (window.scrollY reads 0 while
 // the body is fixed, so each instance must not capture its own).
+// Client components are still server-rendered; useLayoutEffect there triggers
+// React's "does nothing on the server" warning, so fall back to useEffect.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 let bodyScrollLockCount = 0;
 let bodyScrollLockY = 0;
+// Pre-existing inline body styles, snapshotted on first acquire and restored on
+// final release (blanking them would clobber styles set by other code).
+let bodyScrollLockPrevStyles: {
+  position: string;
+  top: string;
+  left: string;
+  right: string;
+  width: string;
+} | null = null;
 
 function acquireBodyScrollLock(): void {
   if (typeof window === "undefined") return;
   if (bodyScrollLockCount === 0) {
     bodyScrollLockY = window.scrollY;
     const { style } = document.body;
+    bodyScrollLockPrevStyles = {
+      position: style.position,
+      top: style.top,
+      left: style.left,
+      right: style.right,
+      width: style.width,
+    };
     style.position = "fixed";
     style.top = `-${bodyScrollLockY}px`;
     style.left = "0";
@@ -333,11 +354,12 @@ function releaseBodyScrollLock(): void {
   bodyScrollLockCount--;
   if (bodyScrollLockCount === 0) {
     const { style } = document.body;
-    style.position = "";
-    style.top = "";
-    style.left = "";
-    style.right = "";
-    style.width = "";
+    style.position = bodyScrollLockPrevStyles?.position ?? "";
+    style.top = bodyScrollLockPrevStyles?.top ?? "";
+    style.left = bodyScrollLockPrevStyles?.left ?? "";
+    style.right = bodyScrollLockPrevStyles?.right ?? "";
+    style.width = bodyScrollLockPrevStyles?.width ?? "";
+    bodyScrollLockPrevStyles = null;
     // Invisible: the body was pinned at exactly this offset the whole time.
     window.scrollTo({ top: bodyScrollLockY, behavior: "instant" });
   }
@@ -394,7 +416,10 @@ export const AnimatedModal = ({
     }
   };
 
-  useEffect(() => {
+  // Layout effect: the pin must land synchronously before the open modal's
+  // first paint, so mount-time child behavior (autofocus, camera init) cannot
+  // scroll the document in the gap. (Isomorphic: silences React's SSR warning.)
+  useIsomorphicLayoutEffect(() => {
     if (lockBodyScroll && isOpen && !holdsLockRef.current) {
       holdsLockRef.current = true;
       acquireBodyScrollLock();

--- a/app/components/AnimatedComponents.tsx
+++ b/app/components/AnimatedComponents.tsx
@@ -299,13 +299,49 @@ type AnimatedModalProps = {
   showGradientHeader?: boolean;
   backgroundImagePath?: string;
   /**
-   * Restore the page scroll position (captured when the modal opened) once the
-   * exit animation completes. Needed for content that displaces the document
-   * scroll while open (e.g. the SmileID camera in KycModal); covers every close
-   * path — buttons, backdrop, and Esc.
+   * Pin the document body (position: fixed at the current offset) while the
+   * modal is open, so nothing can displace the page scroll behind it — e.g.
+   * the SmileID camera in KycModal used to drag the document to the bottom.
+   * Released after the exit animation completes; the page never visibly moves,
+   * unlike the previous restore-on-close approach which jumped after the fact.
    */
-  restoreScrollOnClose?: boolean;
+  lockBodyScroll?: boolean;
 };
+
+// Module-level refcount: overlapping locked modals share one body pin, and only
+// the final release restores the scroll offset (window.scrollY reads 0 while
+// the body is fixed, so each instance must not capture its own).
+let bodyScrollLockCount = 0;
+let bodyScrollLockY = 0;
+
+function acquireBodyScrollLock(): void {
+  if (typeof window === "undefined") return;
+  if (bodyScrollLockCount === 0) {
+    bodyScrollLockY = window.scrollY;
+    const { style } = document.body;
+    style.position = "fixed";
+    style.top = `-${bodyScrollLockY}px`;
+    style.left = "0";
+    style.right = "0";
+    style.width = "100%";
+  }
+  bodyScrollLockCount++;
+}
+
+function releaseBodyScrollLock(): void {
+  if (typeof window === "undefined" || bodyScrollLockCount === 0) return;
+  bodyScrollLockCount--;
+  if (bodyScrollLockCount === 0) {
+    const { style } = document.body;
+    style.position = "";
+    style.top = "";
+    style.left = "";
+    style.right = "";
+    style.width = "";
+    // Invisible: the body was pinned at exactly this offset the whole time.
+    window.scrollTo({ top: bodyScrollLockY, behavior: "instant" });
+  }
+}
 
 /**
  * Enhanced AnimatedModal with gradient header and background image support
@@ -347,22 +383,33 @@ export const AnimatedModal = ({
   contentClassName,
   showGradientHeader = false,
   backgroundImagePath,
-  restoreScrollOnClose = false,
+  lockBodyScroll = false,
 }: AnimatedModalProps) => {
-  const openScrollYRef = useRef(0);
+  const holdsLockRef = useRef(false);
+
+  const releaseHeldLock = () => {
+    if (holdsLockRef.current) {
+      holdsLockRef.current = false;
+      releaseBodyScrollLock();
+    }
+  };
 
   useEffect(() => {
-    if (isOpen) {
-      openScrollYRef.current = window.scrollY;
+    if (lockBodyScroll && isOpen && !holdsLockRef.current) {
+      holdsLockRef.current = true;
+      acquireBodyScrollLock();
     }
-  }, [isOpen]);
+    // Intentionally not released when isOpen flips false: the lock must hold
+    // through the exit animation (content like the camera unmounts at its end).
+  }, [lockBodyScroll, isOpen]);
 
-  // onExitComplete runs after the dialog (and its scroll lock) has unmounted,
-  // so the restore cannot race the close animation or component teardown.
+  // Unmount safety net — e.g. the parent disappears without an exit animation.
+  useEffect(() => releaseHeldLock, []);
+
+  // onExitComplete runs after the dialog has fully unmounted, so nothing can
+  // displace the scroll after the lock is released.
   const handleExitComplete = () => {
-    if (restoreScrollOnClose) {
-      window.scrollTo({ top: openScrollYRef.current, behavior: "instant" });
-    }
+    releaseHeldLock();
   };
 
   return (

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -59,6 +59,10 @@ import {
 } from "../context";
 import { getPreferredNetworkForBalances } from "../lib/getPreferredNetworkForBalances";
 import { hasSeenNetworkModalFlag } from "../lib/networkModalStore";
+import {
+  storePendingReferralCode,
+  readPendingReferralCode,
+} from "../lib/pendingReferralCode";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 
 /**
@@ -193,6 +197,14 @@ function onrampRateQueryTokenAmount(
 export function MainPageContent() {
   const searchParams = useSearchParams();
   const { authenticated, ready, getAccessToken, user } = usePrivy();
+
+  // Persist ?ref=NBXXXX from referral share links immediately on landing —
+  // before login — so the code survives the auth flow (OAuth can drop the
+  // query string) and pre-fills the referral modal instead of being typed.
+  useEffect(() => {
+    storePendingReferralCode(searchParams.get("ref"));
+  }, [searchParams]);
+
   const {
     currentStep,
     setCurrentStep,
@@ -383,8 +395,13 @@ export function MainPageContent() {
         return;
       }
 
+      // A code carried in from a referral share link re-opens the modal even if
+      // this wallet dismissed it before — clicking the link is explicit intent.
       const referralStorageKey = `hasSeenReferralModal-${walletAddress.toLowerCase()}`;
-      if (!localStorage.getItem(referralStorageKey)) {
+      if (
+        !localStorage.getItem(referralStorageKey) ||
+        readPendingReferralCode()
+      ) {
         setShowReferralModal(true);
       }
     },

--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -51,10 +51,9 @@ export const NetworkSelectionModal = ({
   useEffect(() => {
     if (!ready || !authenticated) return;
 
-    // Pass the RAW address to hasSeenNetworkModalFlag: it checks the canonical
-    // lowercased key AND the legacy checksummed key. Lowercasing here first
-    // defeated the legacy lookup and re-opened the modal on login for every
-    // pre-existing account. Only the sentinel comparison is case-normalized.
+    // hasSeenNetworkModalFlag matches keys case-insensitively, so any
+    // historical casing of the stored key (or of the address Privy hands us)
+    // is honored. The sentinel only dedupes re-checks for the same wallet.
     const rawAddress = user?.wallet?.address;
     if (!rawAddress) return; // wait for the address; effect re-runs when it lands
     const sentinel = rawAddress.toLowerCase();

--- a/app/components/NetworkSelectionModal.tsx
+++ b/app/components/NetworkSelectionModal.tsx
@@ -51,14 +51,19 @@ export const NetworkSelectionModal = ({
   useEffect(() => {
     if (!ready || !authenticated) return;
 
-    const walletAddress = user?.wallet?.address?.toLowerCase();
-    if (!walletAddress) return; // wait for the address; effect re-runs when it lands
-    if (checkedWalletRef.current === walletAddress) return;
+    // Pass the RAW address to hasSeenNetworkModalFlag: it checks the canonical
+    // lowercased key AND the legacy checksummed key. Lowercasing here first
+    // defeated the legacy lookup and re-opened the modal on login for every
+    // pre-existing account. Only the sentinel comparison is case-normalized.
+    const rawAddress = user?.wallet?.address;
+    if (!rawAddress) return; // wait for the address; effect re-runs when it lands
+    const sentinel = rawAddress.toLowerCase();
+    if (checkedWalletRef.current === sentinel) return;
 
-    if (!hasSeenNetworkModalFlag(walletAddress)) {
+    if (!hasSeenNetworkModalFlag(rawAddress)) {
       setIsOpen(true);
     }
-    checkedWalletRef.current = walletAddress;
+    checkedWalletRef.current = sentinel;
   }, [ready, authenticated, user?.wallet?.address]);
 
   // const handleClose = () => {

--- a/app/components/ReferralModal.tsx
+++ b/app/components/ReferralModal.tsx
@@ -3,12 +3,17 @@
 import { DialogTitle } from "@headlessui/react";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { usePrivy } from "@privy-io/react-auth";
 import { AnimatedModal } from "./AnimatedComponents";
 import { useNetwork } from "../context/NetworksContext";
 import { submitReferralCode } from "../api/aggregator";
+import {
+    readPendingReferralCode,
+    clearPendingReferralCode,
+    REFERRAL_CODE_PATTERN,
+} from "../lib/pendingReferralCode";
 
 interface ReferralInputModalProps {
     isOpen: boolean;
@@ -26,6 +31,15 @@ export const ReferralInputModal = ({
     const { selectedNetwork } = useNetwork();
     const { getAccessToken } = usePrivy();
 
+    // Pre-fill from a referral share link (?ref=NBXXXX captured on landing in
+    // MainPageContent) so users who arrived via a link don't type the code.
+    useEffect(() => {
+        if (!isOpen) return;
+        setReferralCode((current) =>
+            current.trim() ? current : (readPendingReferralCode() ?? current),
+        );
+    }, [isOpen]);
+
     const sponsorChain = selectedNetwork?.chain.name || "Sponsor Chain";
 
     const handleSubmit = async () => {
@@ -38,7 +52,7 @@ export const ReferralInputModal = ({
 
         try {
             const code = referralCode.trim().toUpperCase();
-            if (!/^NB[A-Z0-9]{4}$/.test(code)) {
+            if (!REFERRAL_CODE_PATTERN.test(code)) {
                 toast.error("Invalid referral code format");
                 return;
             }
@@ -50,6 +64,7 @@ export const ReferralInputModal = ({
 
                 if (res && res.success) {
                     toast.success(res.data?.message || "Referral code applied! Complete KYC and your first transaction to earn rewards.");
+                    clearPendingReferralCode();
                     onSubmitSuccess?.();
                     onClose();
                 } else {
@@ -72,6 +87,9 @@ export const ReferralInputModal = ({
     };
 
     const handleSkip = () => {
+        // Declining also discards any link-carried code, so the modal doesn't
+        // keep re-opening on the strength of a code the user chose not to use.
+        clearPendingReferralCode();
         setReferralCode("");
         onClose();
     };

--- a/app/components/TransactionLimitModal.tsx
+++ b/app/components/TransactionLimitModal.tsx
@@ -273,14 +273,14 @@ export default function TransactionLimitModal({
 
       {/* No outer AnimatePresence/conditional: AnimatedModal manages its own
           presence, and an outer conditional removes it before the exit
-          animation (and the scroll restore in onExitComplete) can run. */}
+          animation (and the scroll-lock release in onExitComplete) can run. */}
       <AnimatedModal
         isOpen={isOpen && isKycModalOpen && tier >= 1}
         onClose={() => {
           setIsKycModalOpen(false);
           onClose();
         }}
-        restoreScrollOnClose
+        lockBodyScroll
       >
         <KycModal
           setIsKycModalOpen={(value) => {

--- a/app/lib/networkModalStore.ts
+++ b/app/lib/networkModalStore.ts
@@ -4,14 +4,6 @@ const NETWORK_MODAL_STORAGE_KEY_PREFIX = "hasSeenNetworkModal-";
 
 // localStorage can throw in restricted environments (storage disabled,
 // private modes, quota); modal gating must degrade gracefully, not crash.
-function safeGetItem(key: string): string | null {
-  try {
-    return localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
 function safeSetItem(key: string, value: string): void {
   try {
     localStorage.setItem(key, value);
@@ -29,21 +21,26 @@ function safeRemoveItem(key: string): void {
 }
 
 /**
- * Canonical "has seen the network modal" persistence. The key is lowercased:
- * the modal used to write the checksummed address while MigrationContext and
- * session-cleanup read/removed the lowercased form, so they never matched.
- * Legacy checksummed keys are still honored on read.
+ * Canonical "has seen the network modal" persistence. New keys are written
+ * lowercased; reads scan for a case-insensitive key match, so legacy keys
+ * written with any historical address casing (e.g. EIP-55 checksummed) are
+ * honored regardless of the casing the caller's address arrives in.
  */
 export function hasSeenNetworkModalFlag(
   walletAddress: string | undefined,
 ): boolean {
   if (typeof window === "undefined" || !walletAddress) return false;
-  return (
-    safeGetItem(
-      `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
-    ) !== null ||
-    safeGetItem(`${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`) !== null
-  );
+  const target =
+    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`.toLowerCase();
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.toLowerCase() === target) return true;
+    }
+  } catch {
+    // ignore storage errors — treat as not seen
+  }
+  return false;
 }
 
 export function markNetworkModalSeen(
@@ -56,15 +53,23 @@ export function markNetworkModalSeen(
   );
 }
 
-/** Removes both canonical and legacy key forms (e.g. fresh-signup reset). */
+/** Removes the seen flag in any historical casing (e.g. fresh-signup reset). */
 export function clearNetworkModalSeen(
   walletAddress: string | undefined,
 ): void {
   if (typeof window === "undefined" || !walletAddress) return;
-  safeRemoveItem(
-    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress.toLowerCase()}`,
-  );
-  safeRemoveItem(`${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`);
+  const target =
+    `${NETWORK_MODAL_STORAGE_KEY_PREFIX}${walletAddress}`.toLowerCase();
+  const toRemove: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.toLowerCase() === target) toRemove.push(key);
+    }
+  } catch {
+    // ignore storage errors
+  }
+  toRemove.forEach(safeRemoveItem);
 }
 
 let dismissed = false;

--- a/app/lib/pendingReferralCode.ts
+++ b/app/lib/pendingReferralCode.ts
@@ -1,0 +1,45 @@
+/**
+ * Carries a referral code from a share link (`?ref=NBXXXX`, see
+ * `handleCopyLink` in app/utils.ts) through the signup/login flow, so the
+ * referral modal can pre-fill it instead of making the user type it manually.
+ * Persisted in localStorage because OAuth logins can navigate away and drop
+ * the query string before the (post-auth) referral modal ever opens.
+ */
+export const REFERRAL_CODE_PATTERN = /^NB[A-Z0-9]{4}$/;
+
+const PENDING_REFERRAL_CODE_KEY = "pendingReferralCode";
+
+function normalize(raw: string | null | undefined): string | null {
+  const code = raw?.trim().toUpperCase();
+  // BlockFest links use ?ref=blockfest — it doesn't match the NBxxxx format,
+  // so the pattern check keeps the two flows apart.
+  return code && REFERRAL_CODE_PATTERN.test(code) ? code : null;
+}
+
+export function storePendingReferralCode(raw: string | null | undefined): void {
+  const code = normalize(raw);
+  if (!code || typeof window === "undefined") return;
+  try {
+    localStorage.setItem(PENDING_REFERRAL_CODE_KEY, code);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function readPendingReferralCode(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return normalize(localStorage.getItem(PENDING_REFERRAL_CODE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingReferralCode(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(PENDING_REFERRAL_CODE_KEY);
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -1255,11 +1255,11 @@ export const TransactionForm = ({
 
         {/* No outer AnimatePresence/conditional: AnimatedModal manages its own
             presence, and an outer conditional removes it before the exit
-            animation (and the scroll restore in onExitComplete) can run. */}
+            animation (and the scroll-lock release in onExitComplete) can run. */}
         <AnimatedModal
           isOpen={isKycModalOpen && tier >= 1}
           onClose={() => setIsKycModalOpen(false)}
-          restoreScrollOnClose
+          lockBodyScroll
         >
           <KycModal
             setIsKycModalOpen={setIsKycModalOpen}


### PR DESCRIPTION




### Description


- NetworkSelectionModal: pass the raw wallet address into hasSeenNetworkModalFlag — pre-lowercasing it defeated the legacy checksummed-key fallback, so the modal re-opened on login for every pre-existing account (regression from the wallet-scoped sentinel fix). Only the sentinel comparison is case-normalized now.
- AnimatedModal: replace restore-scroll-on-close with a body scroll lock (position: fixed at the captured offset) held from open through the end of the exit animation. The document can no longer be dragged to the bottom by modal content (e.g. the SmileID camera), and the visible jump from the old after-the-fact scrollTo restore is gone — the page never moves. Refcounted so overlapping locked modals share one pin; released on exit complete with an unmount safety net. Prop renamed restoreScrollOnClose -> lockBodyScroll.


### References




### Testing




### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network-selection modal reopening unexpectedly when switching accounts or addresses.

* **Improvements**
  * Modals now lock background scrolling while open (including during exit animations) and coordinate correctly across overlapping modals.
  * KYC and transaction modals use the new scroll-lock behavior for a smoother experience.

* **New Features**
  * Referral codes from shared links are persisted, auto-prefilled in the referral modal, and cleared after submit or skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->