### PR TITLE
fix(kyc): update transaction status filters to accurately reflect monthly spend limits

### DIFF
--- a/app/api/kyc/transaction-summary/route.ts
+++ b/app/api/kyc/transaction-summary/route.ts
@@ -56,8 +56,13 @@ export async function GET(request: NextRequest) {
       // Rate fetch failed — cNGN transactions will be excluded below
     }
 
-    const TRACKED_SWAP_CURRENCIES = ["USDC", "USDT", "cUSD", "cNGN"];
-    const STABLE_TO_CURRENCIES = ["USDC", "USDT", "cUSD"];
+    // Currency casing varies by source (e.g. "cNGN" vs "CNGN"), so rows are
+    // normalized to uppercase at fetch time and compared against uppercase
+    // constants — matching upper(...) in insert_swap_transaction_if_within_limit.
+    const normalizeCurrency = (value: unknown) =>
+      String(value ?? "").toUpperCase();
+    const TRACKED_SWAP_CURRENCIES = new Set(["USDC", "USDT", "CUSD", "CNGN"]);
+    const STABLE_TO_CURRENCIES = new Set(["USDC", "USDT", "CUSD"]);
     // Statuses that consume the monthly limit — keep in sync with
     // insert_swap_transaction_if_within_limit. Pending orders count because funds
     // are already committed; refunded/refunding/expired/failed rows do not.
