### PR TITLE
feat(countries): replace REST API with local country data from libphonumberjs

### DIFF
--- a/app/lib/countries.ts
+++ b/app/lib/countries.ts
@@ -1,3 +1,9 @@
+import {
+  getCountries,
+  getCountryCallingCode,
+  type CountryCode,
+} from "libphonenumber-js";
+
 export interface Country {
   code: string;
   flag: string; // URL to flag image
@@ -9,52 +15,55 @@ export interface Country {
 let countriesCache: Country[] | null = null;
 
 /**
- * Fetches country data from REST Countries API
- * Returns countries with calling codes, flags, and names
+ * Builds the full country list locally from libphonenumber-js metadata (the same
+ * library that validates the entered number, so the two can never disagree) plus
+ * Intl.DisplayNames for localized country names. No network call — the previous
+ * REST Countries endpoint now 301-redirects cross-origin with no CORS header, so
+ * the browser fetch always failed and silently fell back to a 15-country list.
+ */
+function buildCountryList(): Country[] {
+  const displayNames = new Intl.DisplayNames(["en"], { type: "region" });
+
+  return getCountries()
+    .map((cc: CountryCode): Country | null => {
+      let callingCode: string;
+      try {
+        callingCode = getCountryCallingCode(cc);
+      } catch {
+        // Region without a dial code in metadata — skip it.
+        return null;
+      }
+      return {
+        code: `+${callingCode}`,
+        flag: `https://flagcdn.com/w40/${cc.toLowerCase()}.png`,
+        name: displayNames.of(cc) ?? cc,
+        country: cc,
+      };
+    })
+    .filter((c): c is Country => c !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Returns the full list of dialable countries (calling codes, flags, names).
+ * Async to preserve the call site's contract; resolves from a local build with
+ * no network dependency. Falls back to a small static list only if metadata is
+ * somehow unavailable.
  */
 export async function fetchCountries(): Promise<Country[]> {
-  // Return cached data if available
   if (countriesCache) {
     return countriesCache;
   }
 
   try {
-    const response = await fetch(
-      'https://restcountries.com/v3.1/all?fields=name,cca2,idd,flag'
-    );
-    
-    if (!response.ok) {
-      throw new Error('Failed to fetch countries');
+    const countries = buildCountryList();
+    if (countries.length === 0) {
+      throw new Error("Country metadata produced an empty list");
     }
-
-    const data = await response.json();
-    
-    // Transform the API response to our format
-    const countries: Country[] = data
-      .filter((country: any) => {
-        // Only include countries with valid calling codes
-        return country.idd?.root && country.idd?.suffixes?.length > 0;
-      })
-      .map((country: any) => {
-        // Get the first calling code (some countries have multiple)
-        const callingCode = country.idd.root + (country.idd.suffixes[0] || '');
-        
-        return {
-          code: callingCode,
-          flag: `https://flagcdn.com/w40/${country.cca2.toLowerCase()}.png`,
-          name: country.name.common,
-          country: country.cca2
-        };
-      })
-      .sort((a: Country, b: Country) => a.name.localeCompare(b.name)); // Sort alphabetically
-
-    // Cache the results
     countriesCache = countries;
     return countries;
   } catch (error) {
-    console.error('Error fetching countries:', error);
-    
-    // Fallback to a basic list if API fails
+    console.error("Error building country list:", error);
     return getDefaultCountries();
   }
 }
@@ -69,6 +78,7 @@ function getDefaultCountries(): Country[] {
     { code: '+233', flag: 'https://flagcdn.com/w40/gh.png', name: 'Ghana', country: 'GH' },
     { code: '+27', flag: 'https://flagcdn.com/w40/za.png', name: 'South Africa', country: 'ZA' },
     { code: '+1', flag: 'https://flagcdn.com/w40/us.png', name: 'United States', country: 'US' },
+    { code: '+1', flag: 'https://flagcdn.com/w40/ca.png', name: 'Canada', country: 'CA' },
     { code: '+44', flag: 'https://flagcdn.com/w40/gb.png', name: 'United Kingdom', country: 'GB' },
     { code: '+33', flag: 'https://flagcdn.com/w40/fr.png', name: 'France', country: 'FR' },
     { code: '+49', flag: 'https://flagcdn.com/w40/de.png', name: 'Germany', country: 'DE' },

--- a/app/lib/phone-validation.ts
+++ b/app/lib/phone-validation.ts
@@ -3,6 +3,7 @@ import {
   parsePhoneNumberWithError,
   parsePhoneNumberFromString,
   validatePhoneNumberLength,
+  getCountryCallingCode,
   type CountryCode,
 } from "libphonenumber-js";
 
@@ -138,9 +139,22 @@ export function validatePhoneForSelectedCountry(
     return { ok: false };
   }
 
+  // US, Canada, and the Caribbean territories all share +1 (the NANP), so
+  // libphonenumber resolves a +1 number to its specific region (e.g. 778 → CA),
+  // which won't equal a US selection. Accept any region that shares the selected
+  // dial code, and reject only a genuine mismatch (e.g. a +44 number entered
+  // under a +1 selection). The returned E.164 carries the correctly-detected region.
   const detected = parsed.country;
   if (detected && detected !== selected.country) {
-    return { ok: false };
+    let detectedDialCode: string | undefined;
+    try {
+      detectedDialCode = getCountryCallingCode(detected);
+    } catch {
+      detectedDialCode = undefined;
+    }
+    if (!detectedDialCode || `+${detectedDialCode}` !== selected.code) {
+      return { ok: false };
+    }
   }
 
   return { ok: true, e164: parsed.format("E.164") };


### PR DESCRIPTION

### Description

- Implemented a new method to build the full country list using libphonenumber-js, eliminating the need for a network call due to CORS issues with the previous REST Countries API.
- Updated fetchCountries function to utilize the local country data, ensuring a consistent and reliable list of countries with calling codes and flags.
- Enhanced phone validation logic to correctly handle country calling codes for regions sharing the same code, specifically for the US and Canada.



### References



### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Canada to supported countries list

* **Improvements**
  * Country and phone data now loads locally for enhanced performance and reliability
  * Phone validation logic improved to better recognize correct regions when calling codes match

<!-- end of auto-generated comment: release notes by coderabbit.ai -->