### PR TITLE
refactor(moralis): improve deposit processing for instant notifications

### DIFF
--- a/app/lib/moralis-deposit-processing.ts
+++ b/app/lib/moralis-deposit-processing.ts
@@ -185,14 +185,7 @@ function createSupportedTokenLoader(): (
 }
 
 /**
- * Links deposit recipients to Privy and Activepieces. Processes both Moralis
- * delivery phases (`confirmed: false` near-tip and `confirmed: true` reorg-safe)
- * so notifications fire the instant the block is mined — roughly when the wallet
- * shows the funds — instead of waiting the chain's confirmation window.
- *
- * Acting on the near-tip delivery trades a small reorg risk for instant delivery.
- * The deposit idempotency key is confirmation-agnostic, so whichever delivery
- * arrives first does the work and the other is skipped as a duplicate.
+* After Moralis has delivered a confirmed block payload, link recipients to Privy and Activepieces.
  */
 export async function processMoralisDepositPayload(
   body: MoralisWebhookBody,

--- a/app/lib/moralis-deposit-processing.ts
+++ b/app/lib/moralis-deposit-processing.ts
@@ -185,7 +185,14 @@ function createSupportedTokenLoader(): (
 }
 
 /**
- * After Moralis has delivered a confirmed block payload, link recipients to Privy and Activepieces.
+ * Links deposit recipients to Privy and Activepieces. Processes both Moralis
+ * delivery phases (`confirmed: false` near-tip and `confirmed: true` reorg-safe)
+ * so notifications fire the instant the block is mined — roughly when the wallet
+ * shows the funds — instead of waiting the chain's confirmation window.
+ *
+ * Acting on the near-tip delivery trades a small reorg risk for instant delivery.
+ * The deposit idempotency key is confirmation-agnostic, so whichever delivery
+ * arrives first does the work and the other is skipped as a duplicate.
  */
 export async function processMoralisDepositPayload(
   body: MoralisWebhookBody,
@@ -194,10 +201,6 @@ export async function processMoralisDepositPayload(
     if (process.env.NODE_ENV === "development") {
       console.log("[moralis deposit] skipping empty test / heartbeat payload");
     }
-    return;
-  }
-
-  if (!body.confirmed) {
     return;
   }
 


### PR DESCRIPTION
Updated the processMoralisDepositPayload function to handle both confirmed and near-tip delivery phases, allowing for immediate notifications when a block is mined. This change reduces the waiting time for confirmations while maintaining idempotency by skipping duplicate deliveries.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.

### References

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit processing now handles incoming webhook events even before they are confirmed, helping ensure deposits are picked up sooner.
  * The app will now continue processing both native and token transfer activity from these events without waiting for confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->