### PR TITLE
feat(kyc): implement unlimited monthly limit for tier 3 KYC users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ NEXT_PUBLIC_LOCAL_TRANSFER_FEE_PERCENT=0.1
 NEXT_PUBLIC_LOCAL_TRANSFER_FEE_CAP=10000
 
 # KYC tier monthly swap limits (USD). Omitted or empty = defaults below.
+# Tier 3 also accepts "unlimited" (case-insensitive) to remove the monthly cap.
+# Do not use 0 for unlimited — tier 0 uses 0 to mean "no swaps until phone".
 NEXT_PUBLIC_KYC_TIER_0_MONTHLY=0
 NEXT_PUBLIC_KYC_TIER_1_MONTHLY=0.5
 NEXT_PUBLIC_KYC_TIER_2_MONTHLY=1

--- a/app/components/KycModal.tsx
+++ b/app/components/KycModal.tsx
@@ -930,7 +930,9 @@ export const KycModal = ({
                 Monthly limit{" "}
               </p>
               <span className="text-xl font-normal text-neutral-900 dark:text-white">
-                ${formatNumberWithCommas(tier3Limits.limits.monthly)}
+                {tier3Limits.limits.unlimited
+                  ? "Unlimited"
+                  : `$${formatNumberWithCommas(tier3Limits.limits.monthly)}`}
               </span>
             </div>
           </div>

--- a/app/components/ProfileDrawer.tsx
+++ b/app/components/ProfileDrawer.tsx
@@ -400,19 +400,23 @@ export default function ProfileDrawer({ isOpen, onClose }: ProfileDrawerProps) {
                               <div className="text-2xl font-light text-text-body dark:text-white">
                                 $
                                 {formatUsdAmount(transactionSummary.monthlySpent)}{" "}
-                                / $
-                                {formatUsdAmount(currentLimits.monthly)}
+                                /{" "}
+                                {currentLimits.unlimited
+                                  ? "Unlimited"
+                                  : `$${formatUsdAmount(currentLimits.monthly)}`}
                               </div>
 
-                              {/* Progress Bar */}
-                              <div className="flex h-2 w-full items-center rounded-full bg-gray-300 dark:bg-white/10">
-                                <div
-                                  className="h-2.5 rounded-full bg-gradient-to-r from-lavender-300 to-lavender-600 transition-all duration-500 dark:from-lavender-400 dark:to-lavender-600"
-                                  style={{
-                                    width: `${Math.min(monthlyProgress, 100)}%`,
-                                  }}
-                                />
-                              </div>
+                              {/* Progress Bar — unlimited tiers have no cap to fill */}
+                              {!currentLimits.unlimited && (
+                                <div className="flex h-2 w-full items-center rounded-full bg-gray-300 dark:bg-white/10">
+                                  <div
+                                    className="h-2.5 rounded-full bg-gradient-to-r from-lavender-300 to-lavender-600 transition-all duration-500 dark:from-lavender-400 dark:to-lavender-600"
+                                    style={{
+                                      width: `${Math.min(monthlyProgress, 100)}%`,
+                                    }}
+                                  />
+                                </div>
+                              )}
                             </div>
 
                             {/* Upgrade Button */}

--- a/app/context/KYCContext.tsx
+++ b/app/context/KYCContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
 } from "react";
 import { useWallets, usePrivy } from "@privy-io/react-auth";
-import { getKycMonthlyLimitsRecord } from "@/app/lib/kyc-tier-limits";
+import { getKycTierLimit } from "@/app/lib/kyc-tier-limits";
 
 export interface TransactionLimits {
   monthly: number;
@@ -24,32 +24,30 @@ export interface KYCTier {
   requirements: string[];
 }
 
-const kycMonthlyLimits = getKycMonthlyLimitsRecord();
-
 /** Product tiers: 0 = unverified (no swaps until phone), 1 = phone, 2 = ID, 3 = address. */
 export const KYC_TIERS: Record<number, KYCTier> = {
   0: {
     level: 0,
     name: "Unverified",
-    limits: { monthly: kycMonthlyLimits[0] },
+    limits: { ...getKycTierLimit(0) },
     requirements: [],
   },
   1: {
     level: 1,
     name: "Phone",
-    limits: { monthly: kycMonthlyLimits[1] },
+    limits: { ...getKycTierLimit(1) },
     requirements: ["Phone number"],
   },
   2: {
     level: 2,
     name: "ID",
-    limits: { monthly: kycMonthlyLimits[2] },
+    limits: { ...getKycTierLimit(2) },
     requirements: ["Government ID", "Selfie verification"],
   },
   3: {
     level: 3,
     name: "Address",
-    limits: { monthly: kycMonthlyLimits[3] },
+    limits: { ...getKycTierLimit(3) },
     requirements: ["Address verification"],
   },
 };

--- a/app/lib/kyc-tier-limits.ts
+++ b/app/lib/kyc-tier-limits.ts
@@ -1,6 +1,10 @@
 /**
  * KYC tier monthly spend limits (USD). Used by the client (NEXT_PUBLIC_*) and API route.
  * Tier 0 = unverified (no monthly spend until phone). Tier 1 = phone, 2 = ID, 3 = address.
+ *
+ * Tier 3 additionally accepts the sentinel string "unlimited" (case-insensitive) in
+ * NEXT_PUBLIC_KYC_TIER_3_MONTHLY to remove the monthly cap entirely. Tiers 0–2 remain
+ * numeric-only. Do NOT use 0 for unlimited — tier 0 uses 0 to mean "no swaps until phone".
  */
 const DEFAULT_KYC_MONTHLY_LIMITS: Record<number, number> = {
   0: 0,
@@ -8,6 +12,12 @@ const DEFAULT_KYC_MONTHLY_LIMITS: Record<number, number> = {
   2: 1,
   3: 2,
 };
+
+/** Resolved limit for a tier. When `unlimited` is true, `monthly` is 0 and must be ignored. */
+export interface KycTierLimit {
+  monthly: number;
+  unlimited: boolean;
+}
 
 function parseNonNegativeNumber(value: string | undefined, fallback: number): number {
   if (value === undefined || value === "") {
@@ -20,24 +30,74 @@ function parseNonNegativeNumber(value: string | undefined, fallback: number): nu
   return n;
 }
 
-/** Monthly USD limits per tier (0–3). Env: NEXT_PUBLIC_KYC_TIER_{n}_MONTHLY */
+/** True when a tier-3 env value is the "unlimited" sentinel (trimmed, case-insensitive). */
+export function isUnlimitedTier3EnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().toLowerCase() === "unlimited";
+}
+
+/**
+ * Tier-3-specific parser. Accepts the "unlimited" sentinel or a non-negative number.
+ * Invalid/empty values fall back to the default tier-3 cap.
+ */
+export function parseTier3MonthlyLimit(raw: string | undefined): KycTierLimit {
+  if (isUnlimitedTier3EnvValue(raw)) {
+    return { monthly: 0, unlimited: true };
+  }
+  return {
+    monthly: parseNonNegativeNumber(raw, DEFAULT_KYC_MONTHLY_LIMITS[3]),
+    unlimited: false,
+  };
+}
+
+/**
+ * Per-tier limit config. Tiers 0–2 are numeric-only; tier 3 may be unlimited.
+ * Prefer this over getKycMonthlyLimitsRecord() — callers must honor `unlimited`.
+ */
+export function getKycTierLimit(tier: number): KycTierLimit {
+  switch (tier) {
+    case 0:
+      return {
+        monthly: parseNonNegativeNumber(
+          process.env.NEXT_PUBLIC_KYC_TIER_0_MONTHLY,
+          DEFAULT_KYC_MONTHLY_LIMITS[0],
+        ),
+        unlimited: false,
+      };
+    case 1:
+      return {
+        monthly: parseNonNegativeNumber(
+          process.env.NEXT_PUBLIC_KYC_TIER_1_MONTHLY,
+          DEFAULT_KYC_MONTHLY_LIMITS[1],
+        ),
+        unlimited: false,
+      };
+    case 2:
+      return {
+        monthly: parseNonNegativeNumber(
+          process.env.NEXT_PUBLIC_KYC_TIER_2_MONTHLY,
+          DEFAULT_KYC_MONTHLY_LIMITS[2],
+        ),
+        unlimited: false,
+      };
+    case 3:
+      return parseTier3MonthlyLimit(process.env.NEXT_PUBLIC_KYC_TIER_3_MONTHLY);
+    default:
+      return { monthly: 0, unlimited: false };
+  }
+}
+
+/**
+ * Monthly USD limits per tier (0–3), numeric only. Env: NEXT_PUBLIC_KYC_TIER_{n}_MONTHLY.
+ *
+ * Backward-compat shim for legacy callers that only need a number. An unlimited tier 3
+ * collapses to `monthly: 0` here, which is indistinguishable from "no limit configured" —
+ * consumers that must respect unlimited should call getKycTierLimit() and check `.unlimited`.
+ */
 export function getKycMonthlyLimitsRecord(): Record<number, number> {
   return {
-    0: parseNonNegativeNumber(
-      process.env.NEXT_PUBLIC_KYC_TIER_0_MONTHLY,
-      DEFAULT_KYC_MONTHLY_LIMITS[0],
-    ),
-    1: parseNonNegativeNumber(
-      process.env.NEXT_PUBLIC_KYC_TIER_1_MONTHLY,
-      DEFAULT_KYC_MONTHLY_LIMITS[1],
-    ),
-    2: parseNonNegativeNumber(
-      process.env.NEXT_PUBLIC_KYC_TIER_2_MONTHLY,
-      DEFAULT_KYC_MONTHLY_LIMITS[2],
-    ),
-    3: parseNonNegativeNumber(
-      process.env.NEXT_PUBLIC_KYC_TIER_3_MONTHLY,
-      DEFAULT_KYC_MONTHLY_LIMITS[3],
-    ),
+    0: getKycTierLimit(0).monthly,
+    1: getKycTierLimit(1).monthly,
+    2: getKycTierLimit(2).monthly,
+    3: getKycTierLimit(3).monthly,
   };
 }

--- a/app/lib/swap-transaction-limit-server.ts
+++ b/app/lib/swap-transaction-limit-server.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
-import { getKycMonthlyLimitsRecord } from "@/app/lib/kyc-tier-limits";
+import { getKycTierLimit } from "@/app/lib/kyc-tier-limits";
 import { collectLinkedEvmAddressesForPrivyUserId } from "@/app/lib/privy";
 
 export type SwapLimitRpcBody = {
@@ -106,7 +106,6 @@ export async function executeSwapTransactionLimitCheck(
     normalizedEmail: string | null;
   },
 ): Promise<SwapLimitCheckResult> {
-  const KYC_MONTHLY_LIMITS = getKycMonthlyLimitsRecord();
   const kycWalletAddress = normalizedBodyWalletAddress;
 
   const { data: kycProfile, error: kycError } = await supabaseAdmin
@@ -120,11 +119,17 @@ export async function executeSwapTransactionLimitCheck(
   }
 
   const tier = Math.min(Math.max(Number(kycProfile?.tier ?? 0), 0), 3);
-  const monthlyLimit = KYC_MONTHLY_LIMITS[tier] ?? 0;
+  const tierLimit = getKycTierLimit(tier);
 
-  if (monthlyLimit === 0) {
+  // A capped limit of 0 means "no swaps until phone" (tier 0). An unlimited tier
+  // must never hit this branch.
+  if (!tierLimit.unlimited && tierLimit.monthly === 0) {
     return { kind: "kyc_required" };
   }
+
+  // Sent to the RPC and echoed back in success/limit_exceeded results.
+  // null signals "no cap" to the RPC; 0 is only reachable for capped tiers above.
+  const monthlyLimit = tierLimit.unlimited ? 0 : tierLimit.monthly;
 
   let cngnToUsdRate = 0;
   try {
@@ -147,7 +152,7 @@ export async function executeSwapTransactionLimitCheck(
     "insert_swap_transaction_if_within_limit",
     {
       p_wallet_address: normalizedBodyWalletAddress,
-      p_monthly_limit: monthlyLimit,
+      p_monthly_limit: tierLimit.unlimited ? null : tierLimit.monthly,
       p_cngn_to_usd_rate: cngnToUsdRate,
       p_transaction_type: body.transactionType,
       p_from_currency: body.fromCurrency,

--- a/supabase/migrations/20260617120000_tier3_unlimited_kyc_limit.sql
+++ b/supabase/migrations/20260617120000_tier3_unlimited_kyc_limit.sql
@@ -1,0 +1,175 @@
+-- ─── Tier 3 unlimited monthly KYC limit ───────────────────────────────────────
+--
+-- Adds support for an uncapped monthly spend tier. The app passes
+-- p_monthly_limit = NULL (from NEXT_PUBLIC_KYC_TIER_3_MONTHLY="unlimited") to
+-- signal "no cap". Previously p_monthly_limit was always a NUMERIC and every
+-- transaction was compared against it.
+--
+-- Behavior:
+--   * p_monthly_limit IS NULL  → no cap. Skip the cNGN-rate requirement and the
+--     spend summation entirely (an unlimited user must never be blocked by
+--     rate_unavailable or limit_exceeded), then insert / dry-run as usual.
+--   * p_monthly_limit IS NOT NULL → unchanged capped behavior, including the
+--     rate_unavailable guard and the monthly limit comparison.
+--
+-- Returns { "id": uuid } | { "ok": true } (dry_run) | { "error": ... }.
+
+CREATE OR REPLACE FUNCTION public.insert_swap_transaction_if_within_limit(
+  p_wallet_address   TEXT,
+  p_monthly_limit    NUMERIC,
+  p_cngn_to_usd_rate NUMERIC,
+  p_transaction_type TEXT,
+  p_from_currency    TEXT,
+  p_to_currency      TEXT,
+  p_amount_sent      NUMERIC,
+  p_amount_received  NUMERIC,
+  p_fee              NUMERIC,
+  p_recipient        JSONB,
+  p_status           TEXT,
+  p_network          TEXT DEFAULT NULL,
+  p_time_spent       TEXT DEFAULT NULL,
+  p_tx_hash          TEXT DEFAULT NULL,
+  p_order_id         TEXT DEFAULT NULL,
+  p_email            TEXT DEFAULT NULL,
+  p_explorer_link    TEXT DEFAULT NULL,
+  p_dry_run          BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_monthly_spent       NUMERIC := 0;
+  v_offramp_spent       NUMERIC := 0;
+  v_onramp_spent        NUMERIC := 0;
+  v_this_tx_usd         NUMERIC;
+  v_new_id              UUID;
+  v_month_start         TIMESTAMPTZ;
+  v_has_cngn_history    BOOLEAN;
+  v_needs_fiat_rate     BOOLEAN;
+  v_stable_to           TEXT[] := ARRAY['USDC', 'USDT', 'CUSD'];
+  -- Statuses that consume the monthly limit: anything in-flight or settled.
+  -- 'fulfilling' is legacy-only (the app maps the aggregator's "fulfilling"
+  -- to 'pending') but is kept in case old rows carry it.
+  v_spend_statuses      TEXT[] := ARRAY['pending', 'fulfilling', 'fulfilled', 'completed'];
+BEGIN
+  PERFORM set_config('search_path', 'public', true);
+
+  PERFORM pg_advisory_xact_lock(hashtext(p_wallet_address));
+
+  -- Capped tiers run the full rate + spend + limit check. An unlimited tier
+  -- (p_monthly_limit IS NULL) skips straight to the insert/dry-run tail.
+  IF p_monthly_limit IS NOT NULL THEN
+    v_month_start := date_trunc('month', now() AT TIME ZONE 'UTC');
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM transactions
+      WHERE wallet_address   = p_wallet_address
+        AND transaction_type = 'offramp'
+        AND status           = ANY (v_spend_statuses)
+        AND upper(coalesce(from_currency, '')) = 'CNGN'
+        AND created_at       >= v_month_start
+    ) INTO v_has_cngn_history;
+
+    v_needs_fiat_rate := (
+      v_has_cngn_history
+      OR upper(coalesce(p_from_currency, '')) = 'CNGN'
+      OR upper(coalesce(p_to_currency, '')) = 'CNGN'
+      OR EXISTS (
+        SELECT 1
+        FROM transactions
+        WHERE wallet_address   = p_wallet_address
+          AND transaction_type = 'onramp'
+          AND status           = ANY (v_spend_statuses)
+          AND created_at       >= v_month_start
+          AND upper(coalesce(to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      )
+      OR (
+        p_transaction_type = 'onramp'
+        AND upper(coalesce(p_to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      )
+    );
+
+    IF v_needs_fiat_rate AND (p_cngn_to_usd_rate IS NULL OR p_cngn_to_usd_rate <= 0) THEN
+      RETURN jsonb_build_object('error', 'rate_unavailable');
+    END IF;
+
+    SELECT COALESCE(SUM(
+      CASE
+        WHEN upper(coalesce(from_currency, '')) = 'CNGN' THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+        ELSE amount_sent::NUMERIC
+      END
+    ), 0)
+    INTO v_offramp_spent
+    FROM transactions
+    WHERE wallet_address   = p_wallet_address
+      AND transaction_type = 'offramp'
+      AND status           = ANY (v_spend_statuses)
+      AND upper(coalesce(from_currency, '')) IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      AND created_at       >= v_month_start;
+
+    SELECT COALESCE(SUM(
+      CASE
+        WHEN upper(coalesce(to_currency, '')) = ANY (v_stable_to) THEN amount_received::NUMERIC
+        WHEN upper(coalesce(to_currency, '')) = 'CNGN' THEN amount_received::NUMERIC / p_cngn_to_usd_rate
+        WHEN upper(coalesce(from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+          THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+        ELSE amount_received::NUMERIC
+      END
+    ), 0)
+    INTO v_onramp_spent
+    FROM transactions
+    WHERE wallet_address   = p_wallet_address
+      AND transaction_type = 'onramp'
+      AND status           = ANY (v_spend_statuses)
+      AND created_at       >= v_month_start;
+
+    v_monthly_spent := v_offramp_spent + v_onramp_spent;
+
+    IF p_transaction_type = 'onramp' THEN
+      IF upper(coalesce(p_to_currency, '')) = ANY (v_stable_to) THEN
+        v_this_tx_usd := p_amount_received;
+      ELSIF upper(coalesce(p_to_currency, '')) = 'CNGN' THEN
+        v_this_tx_usd := p_amount_received / p_cngn_to_usd_rate;
+      ELSIF upper(coalesce(p_from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN') THEN
+        v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+      ELSE
+        v_this_tx_usd := p_amount_received;
+      END IF;
+    ELSIF upper(coalesce(p_from_currency, '')) = 'CNGN' THEN
+      v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+    ELSE
+      v_this_tx_usd := p_amount_sent;
+    END IF;
+
+    IF v_monthly_spent + v_this_tx_usd > p_monthly_limit THEN
+      RETURN jsonb_build_object(
+        'error',         'limit_exceeded',
+        'monthly_spent', v_monthly_spent,
+        'this_tx_usd',   v_this_tx_usd,
+        'monthly_limit', p_monthly_limit
+      );
+    END IF;
+  END IF;
+
+  IF COALESCE(p_dry_run, FALSE) THEN
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  INSERT INTO transactions (
+    wallet_address, transaction_type, from_currency, to_currency,
+    amount_sent, amount_received, fee, recipient, status, network,
+    time_spent, tx_hash, order_id, email, explorer_link
+  ) VALUES (
+    p_wallet_address, p_transaction_type, p_from_currency, p_to_currency,
+    p_amount_sent, p_amount_received, p_fee, p_recipient, p_status, p_network,
+    p_time_spent, p_tx_hash, p_order_id, p_email, p_explorer_link
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object('id', v_new_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.insert_swap_transaction_if_within_limit TO service_role;


### PR DESCRIPTION


### Description

- Updated KYC tier configuration to allow tier 3 users to have an unlimited monthly spend limit by accepting the "unlimited" sentinel in environment variables.
- Modified KYC-related components to display "Unlimited" for tier 3 users when applicable.
- Refactored limit-checking logic in the backend to accommodate the new unlimited tier, ensuring proper handling of transactions without caps.
- Added database migration to support the new unlimited limit functionality.


### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tier 3 KYC now supports unlimited monthly spend by setting the monthly limit to "unlimited"

* **Improvements**
  * Monthly limit display now shows "Unlimited" for unlimited tier accounts instead of a dollar amount
  * Progress bar is only displayed for accounts with capped monthly limits, improving clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->