@@ -71,7 +76,6 @@ export async function GET(request: NextRequest) {
       .eq("wallet_address", walletAddress)
       .eq("transaction_type", "offramp")
       .in("status", SPEND_STATUSES)
-      .in("from_currency", TRACKED_SWAP_CURRENCIES)
       .gte("created_at", monthStart.toISOString());
 
     const { data: onrampTransactions, error: onrampError } = await supabaseAdmin
@@ -86,13 +90,20 @@ export async function GET(request: NextRequest) {
 
     const error = swapError ?? onrampError;
     const transactions = [
-      ...(swapTransactions ?? []).map((tx) => ({
-        ...tx,
-        kind: "offramp" as const,
-      })),
+      // The tracked-currency filter lives here rather than in the query because
+      // PostgREST cannot compare a column case-insensitively in .in().
+      ...(swapTransactions ?? [])
+        .map((tx) => ({
+          ...tx,
+          kind: "offramp" as const,
+          from_currency: normalizeCurrency(tx.from_currency),
+        }))
+        .filter((tx) => TRACKED_SWAP_CURRENCIES.has(tx.from_currency)),
       ...(onrampTransactions ?? []).map((tx) => ({
         ...tx,
         kind: "onramp" as const,
+        from_currency: normalizeCurrency(tx.from_currency),
+        to_currency: normalizeCurrency(tx.to_currency),
       })),
     ];
 
@@ -109,8 +120,8 @@ export async function GET(request: NextRequest) {
     // the numbers for limit enforcement.
     const hasCngnTxs = transactions?.some(
       (tx) =>
-        tx.from_currency === "cNGN" ||
-        ("to_currency" in tx && tx.to_currency === "cNGN"),
+        tx.from_currency === "CNGN" ||
+        ("to_currency" in tx && tx.to_currency === "CNGN"),
     );
     if (hasCngnTxs && cngnToUsdRate === null) {
       trackApiError(
@@ -140,12 +151,11 @@ export async function GET(request: NextRequest) {
 
       let usdAmount: number;
       if (tx.kind === "onramp") {
-        const toCur = String(tx.to_currency ?? "").toUpperCase();
         const recv = parseFloat(String(tx.amount_received)) || 0;
         const sent = parseFloat(String(tx.amount_sent)) || 0;
-        if (STABLE_TO_CURRENCIES.includes(toCur)) {
+        if (STABLE_TO_CURRENCIES.has(tx.to_currency)) {
           usdAmount = recv;
-        } else if (toCur === "CNGN" && cngnToUsdRate) {
+        } else if (tx.to_currency === "CNGN" && cngnToUsdRate) {
           usdAmount = recv / cngnToUsdRate;
         } else if (cngnToUsdRate && sent > 0) {
           usdAmount = sent / cngnToUsdRate;
@@ -154,7 +164,7 @@ export async function GET(request: NextRequest) {
         }
       } else {
         const rawAmount = parseFloat(tx.amount_sent) || 0;
-        if (tx.from_currency === "cNGN") {
+        if (tx.from_currency === "CNGN") {
           usdAmount = rawAmount / cngnToUsdRate!;
         } else {
           usdAmount = rawAmount;

--- a/app/api/kyc/transaction-summary/route.ts
+++ b/app/api/kyc/transaction-summary/route.ts
@@ -58,13 +58,19 @@ export async function GET(request: NextRequest) {
 
     const TRACKED_SWAP_CURRENCIES = ["USDC", "USDT", "cUSD", "cNGN"];
     const STABLE_TO_CURRENCIES = ["USDC", "USDT", "cUSD"];
+    // Statuses that consume the monthly limit — keep in sync with
+    // insert_swap_transaction_if_within_limit. Pending orders count because funds
+    // are already committed; refunded/refunding/expired/failed rows do not.
+    // 'fulfilling' is legacy-only (the app maps the aggregator's "fulfilling" to
+    // 'pending') but is kept in case old rows carry it.
+    const SPEND_STATUSES = ["pending", "fulfilling", "fulfilled", "completed"];
 
     const { data: swapTransactions, error: swapError } = await supabaseAdmin
       .from("transactions")
       .select("amount_sent, from_currency, created_at")
       .eq("wallet_address", walletAddress)
       .eq("transaction_type", "offramp")
-      .in("status", ["fulfilling", "completed"])
+      .in("status", SPEND_STATUSES)
       .in("from_currency", TRACKED_SWAP_CURRENCIES)
       .gte("created_at", monthStart.toISOString());
 
@@ -75,7 +81,7 @@ export async function GET(request: NextRequest) {
       )
       .eq("wallet_address", walletAddress)
       .eq("transaction_type", "onramp")
-      .in("status", ["pending", "fulfilling", "completed"])
+      .in("status", SPEND_STATUSES)
       .gte("created_at", monthStart.toISOString());
 
     const error = swapError ?? onrampError;

--- a/app/api/referral/claim/route.ts
+++ b/app/api/referral/claim/route.ts
@@ -35,11 +35,10 @@ type QualificationResult =
   | { ok: true; totalUsd: number }
   | { ok: false; code: string; message: string };
 
-const USD_STABLE = new Set(["USDC", "USDT"]);
-const CNGN_SYMBOLS = new Set(["cNGN", "CNGN"]);
-// Onramp rows store the fiat currency in from_currency and the token in to_currency,
-// so their USD value comes from the receive side (mirrors /api/kyc/transaction-summary).
-const ONRAMP_USD_STABLE_TO = new Set(["USDC", "USDT", "CUSD"]);
+// Currency casing varies by source (e.g. "cNGN" vs "CNGN"), so rows are
+// normalized to uppercase at fetch time and compared against uppercase constants.
+const normalizeCurrency = (value: unknown) => String(value ?? "").toUpperCase();
+const USD_STABLE = new Set(["USDC", "USDT", "CUSD"]);
 
 type QualificationSubject = "claimant" | "referee";
 
@@ -92,19 +91,25 @@ async function checkPartyQualification(
     };
   }
 
-  const txList = (volTxs || []) as Array<{
-    amount_sent: string | number;
-    amount_received: string | number | null;
-    from_currency: string;
-    to_currency: string | null;
-    transaction_type: string;
-  }>;
+  const txList = (
+    (volTxs || []) as Array<{
+      amount_sent: string | number;
+      amount_received: string | number | null;
+      from_currency: string;
+      to_currency: string | null;
+      transaction_type: string;
+    }>
+  ).map((tx) => ({
+    ...tx,
+    from_currency: normalizeCurrency(tx.from_currency),
+    to_currency: normalizeCurrency(tx.to_currency),
+  }));
   // The NGN rate is needed for cNGN legs and for onramps whose USD value must be
   // derived from the fiat amount sent (onramp from_currency is fiat, e.g. NGN).
   const needsNgnRate = txList.some((tx) =>
     tx.transaction_type === "onramp"
-      ? !ONRAMP_USD_STABLE_TO.has((tx.to_currency ?? "").toUpperCase())
-      : CNGN_SYMBOLS.has(tx.from_currency),
+      ? !USD_STABLE.has(tx.to_currency)
+      : tx.from_currency === "CNGN",
   );
 
   let ngnPerUsd: number | null = null;
@@ -134,12 +139,14 @@ async function checkPartyQualification(
   const totalUsd = txList.reduce((sum, tx) => {
     const amount = Number(tx.amount_sent ?? 0);
     if (tx.transaction_type === "onramp") {
-      const toCur = (tx.to_currency ?? "").toUpperCase();
+      // Onramp rows store the fiat currency in from_currency and the token in
+      // to_currency, so their USD value comes from the receive side (mirrors
+      // /api/kyc/transaction-summary).
       const received = Number(tx.amount_received ?? 0);
-      if (ONRAMP_USD_STABLE_TO.has(toCur)) {
+      if (USD_STABLE.has(tx.to_currency)) {
         return sum + received;
       }
-      if (toCur === "CNGN" && ngnPerUsd && ngnPerUsd > 0) {
+      if (tx.to_currency === "CNGN" && ngnPerUsd && ngnPerUsd > 0) {
         return sum + received / ngnPerUsd;
       }
       // Non-stable receive leg: fall back to the fiat amount sent (NGN).
@@ -151,7 +158,7 @@ async function checkPartyQualification(
     if (USD_STABLE.has(tx.from_currency)) {
       return sum + amount;
     }
-    if (CNGN_SYMBOLS.has(tx.from_currency) && ngnPerUsd && ngnPerUsd > 0) {
+    if (tx.from_currency === "CNGN" && ngnPerUsd && ngnPerUsd > 0) {
       return sum + amount / ngnPerUsd;
     }
     return sum;

--- a/app/api/referral/claim/route.ts
+++ b/app/api/referral/claim/route.ts
@@ -37,6 +37,9 @@ type QualificationResult =
 
 const USD_STABLE = new Set(["USDC", "USDT"]);
 const CNGN_SYMBOLS = new Set(["cNGN", "CNGN"]);
+// Onramp rows store the fiat currency in from_currency and the token in to_currency,
+// so their USD value comes from the receive side (mirrors /api/kyc/transaction-summary).
+const ONRAMP_USD_STABLE_TO = new Set(["USDC", "USDT", "CUSD"]);
 
 type QualificationSubject = "claimant" | "referee";
 
@@ -74,7 +77,9 @@ async function checkPartyQualification(
 
   const { data: volTxs, error: volTxError } = await supabaseAdmin
     .from("transactions")
-    .select("amount_sent, from_currency")
+    .select(
+      "amount_sent, amount_received, from_currency, to_currency, transaction_type",
+    )
     .eq("wallet_address", qualifyingWallet)
     .eq("status", "completed")
     .gte("created_at", referralCreatedAt);
@@ -89,12 +94,21 @@ async function checkPartyQualification(
 
   const txList = (volTxs || []) as Array<{
     amount_sent: string | number;
+    amount_received: string | number | null;
     from_currency: string;
+    to_currency: string | null;
+    transaction_type: string;
   }>;
-  const hasCngn = txList.some((tx) => CNGN_SYMBOLS.has(tx.from_currency));
+  // The NGN rate is needed for cNGN legs and for onramps whose USD value must be
+  // derived from the fiat amount sent (onramp from_currency is fiat, e.g. NGN).
+  const needsNgnRate = txList.some((tx) =>
+    tx.transaction_type === "onramp"
+      ? !ONRAMP_USD_STABLE_TO.has((tx.to_currency ?? "").toUpperCase())
+      : CNGN_SYMBOLS.has(tx.from_currency),
+  );
 
   let ngnPerUsd: number | null = null;
-  if (hasCngn) {
+  if (needsNgnRate) {
     try {
       const rateUrl = `${process.env.NEXT_PUBLIC_AGGREGATOR_URL}/rates/USDC/1/NGN`;
       const rateRes = await fetch(rateUrl, { signal: AbortSignal.timeout(5000) });
@@ -119,6 +133,21 @@ async function checkPartyQualification(
 
   const totalUsd = txList.reduce((sum, tx) => {
     const amount = Number(tx.amount_sent ?? 0);
+    if (tx.transaction_type === "onramp") {
+      const toCur = (tx.to_currency ?? "").toUpperCase();
+      const received = Number(tx.amount_received ?? 0);
+      if (ONRAMP_USD_STABLE_TO.has(toCur)) {
+        return sum + received;
+      }
+      if (toCur === "CNGN" && ngnPerUsd && ngnPerUsd > 0) {
+        return sum + received / ngnPerUsd;
+      }
+      // Non-stable receive leg: fall back to the fiat amount sent (NGN).
+      if (ngnPerUsd && ngnPerUsd > 0 && amount > 0) {
+        return sum + amount / ngnPerUsd;
+      }
+      return sum;
+    }
     if (USD_STABLE.has(tx.from_currency)) {
       return sum + amount;
     }

--- a/app/components/EarnConsentModal.tsx
+++ b/app/components/EarnConsentModal.tsx
@@ -67,7 +67,7 @@ export const EarnConsentModal: React.FC<EarnConsentModalProps> = ({
               className="w-full"
             >
               <DialogPanel
-                className="relative mx-auto flex w-full flex-col overflow-hidden rounded-t-[30px] bg-white text-sm dark:bg-surface-overlay max-h-[90dvh] sm:max-h-[90vh] sm:rounded-3xl"
+                className="relative mx-auto flex w-full flex-col overflow-hidden rounded-t-[30px] bg-white text-sm dark:bg-surface-overlay max-h-[85vh] supports-[height:100dvh]:max-h-[90dvh] sm:max-h-[90vh] sm:rounded-3xl"
                 style={{
                   maxWidth:
                     typeof window !== "undefined" && window.innerWidth > 640

--- a/app/components/KycModal.tsx
+++ b/app/components/KycModal.tsx
@@ -671,7 +671,7 @@ export const KycModal = ({
   );
 
   const renderCapture = () => (
-    <motion.div key="capture" {...fadeInOut} className="flex flex-col py-4" style={{ maxHeight: "min(90dvh, 48rem)" }}>
+    <motion.div key="capture" {...fadeInOut} className="flex flex-col py-4 max-h-[min(85vh,48rem)] supports-[height:100dvh]:max-h-[min(90dvh,48rem)]">
       <div className="space-y-3">
         <div className="flex items-center justify-between">
         <UserDetailsIcon />

--- a/supabase/migrations/20260612130000_fix_kyc_limit_status_filters.sql
+++ b/supabase/migrations/20260612130000_fix_kyc_limit_status_filters.sql
@@ -1,0 +1,193 @@
+-- ─── Fix KYC limit enforcement status filters ─────────────────────────────────
+--
+-- Bug: offramp spend was counted only for status IN ('fulfilling', 'completed'),
+-- but the app never writes 'fulfilling' — mapAggregatorStatusToDbStatus maps the
+-- aggregator's "fulfilling" to 'pending' and "fulfilled" to 'fulfilled'. An offramp
+-- therefore contributed $0 to monthly spend until the client-side poller persisted
+-- a terminal 'completed', letting a follow-up onramp bypass the monthly limit.
+--
+-- Fix:
+--   1. Count offramp spend for status IN ('pending', 'fulfilling', 'fulfilled',
+--      'completed') — once an offramp order is created on-chain the funds are
+--      committed, so pending orders must consume the limit. Refunded / refunding /
+--      expired / failed rows stop counting as soon as that status is persisted.
+--   2. Add 'fulfilled' to the onramp spend statuses for the same reason.
+--   3. Relax the transactions.status CHECK constraint to the statuses the app
+--      actually writes ('fulfilled', 'refunded', 'refunding', 'expired' were
+--      missing), so status updates no longer violate the constraint.
+--
+-- Keep /api/kyc/transaction-summary in sync with the status lists below.
+
+ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_status_check;
+ALTER TABLE transactions ADD CONSTRAINT transactions_status_check CHECK (
+    status IN (
+        'pending',
+        'fulfilling',
+        'fulfilled',
+        'completed',
+        'failed',
+        'refunded',
+        'refunding',
+        'expired'
+    )
+);
+
+-- ─── insert_swap_transaction_if_within_limit ──────────────────────────────────
+-- Atomically checks monthly KYC spend (onramp + offramp) and optionally inserts.
+-- Returns { "id": uuid } | { "ok": true } (dry_run) | { "error": ... }.
+
+CREATE OR REPLACE FUNCTION public.insert_swap_transaction_if_within_limit(
+  p_wallet_address   TEXT,
+  p_monthly_limit    NUMERIC,
+  p_cngn_to_usd_rate NUMERIC,
+  p_transaction_type TEXT,
+  p_from_currency    TEXT,
+  p_to_currency      TEXT,
+  p_amount_sent      NUMERIC,
+  p_amount_received  NUMERIC,
+  p_fee              NUMERIC,
+  p_recipient        JSONB,
+  p_status           TEXT,
+  p_network          TEXT DEFAULT NULL,
+  p_time_spent       TEXT DEFAULT NULL,
+  p_tx_hash          TEXT DEFAULT NULL,
+  p_order_id         TEXT DEFAULT NULL,
+  p_email            TEXT DEFAULT NULL,
+  p_explorer_link    TEXT DEFAULT NULL,
+  p_dry_run          BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_monthly_spent       NUMERIC := 0;
+  v_offramp_spent       NUMERIC := 0;
+  v_onramp_spent        NUMERIC := 0;
+  v_this_tx_usd         NUMERIC;
+  v_new_id              UUID;
+  v_month_start         TIMESTAMPTZ;
+  v_has_cngn_history    BOOLEAN;
+  v_needs_fiat_rate     BOOLEAN;
+  v_stable_to           TEXT[] := ARRAY['USDC', 'USDT', 'CUSD'];
+  -- Statuses that consume the monthly limit: anything in-flight or settled.
+  -- 'fulfilling' is legacy-only (the app maps the aggregator's "fulfilling"
+  -- to 'pending') but is kept in case old rows carry it.
+  v_spend_statuses      TEXT[] := ARRAY['pending', 'fulfilling', 'fulfilled', 'completed'];
+BEGIN
+  PERFORM set_config('search_path', 'public', true);
+
+  PERFORM pg_advisory_xact_lock(hashtext(p_wallet_address));
+
+  v_month_start := date_trunc('month', now() AT TIME ZONE 'UTC');
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM transactions
+    WHERE wallet_address   = p_wallet_address
+      AND transaction_type = 'offramp'
+      AND status           = ANY (v_spend_statuses)
+      AND upper(coalesce(from_currency, '')) = 'CNGN'
+      AND created_at       >= v_month_start
+  ) INTO v_has_cngn_history;
+
+  v_needs_fiat_rate := (
+    v_has_cngn_history
+    OR upper(coalesce(p_from_currency, '')) = 'CNGN'
+    OR upper(coalesce(p_to_currency, '')) = 'CNGN'
+    OR EXISTS (
+      SELECT 1
+      FROM transactions
+      WHERE wallet_address   = p_wallet_address
+        AND transaction_type = 'onramp'
+        AND status           = ANY (v_spend_statuses)
+        AND created_at       >= v_month_start
+        AND upper(coalesce(to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+    )
+    OR (
+      p_transaction_type = 'onramp'
+      AND upper(coalesce(p_to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+    )
+  );
+
+  IF v_needs_fiat_rate AND (p_cngn_to_usd_rate IS NULL OR p_cngn_to_usd_rate <= 0) THEN
+    RETURN jsonb_build_object('error', 'rate_unavailable');
+  END IF;
+
+  SELECT COALESCE(SUM(
+    CASE
+      WHEN upper(coalesce(from_currency, '')) = 'CNGN' THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+      ELSE amount_sent::NUMERIC
+    END
+  ), 0)
+  INTO v_offramp_spent
+  FROM transactions
+  WHERE wallet_address   = p_wallet_address
+    AND transaction_type = 'offramp'
+    AND status           = ANY (v_spend_statuses)
+    AND upper(coalesce(from_currency, '')) IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+    AND created_at       >= v_month_start;
+
+  SELECT COALESCE(SUM(
+    CASE
+      WHEN upper(coalesce(to_currency, '')) = ANY (v_stable_to) THEN amount_received::NUMERIC
+      WHEN upper(coalesce(to_currency, '')) = 'CNGN' THEN amount_received::NUMERIC / p_cngn_to_usd_rate
+      WHEN upper(coalesce(from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+        THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+      ELSE amount_received::NUMERIC
+    END
+  ), 0)
+  INTO v_onramp_spent
+  FROM transactions
+  WHERE wallet_address   = p_wallet_address
+    AND transaction_type = 'onramp'
+    AND status           = ANY (v_spend_statuses)
+    AND created_at       >= v_month_start;
+
+  v_monthly_spent := v_offramp_spent + v_onramp_spent;
+
+  IF p_transaction_type = 'onramp' THEN
+    IF upper(coalesce(p_to_currency, '')) = ANY (v_stable_to) THEN
+      v_this_tx_usd := p_amount_received;
+    ELSIF upper(coalesce(p_to_currency, '')) = 'CNGN' THEN
+      v_this_tx_usd := p_amount_received / p_cngn_to_usd_rate;
+    ELSIF upper(coalesce(p_from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN') THEN
+      v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+    ELSE
+      v_this_tx_usd := p_amount_received;
+    END IF;
+  ELSIF upper(coalesce(p_from_currency, '')) = 'CNGN' THEN
+    v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+  ELSE
+    v_this_tx_usd := p_amount_sent;
+  END IF;
+
+  IF v_monthly_spent + v_this_tx_usd > p_monthly_limit THEN
+    RETURN jsonb_build_object(
+      'error',         'limit_exceeded',
+      'monthly_spent', v_monthly_spent,
+      'this_tx_usd',   v_this_tx_usd,
+      'monthly_limit', p_monthly_limit
+    );
+  END IF;
+
+  IF COALESCE(p_dry_run, FALSE) THEN
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  INSERT INTO transactions (
+    wallet_address, transaction_type, from_currency, to_currency,
+    amount_sent, amount_received, fee, recipient, status, network,
+    time_spent, tx_hash, order_id, email, explorer_link
+  ) VALUES (
+    p_wallet_address, p_transaction_type, p_from_currency, p_to_currency,
+    p_amount_sent, p_amount_received, p_fee, p_recipient, p_status, p_network,
+    p_time_spent, p_tx_hash, p_order_id, p_email, p_explorer_link
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object('id', v_new_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.insert_swap_transaction_if_within_limit TO service_role;


### PR DESCRIPTION




### Description

- Adjusted the status filters for offramp and onramp transactions to include 'pending', 'fulfilling', 'fulfilled', and 'completed' statuses, ensuring that all relevant transactions contribute to the monthly spend limit.
- Updated the SQL migration to relax the transactions.status CHECK constraint, allowing for accurate status updates without constraint violations.
- Enhanced the logic in the transaction summary API to align with the new status definitions, improving the accuracy of spend calculations.

### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction counting now includes pending/fulfilling/fulfilled/completed states for spend totals.
  * KYC monthly spend enforcement improved to correctly include onramp/offramp activity.
  * Referral qualification now accounts for onramp receives and treats CUSD as USD-stable.
  * Currency normalization and CNGN handling improved; USD conversions updated and endpoints may return a partial 503 if a required CNGN→USD rate is missing.

* **UI Improvements**
  * Modal height behavior refined for better responsiveness across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->