### PR TITLE
feat(login): implement body scroll pinning during Privy login flow

### DIFF
--- a/app/components/AnimatedComponents.tsx
+++ b/app/components/AnimatedComponents.tsx
@@ -301,9 +301,12 @@ type AnimatedModalProps = {
   /**
    * Pin the document body (position: fixed at the current offset) while the
    * modal is open, so nothing can displace the page scroll behind it — e.g.
-   * the SmileID camera in KycModal used to drag the document to the bottom.
+   * the SmileID camera in KycModal and Privy's login-time wallet iframe both
+   * dragged the document to the bottom behind open modals on mobile.
    * Released after the exit animation completes; the page never visibly moves,
    * unlike the previous restore-on-close approach which jumped after the fact.
+   * Defaults to true so no modal can forget it; pass false only when a modal
+   * genuinely needs the page behind it to stay scrollable.
    */
   lockBodyScroll?: boolean;
 };
@@ -328,7 +331,7 @@ let bodyScrollLockPrevStyles: {
   width: string;
 } | null = null;
 
-function acquireBodyScrollLock(): void {
+export function acquireBodyScrollLock(): void {
   if (typeof window === "undefined") return;
   if (bodyScrollLockCount === 0) {
     bodyScrollLockY = window.scrollY;
@@ -349,7 +352,7 @@ function acquireBodyScrollLock(): void {
   bodyScrollLockCount++;
 }
 
-function releaseBodyScrollLock(): void {
+export function releaseBodyScrollLock(): void {
   if (typeof window === "undefined" || bodyScrollLockCount === 0) return;
   bodyScrollLockCount--;
   if (bodyScrollLockCount === 0) {
@@ -405,7 +408,7 @@ export const AnimatedModal = ({
   contentClassName,
   showGradientHeader = false,
   backgroundImagePath,
-  lockBodyScroll = false,
+  lockBodyScroll = true,
 }: AnimatedModalProps) => {
   const holdsLockRef = useRef(false);
 

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -452,21 +452,21 @@ export const MobileDropdown = ({
                 </motion.div>
               </div>
             </div>
+
+            <EarnConsentModal
+              isOpen={isEarnConsentModalOpen}
+              onClose={dismissEarnConsent}
+              onAccepted={() => handleEarnConsentAccepted(onEarnAccessAction)}
+            />
+
+            <CopyAddressWarningModal
+              isOpen={isWarningModalOpen}
+              onClose={() => setIsWarningModalOpen(false)}
+              address={walletForCopy?.address ?? ""}
+            />
           </Dialog>
         )}
       </AnimatePresence>
-
-      <EarnConsentModal
-        isOpen={isEarnConsentModalOpen}
-        onClose={dismissEarnConsent}
-        onAccepted={() => handleEarnConsentAccepted(onEarnAccessAction)}
-      />
-
-      <CopyAddressWarningModal
-        isOpen={isWarningModalOpen}
-        onClose={() => setIsWarningModalOpen(false)}
-        address={walletForCopy?.address ?? ""}
-      />
 
       <WalletMigrationModal
         isOpen={isMigrationModalOpen}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -27,6 +27,7 @@ import Image from "next/image";
 import { useNetwork } from "../context/NetworksContext";
 import { useInjectedWallet } from "../context";
 import { useActualTheme } from "../hooks/useActualTheme";
+import { useLoginWithScrollPin } from "../hooks/useLoginWithScrollPin";
 import { clearNetworkModalSeen } from "../lib/networkModalStore";
 import { useWallets } from "@privy-io/react-auth";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
@@ -94,6 +95,10 @@ export const Navbar = () => {
       }
     },
   });
+
+  // Pin body scroll while the Privy dialog is up — its end-of-body iframe
+  // steals focus on mobile and drags the page to the bottom otherwise.
+  const loginWithScrollPin = useLoginWithScrollPin(login);
 
   useEffect(() => {
     setMounted(true);
@@ -322,7 +327,7 @@ export const Navbar = () => {
               <button
                 type="button"
                 className={`${baseBtnClasses} min-h-9 bg-lavender-50 text-lavender-500 hover:bg-lavender-100 dark:bg-lavender-500/[12%] dark:text-lavender-500 dark:hover:bg-lavender-500/[20%]`}
-                onClick={() => login()}
+                onClick={() => loginWithScrollPin()}
               >
                 Sign in
               </button>

--- a/app/hooks/useLoginWithScrollPin.ts
+++ b/app/hooks/useLoginWithScrollPin.ts
@@ -43,7 +43,10 @@ export function useLoginWithScrollPin(login: () => void): () => void {
   useEffect(() => release, [release]);
 
   return useCallback(() => {
-    if (typeof window !== "undefined" && !holdsLockRef.current) {
+    // In-flight guard: while the pin is held the login flow is already under
+    // way, so don't fire login() again on rapid repeat taps.
+    if (holdsLockRef.current) return;
+    if (typeof window !== "undefined") {
       holdsLockRef.current = true;
       acquireBodyScrollLock();
 
@@ -68,6 +71,11 @@ export function useLoginWithScrollPin(login: () => void): () => void {
         if (!dialogSeen) release();
       }, DIALOG_APPEAR_TIMEOUT_MS);
     }
-    login();
+    try {
+      login();
+    } catch (error) {
+      release();
+      throw error;
+    }
   }, [login, release]);
 }

--- a/app/hooks/useLoginWithScrollPin.ts
+++ b/app/hooks/useLoginWithScrollPin.ts
@@ -1,0 +1,73 @@
+"use client";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  acquireBodyScrollLock,
+  releaseBodyScrollLock,
+} from "../components/AnimatedComponents";
+
+/** Privy's dialog root — verified against @privy-io/react-auth dist (id:"privy-dialog"). */
+const PRIVY_DIALOG_ID = "privy-dialog";
+/** If the dialog never mounts (e.g. instant OAuth redirect), unpin after this. */
+const DIALOG_APPEAR_TIMEOUT_MS = 5000;
+
+/**
+ * Wraps Privy's login() so the document body stays pinned for the whole login
+ * flow. Privy mounts companion iframes at the end of <body>; when one takes
+ * focus on mobile the browser scrolls the document to the bottom behind the
+ * (position: fixed) login dialog. AnimatedModal's lock can't cover this — the
+ * displacement happens before any app modal exists — so the pin is acquired
+ * here, before the dialog opens, and released when #privy-dialog leaves the
+ * DOM (login success or dismissal). Uses the same refcounted body lock as
+ * AnimatedModal, so a post-login modal taking its own lock keeps the body
+ * pinned continuously with no visible jump.
+ */
+export function useLoginWithScrollPin(login: () => void): () => void {
+  const holdsLockRef = useRef(false);
+  const observerRef = useRef<MutationObserver | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const release = useCallback(() => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (holdsLockRef.current) {
+      holdsLockRef.current = false;
+      releaseBodyScrollLock();
+    }
+  }, []);
+
+  // Unmount safety net — never leave the body pinned with no one to release it.
+  useEffect(() => release, [release]);
+
+  return useCallback(() => {
+    if (typeof window !== "undefined" && !holdsLockRef.current) {
+      holdsLockRef.current = true;
+      acquireBodyScrollLock();
+
+      let dialogSeen = false;
+      const check = () => {
+        if (document.getElementById(PRIVY_DIALOG_ID)) {
+          dialogSeen = true;
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+          }
+        } else if (dialogSeen) {
+          release();
+        }
+      };
+      observerRef.current = new MutationObserver(check);
+      observerRef.current.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+      timeoutRef.current = setTimeout(() => {
+        if (!dialogSeen) release();
+      }, DIALOG_APPEAR_TIMEOUT_MS);
+    }
+    login();
+  }, [login, release]);
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -39,6 +39,7 @@ import {
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
 import { useWalletAddress } from "../hooks/useWalletAddress";
+import { useLoginWithScrollPin } from "../hooks/useLoginWithScrollPin";
 import { useCNGNRate } from "../hooks/useCNGNRate";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useShouldUseEOA, useWalletMigrationStatus } from "../hooks/useEIP7702Account";
@@ -99,6 +100,9 @@ export const TransactionForm = ({
   // Destructure stateProps
   const { rate, isFetchingRate, setOrderId } = stateProps;
   const { authenticated, ready, login, user } = usePrivy();
+  // Pin body scroll while the Privy dialog is up — its end-of-body iframe
+  // steals focus on mobile and drags the page to the bottom otherwise.
+  const loginWithScrollPin = useLoginWithScrollPin(login);
   const { wallets } = useWallets();
   const { selectedNetwork } = useNetwork();
   const { smartWalletBalance, externalWalletBalance, injectedWalletBalance, isLoading } = useBalance();
@@ -1308,7 +1312,7 @@ export const TransactionForm = ({
               disabled={!isEnabled}
               onClick={buttonAction(
                 handleSwap,
-                login,
+                loginWithScrollPin,
                 () =>
                   handleFundWallet(
                     activeWallet?.address ?? "",


### PR DESCRIPTION

### Description

- Introduced a new hook, useLoginWithScrollPin, to manage body scroll locking while the Privy login dialog is active, preventing unwanted scrolling on mobile devices.
- Updated AnimatedModal to default lockBodyScroll to true, ensuring modals maintain scroll lock by default.
- Refactored Navbar and TransactionForm components to utilize the new loginWithScrollPin function for improved user experience during login.


### References



### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login/auth dialog now pins page scrolling while open, improving focus during authentication.
  * Body-scroll control utilities are exposed for reuse across the app.

* **Bug Fixes**
  * Modals and certain dialogs now mount inside their parent sheets to fix stacking and lifecycle issues.
  * Default behavior updated so modals pin body scroll when opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->