### PR TITLE
refactor(moralis): enhance deposit processing with token support checks

### DIFF
--- a/app/lib/moralis-deposit-processing.ts
+++ b/app/lib/moralis-deposit-processing.ts
@@ -4,9 +4,10 @@ import { triggerActivepiecesDeposit } from "@/app/lib/activepieces-deposit";
 import {
   getEmailForMonitoredAddress,
   getMoralisDepositNetworkAndExplorer,
+  getNetworkTokens,
 } from "@/app/utils";
 import { supabaseAdmin } from "@/app/lib/supabase";
-import type { MoralisWebhookBody } from "../types";
+import type { MoralisWebhookBody, Token } from "../types";
 
 type MoralisDepositIdempotencyInput =
   | { kind: "native"; chainId: string; txHash: string; to: string }
@@ -151,6 +152,38 @@ function isEmptyTestPayload(body: MoralisWebhookBody): boolean {
   return noChain && noData;
 }
 
+function isSupportedNativeDeposit(tokens: Token[]): boolean {
+  return tokens.some((t) => t.isNative);
+}
+
+function isSupportedErc20Deposit(
+  tokens: Token[],
+  contractAddress: string,
+): boolean {
+  const addr = contractAddress.trim().toLowerCase();
+  if (!addr) {
+    return false;
+  }
+  return tokens.some(
+    (t) => !t.isNative && t.address.trim().toLowerCase() === addr,
+  );
+}
+
+function createSupportedTokenLoader(): (
+  chainId: string,
+) => Promise<Token[]> {
+  const cache = new Map<string, Promise<Token[]>>();
+  return async (chainId: string) => {
+    const { network } = getMoralisDepositNetworkAndExplorer(chainId, "");
+    let pending = cache.get(network);
+    if (!pending) {
+      pending = getNetworkTokens(network);
+      cache.set(network, pending);
+    }
+    return pending;
+  };
+}
+
 /**
  * After Moralis has delivered a confirmed block payload, link recipients to Privy and Activepieces.
  */
