### PR TITLE
feat(MobileDropdown): reset nested views on sheet close

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -246,6 +246,17 @@ export const MobileDropdown = ({
     if (currentView !== "history") clearTransactions();
   }, [currentView, clearTransactions]);
 
+  // Reset nested views when the sheet closes so reopening always starts on Wallet
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentView("wallet");
+      setSelectedEarnActivity(null);
+      setEarnActivityReturnView("wallet");
+      setSelectedTransaction(null);
+      setIsNetworkListOpen(false);
+    }
+  }, [isOpen]);
+
   const { client } = useSmartWallets();
 
   const showEarnUi = isEarnUiVisible(selectedNetwork.chain.name);


### PR DESCRIPTION
- Added a useEffect hook to reset the current view to "wallet" and clear selected activities when the dropdown sheet closes. This ensures a consistent starting point for users when reopening the dropdown.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed e.g closes #407
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile dropdown now properly resets and clears previous wallet selections, activities, and network choices when closed and reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->