### PR TITLE
fix(kyc): update transaction type query to include legacy "swap" label

### DIFF
--- a/app/api/kyc/transaction-summary/route.ts
+++ b/app/api/kyc/transaction-summary/route.ts
@@ -70,11 +70,14 @@ export async function GET(request: NextRequest) {
     // 'pending') but is kept in case old rows carry it.
     const SPEND_STATUSES = ["pending", "fulfilling", "fulfilled", "completed"];
 
+    // "offramp" is the current label; "swap" is the legacy label used before
+    // 2026-05-29 (commit 73ebf7b normalized swap→offramp and added the
+    // transaction_type CHECK). Both denote the same sell, so include both.
     const { data: swapTransactions, error: swapError } = await supabaseAdmin
       .from("transactions")
       .select("amount_sent, from_currency, created_at")
       .eq("wallet_address", walletAddress)
-      .eq("transaction_type", "offramp")
+      .in("transaction_type", ["offramp", "swap"])
       .in("status", SPEND_STATUSES)
       .gte("created_at", monthStart.toISOString());
 


### PR DESCRIPTION
### Description

- Modified the transaction query to use an "in" clause for the "transaction_type" field, allowing both "offramp" and the legacy "swap" labels to be included.
- This change ensures compatibility with older transaction records while maintaining current functionality.

### References




### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction summary calculations to properly include all historical transaction types for KYC compliance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->