@@ -167,6 +200,8 @@ export async function processMoralisDepositPayload(
   if (!body.confirmed) {
     return;
   }
+
+  const loadSupportedTokens = createSupportedTokenLoader();
 
   for (const tx of body.txs ?? []) {
     const to = tx.toAddress?.toLowerCase();
@@ -190,13 +225,26 @@ export async function processMoralisDepositPayload(
       continue;
     }
 
+    const supportedTokens = await loadSupportedTokens(body.chainId);
+    if (!isSupportedNativeDeposit(supportedTokens)) {
+      if (process.env.NODE_ENV === "development") {
+        console.log(
+          "[moralis deposit] unsupported native deposit on chain",
+          body.chainId,
+        );
+      }
+      continue;
+    }
+
     let amountStr: string;
     try {
       amountStr = formatUnits(BigInt(tx.value), 18);
     } catch {
       amountStr = tx.value;
     }
-    const symbol = nativeSymbol(body.chainId);
+    const symbol =
+      supportedTokens.find((t) => t.isNative)?.symbol ??
+      nativeSymbol(body.chainId);
     if (process.env.NODE_ENV === "development") {
       console.log(
         "[moralis deposit] native →",
@@ -265,6 +313,20 @@ export async function processMoralisDepositPayload(
       }
       continue;
     }
+
+    const tokenAddress = (tr.contract ?? "").trim().toLowerCase();
+    const supportedTokens = await loadSupportedTokens(body.chainId);
+    if (!isSupportedErc20Deposit(supportedTokens, tokenAddress)) {
+      if (process.env.NODE_ENV === "development") {
+        console.log(
+          "[moralis deposit] unsupported ERC-20",
+          tr.tokenSymbol,
+          tokenAddress,
+        );
+      }
+      continue;
+    }
+
     if (process.env.NODE_ENV === "development") {
       console.log(
         "[moralis deposit] erc20 →",
@@ -275,8 +337,11 @@ export async function processMoralisDepositPayload(
       );
     }
     try {
-      const token = tr.tokenSymbol || "TOKEN";
-      const tokenAddress = (tr.contract ?? "").trim().toLowerCase();
+      const matchedToken = supportedTokens.find(
+        (t) =>
+          !t.isNative && t.address.trim().toLowerCase() === tokenAddress,
+      );
+      const token = matchedToken?.symbol || tr.tokenSymbol || "TOKEN";
       await moralisDepositNotificationOnce(
         {
           kind: "erc20",

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -785,15 +785,15 @@ export type UnifiedWalletBalances = {
 
 export type FetchBalancesForChainArgs =
   | {
-      kind: "evm";
-      client: any;
-      walletAddress: string;
-    }
+    kind: "evm";
+    client: any;
+    walletAddress: string;
+  }
   | {
-      kind: "starknet";
-      walletAddress: string;
-      tokens?: Token[];
-    };
+    kind: "starknet";
+    walletAddress: string;
+    tokens?: Token[];
+  };
 
 async function fetchEvmBalancesUnifiedUncached(
   client: any,
@@ -840,20 +840,20 @@ async function fetchEvmBalancesUnifiedUncached(
       nativeTokens.length === 0
         ? Promise.resolve()
         : Promise.all(
-            nativeTokens.map(async (token: Token) => {
-              try {
-                const balanceInWei = await client.getBalance({ address });
-                fillBalancesFromWei(token, balanceInWei);
-              } catch (error) {
-                console.error(
-                  `Error fetching native balance for ${token.symbol}:`,
-                  error,
-                );
-                balances[token.symbol] = 0;
-                balancesInWei[token.symbol] = BigInt(0);
-              }
-            }),
-          );
+          nativeTokens.map(async (token: Token) => {
+            try {
+              const balanceInWei = await client.getBalance({ address });
+              fillBalancesFromWei(token, balanceInWei);
+            } catch (error) {
+              console.error(
+                `Error fetching native balance for ${token.symbol}:`,
+                error,
+              );
+              balances[token.symbol] = 0;
+              balancesInWei[token.symbol] = BigInt(0);
+            }
+          }),
+        );
 
     const erc20Promise = (async () => {
       if (erc20Tokens.length === 0) return;


### PR DESCRIPTION
### Description

Moralis Streams reports **every** native and ERC‑20 transfer to a watched EOA. After the deposit-notifications work landed on staging, unrelated tokens (e.g. WaR, SAOS, CDOF, USDOR on Base) were ingested as `credit` transactions, triggered deposit emails via Activepieces, and appeared in transaction history with broken logos.

This PR filters Moralis deposit processing so only **Noblocks-supported tokens** are notified and persisted. The allowlist is loaded via `getNetworkTokens(network)` — the same aggregator + fallback source used elsewhere in the app for fund/swap token lists.

**Implementation (`app/lib/moralis-deposit-processing.ts`):**

- Resolve Moralis `chainId` → network name, then load supported tokens once per webhook (cached per network).
- **ERC‑20:** skip unless `tr.contract` matches a supported token **contract address** on that network (not symbol).
- **Native:** skip unless the network has a supported native token (e.g. ETH on Base).
- On match, use the allowlist symbol for email/DB rows instead of Moralis’ `tokenSymbol`.
- Unsupported transfers are skipped silently in production; dev logs `[moralis deposit] unsupported ERC-20 …`.

**What this does not change:**

- Moralis still receives all on-chain transfers; Noblocks simply ignores unsupported ones.
- **Existing** junk `credit` rows already in Supabase are **not** deleted or hidden — only **new** unsupported deposits are blocked. Cleanup can be a follow-up (SQL or UI filter).
- No API contract, env var, or migration changes.

**Breaking changes:** None for clients or webhooks. Moralis continues to get `200` on valid signed payloads.

**Alternatives considered:**

- Symbol blocklist (WaR, SAOS, …) — rejected; spam symbols change constantly.
- Moralis stream filtering — streams watch addresses, not token contracts; insufficient.
- UI-only filter — would not stop emails or DB writes.

---

### References


---

### Testing

**Environment:** Node 22, local/staging with Moralis webhook + Privy email user + `ACTIVEPIECES_WEBHOOK_URL` configured.

**Manual steps:**

1. Deploy branch to staging (or run locally with ngrok + Moralis stream).
2. Send a **supported** deposit on Base (e.g. USDC) to a registered email user’s EOA.
   - Expect: deposit email, one `credit` row (`Funded … USDC`), dev log `[moralis deposit] erc20 →`.
3. Trigger or wait for an **unsupported** ERC‑20 transfer to the same address (or replay a webhook with a non-allowlisted contract).
   - Expect: **no** new `credit` row, **no** email; dev log `unsupported ERC-20`.
4. Confirm **existing** pre-fix spam rows still appear in history (expected until cleanup).
5. Confirm supported flows unchanged: swap, transfer, onramp/offramp history still render.

- [ ] This change adds test coverage for new/changed/fixed functionality

---

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposits for unsupported assets on destination chains are now properly filtered and excluded from processing.
  * Improved symbol display accuracy for native and ERC-20 token deposits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->