### PR TITLE
feat(refund): enforce KYC name matching for refund accounts 

### DIFF
--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -281,6 +281,9 @@ export function AddRefundAccountModal({
                   }}
                   placeholder={getOfframpAccountIdentifierPlaceholder(currency, selectedInstitution?.type)}
                 />
+                {accountNumberError ? (
+                  <InputError message={accountNumberError} />
+                ) : null}
               </div>
 
               {/* 3. Account name — auto-fetched */}

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -124,6 +124,11 @@ export function AddRefundAccountModal({
           accountIdentifier: digits || accountNumber,
         });
         setAccountName(name);
+        if (kycFullName && !accountNameMatchesKyc(kycFullName, name)) {
+          setFormError(REFUND_NAME_MISMATCH_MESSAGE);
+        } else {
+          setFormError(null);
+        }
         setAccountNameError(null);
       } catch {
         setAccountNameError("Account not found. Check the number and bank.");
@@ -270,21 +275,12 @@ export function AddRefundAccountModal({
                   inputMode="numeric"
                   autoComplete="off"
                   value={accountNumber}
-                  onChange={(e) => setAccountNumber(e.target.value)}
-                  placeholder={getOfframpAccountIdentifierPlaceholder(
-                    currency,
-                    selectedInstitution?.type,
-                  )}
-                  className={classNames(
-                    "w-full rounded-xl border bg-white px-3.5 py-3 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400 focus:ring-2 dark:bg-[#202020] dark:text-white dark:placeholder:text-white/35",
-                    accountNumberError
-                      ? "border-red-400 focus:border-red-400 focus:ring-red-400/25 dark:border-red-500 dark:focus:border-red-500 dark:focus:ring-red-500/20"
-                      : "border-neutral-200 focus:border-blue-500 focus:ring-blue-500/25 dark:border-white/[0.12] dark:focus:border-blue-500 dark:focus:ring-blue-500/35",
-                  )}
+                  onChange={(e) => {
+                    setAccountNumber(e.target.value);
+                    setFormError(null);
+                  }}
+                  placeholder={getOfframpAccountIdentifierPlaceholder(currency, selectedInstitution?.type)}
                 />
-                {accountNumberError && (
-                  <InputError message={accountNumberError} />
-                )}
               </div>
 
               {/* 3. Account name — auto-fetched */}
@@ -351,7 +347,7 @@ export function AddRefundAccountModal({
             <button
               type="button"
               onClick={() => void handleAddAccount()}
-              disabled={isSaving || !allFieldsFilled || !hasChanges}
+              disabled={isSaving || !allFieldsFilled || !hasChanges || !!formError}
               className={classNames(primaryBtnClasses, "flex-1")}
             >
               {isSaving ? "Saving…" : initial ? "Save changes" : "Add account"}

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -517,7 +517,7 @@ export const RecipientDetailsForm = ({
               !isDestinationOwnWallet && (
                 <div className="flex items-center gap-2 rounded-xl bg-gray-50 px-3 py-2.5 text-xs font-normal leading-4 text-text-disabled dark:bg-white/5 dark:text-white/30">
                   <InformationCircleIcon className="size-4 flex-shrink-0" />
-                  <span>Funds will be routed through your noblocks wallet.</span>
+                  <span>Funds will be routed through your Noblocks wallet.</span>
                 </div>
               )}
             {networkName && (


### PR DESCRIPTION


### Description
- Added validation to ensure the refund account name matches the user's KYC full name, providing instant feedback on mismatches.
- Updated account number input handling to reset form errors on change.
- Minor UI text correction in RecipientDetailsForm for consistency in branding.


### References




### Testing

<img width="974" height="1586" alt="image" src="https://github.com/user-attachments/assets/4e4e60dc-7bad-43f3-8d3a-a7b3a50f2b51" />

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refund account validation by immediately checking the auto-fetched account name against KYC details and showing an error when they don’t match.
  * Cleared refund validation errors as the account number is edited to prevent stale error messages.
  * Updated the refund account “Add/Save” action to remain disabled while a validation issue is present.
  * Corrected the capitalization of “Noblocks” in the onramp routing notice on recipient details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->