### PR TITLE
Revert "feat(transaction): enhance on-ramp functionality with dynamic fiat li…"

### DIFF
--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -35,10 +35,6 @@ import {
   formatDecimalPrecision,
   currencyToCountryCode,
   reorderCurrenciesByLocation,
-  isStarknetChain,
-  getCurrencySymbol,
-  getOnrampFiatMaxAmount,
-  isOnrampFiatCurrencyCode,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -492,8 +488,9 @@ export const TransactionForm = ({
 
         const normalizedToken = token?.toUpperCase();
 
-        if (swapMode === "onramp") {
-          maxAmountSentValue = getOnrampFiatMaxAmount(currency || "NGN");
+        if (isSwapped) {
+          // On-ramp: send NGN; min in validate.onrampFiatMin, max 2.3M NGN product cap.
+          maxAmountSentValue = 2_300_000;
           setRateError(null);
         } else if (normalizedToken === "CNGN") {
           if (cngnRate && cngnRate > 0) {
@@ -540,8 +537,7 @@ export const TransactionForm = ({
               const n = Number(value);
               const floor = 0.5 * rate;
               if (n >= floor) return true;
-              const fiat = (currency || "NGN").toUpperCase();
-              return `Minimum amount is ${getCurrencySymbol(fiat)}${formatNumberWithCommas(floor)}`;
+              return `Minimum amount is ${formatNumberWithCommas(floor)} NGN`;
             },
           },
         });
@@ -554,11 +550,12 @@ export const TransactionForm = ({
           required: { value: false, message: "Add description" },
         });
 
-        if (swapMode === "onramp") {
+        if (isSwapped) {
+          // On-ramp is NGN-only for now (send side).
           currencies.forEach((c: CurrencyOption) => {
-            c.disabled = !isOnrampFiatCurrencyCode(c.name);
+            c.disabled = c.name !== "NGN";
           });
-          if (!isOnrampFiatCurrencyCode(currency)) {
+          if (currency !== "NGN") {
             formMethods.setValue("currency", "NGN", { shouldDirty: true });
           }
         } else if (normalizedToken === "CNGN") {
@@ -601,7 +598,6 @@ export const TransactionForm = ({
       cngnRate,
       cngnRateError,
       isSwapped,
-      swapMode,
       rate,
     ],
   );
@@ -728,7 +724,6 @@ export const TransactionForm = ({
     // Only enable on-ramp from pre-filled wallet; do not force off-ramp (avoids clobbering toggle before this runs)
     if (hasWallet) {
       setValue("isSwapped", true, { shouldDirty: false });
-      setValue("swapMode", "onramp", { shouldDirty: false });
       const t = getValues("token");
       if (typeof t === "string" && t.trim().length > 0) {
         setValue("receiveDestinationExplicitlySelected", true, {
@@ -744,7 +739,7 @@ export const TransactionForm = ({
   const handleSwapFields = () => {
     const currentAmountSent = amountSent;
     const currentAmountReceived = amountReceived;
-    const nextSwapMode = swapMode === "onramp" ? "offramp" : "onramp";
+    const willBeSwapped = !isSwapped;
 
     const hasToken = typeof token === "string" && token.trim().length > 0;
     const hasCurrency = typeof currency === "string" && currency.trim().length > 0;
@@ -762,8 +757,10 @@ export const TransactionForm = ({
     });
 
     // Toggle swap mode FIRST (persisted on form so parent rate fetch uses correct side)
-    setValue("swapMode", nextSwapMode, { shouldDirty: true });
-    setValue("isSwapped", nextSwapMode === "onramp", { shouldDirty: true });
+    setValue("isSwapped", willBeSwapped, { shouldDirty: true });
+    setValue("swapMode", willBeSwapped ? "onramp" : "offramp", {
+      shouldDirty: true,
+    });
 
     if (isCompleteFlow) {
       // Swap send/receive numbers and formatting; keep token & currency (and wallet) across the flip
@@ -772,8 +769,9 @@ export const TransactionForm = ({
       setFormattedSentAmount(formattedReceivedAmount);
       setFormattedReceivedAmount(formattedSentAmount);
 
-      if (nextSwapMode === "onramp") {
-        if (!isOnrampFiatCurrencyCode(currency)) {
+      if (willBeSwapped) {
+        // On-ramp send fiat is NGN-only — normalize if coming from another receive fiat
+        if (currency !== "NGN") {
           setValue("currency", "NGN", { shouldDirty: true });
         }
       }
@@ -784,7 +782,8 @@ export const TransactionForm = ({
       setFormattedSentAmount("");
       setFormattedReceivedAmount("");
 
-      if (nextSwapMode === "onramp") {
+      if (willBeSwapped) {
+        // On-ramp: fiat send is NGN-only for now. Receive token chosen on the Receive row.
         setValue("currency", "NGN", { shouldDirty: true });
         setValue("token", "", { shouldDirty: true });
         if (!walletAddress) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -49,7 +49,7 @@ export type FormData = {
   memo: string;
   amountSent: number;
   amountReceived: number;
-  /** Fiat → crypto = onramp (NGN/KES→token); crypto → fiat = offramp */
+  /** Fiat → crypto = onramp (NGN→token); crypto → fiat = offramp */
   swapMode: SwapMode;
   /** Legacy compatibility for extracted KYC branch components. */
   isSwapped?: boolean;

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -215,29 +215,6 @@ export function isNoblocksFiatCurrencyCode(code: string): boolean {
   return NOBLOCKS_FIAT_CURRENCY_CODES.has(code.toUpperCase());
 }
 
-/** Fiat codes enabled for on-ramp (send fiat → receive crypto). */
-export const ONRAMP_FIAT_CURRENCY_CODES = new Set(["NGN", "KES"]);
-
-export function isOnrampFiatCurrencyCode(code: string): boolean {
-  return ONRAMP_FIAT_CURRENCY_CODES.has(code.toUpperCase());
-}
-
-/**
- * Max send amount for on-ramp in local fiat units (product caps per corridor).
- * Tune KES with product/compliance when backend limits are finalized.
- * @throws If currencyCode is not a supported on-ramp fiat (fail closed; no silent NGN cap).
- */
-export function getOnrampFiatMaxAmount(currencyCode: string): number {
-  const code = (currencyCode ?? "").trim().toUpperCase();
-  switch (code) {
-    case "KES":
-      return 3_000_000;
-    case "NGN":
-      return 2_300_000;
-    default:
-      throw new Error(`Unsupported on-ramp fiat currency: ${currencyCode}`);
-  }
-}
 
 /**
  * Parses a transaction amount from the API body. Returns null if missing or invalid.


### PR DESCRIPTION
Reverts paycrest/noblocks#495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened transaction form validation for swapped/on-ramp flows.
  * Fixed currency selection so fiat on-ramp amounts are normalized to NGN and the currency picker is disabled in that mode.
  * Updated amount limits and messaging to use a consistent NGN-only rule for fiat sends.
  * Improved swap behavior so form state stays in sync when flipping transaction direction or restoring saved entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->