### PR TITLE
feat: Enhance UI components with improved styling and functionality

### DIFF
--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -284,6 +284,12 @@ export function AddRefundAccountModal({
                     setFormError(null);
                   }}
                   placeholder={getOfframpAccountIdentifierPlaceholder(currency, selectedInstitution?.type)}
+                  className={classNames(
+                    "w-full rounded-xl border bg-white px-3.5 py-3 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/25 dark:bg-[#202020] dark:text-white dark:placeholder:text-white/40 dark:focus:border-blue-500 dark:focus:ring-blue-500/35",
+                    accountNumberError
+                      ? "border-red-500 dark:border-red-500"
+                      : "border-neutral-200 dark:border-white/[0.12]",
+                  )}
                 />
                 {accountNumberError ? (
                   <InputError message={accountNumberError} />

--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -14,6 +14,7 @@ import NoticeBanner from "./NoticeBanner";
 import { MaintenanceNoticeModal, MaintenanceBanner } from "./MaintenanceNoticeModal";
 import {
   PlayPromoBanner,
+  PlayPromoButton,
   PlayPromoModal,
   usePlayPromoBannerVisible,
 } from "./PlayPromo";
@@ -52,8 +53,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         ) : (
           <div className="min-h-full min-w-full bg-white transition-colors dark:bg-neutral-900">
             <div
-              className={`relative ${showPlayPromoBanner
-                  ? "mb-16 md:mb-20"
+              className={`relative ${              showPlayPromoBanner
+                ? "mb-16 md:mb-[64px]"
                   : config.maintenanceEnabled
                     ? "mb-16"
                     : ""
@@ -74,6 +75,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <MainContent>{children}</MainContent>
             </LayoutWrapper>
 
+            {isHomepage && <PlayPromoButton />}
             <PWAInstall />
             <MaintenanceNoticeModal />
             {isHomepage && <PlayPromoModal />}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useLogin, usePrivy } from "@privy-io/react-auth";
 import { usePathname } from "next/navigation";
 
@@ -39,7 +40,9 @@ export const Navbar = () => {
   const [mounted, setMounted] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isMobileDropdownOpen, setIsMobileDropdownOpen] = useState(false);
+  const [logoDropdownPos, setLogoDropdownPos] = useState({ top: 0, left: 0, width: 0 });
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const portaledDropdownRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const { selectedNetwork } = useNetwork();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
@@ -134,28 +137,46 @@ export const Navbar = () => {
     }
   }, []);
 
-  // Close dropdown when clicking outside
+  const updateLogoDropdownPos = useCallback(() => {
+    if (!dropdownRef.current) return;
+    const rect = dropdownRef.current.getBoundingClientRect();
+    setLogoDropdownPos({
+      top: rect.bottom + 16,
+      left: rect.left,
+      width: rect.width,
+    });
+  }, []);
+
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target;
+    if (!isDropdownOpen) return;
+    updateLogoDropdownPos();
+    window.addEventListener("resize", updateLogoDropdownPos);
+    window.addEventListener("scroll", updateLogoDropdownPos, true);
+    return () => {
+      window.removeEventListener("resize", updateLogoDropdownPos);
+      window.removeEventListener("scroll", updateLogoDropdownPos, true);
+    };
+  }, [isDropdownOpen, updateLogoDropdownPos]);
+
+  const closeLogoDropdownUnlessHovered = useCallback(
+    (related: EventTarget | null) => {
       if (
-        dropdownRef.current &&
-        target instanceof Node &&
-        !dropdownRef.current.contains(target)
+        !related ||
+        !(related instanceof Node) ||
+        (!dropdownRef.current?.contains(related) &&
+          !portaledDropdownRef.current?.contains(related))
       ) {
         setIsDropdownOpen(false);
       }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    },
+    [],
+  );
 
   if (!mounted) return null;
 
   return (
     <header
-      className="fixed left-0 top-0 z-40 w-full bg-white/95 backdrop-blur transition-all dark:bg-neutral-900/95"
+      className="fixed left-0 top-0 z-50 w-full bg-white/95 backdrop-blur transition-all dark:bg-neutral-900/95"
       role="banner"
     >
       <nav
@@ -170,16 +191,7 @@ export const Navbar = () => {
             <div
               className="flex cursor-pointer items-center gap-1"
               onMouseEnter={() => setIsDropdownOpen(true)}
-              onMouseLeave={(e) => {
-                const related = e.relatedTarget;
-                if (
-                  !related ||
-                  !(related instanceof Node) ||
-                  !dropdownRef.current?.contains(related)
-                ) {
-                  setIsDropdownOpen(false);
-                }
-              }}
+              onMouseLeave={(e) => closeLogoDropdownUnlessHovered(e.relatedTarget)}
             >
               <button
                 aria-label="Noblocks Logo Icon"
@@ -255,56 +267,80 @@ export const Navbar = () => {
                 </Link>
               </div>
             )}
-            <AnimatePresence>
-              {isDropdownOpen && (
-                <>
-                  {/* Invisible bridge to prevent dropdown from closing when moving cursor */}
-                  <div className="absolute left-0 top-[calc(100%-0.5rem)] z-40 h-6 w-full" />
-                  <motion.div
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -10 }}
-                    transition={{ duration: 0.2 }}
-                    className="absolute left-0 top-full z-50 mt-4 w-48 rounded-lg border border-border-light bg-white p-2 text-sm shadow-lg dark:border-white/5 dark:bg-surface-overlay"
-                    onMouseEnter={() => setIsDropdownOpen(true)}
-                    onMouseLeave={() => setIsDropdownOpen(false)}
-                  >
-                    {pathname !== "/" && (
-                      <Link
-                        href="/"
-                        className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
-                        onClick={() => setIsDropdownOpen(false)}
+            {mounted &&
+              typeof document !== "undefined" &&
+              createPortal(
+                <AnimatePresence>
+                  {isDropdownOpen && (
+                    <div ref={portaledDropdownRef}>
+                      {/* Invisible bridge — portaled above promo collage (z-[55]) */}
+                      <div
+                        className="fixed z-[60]"
+                        style={{
+                          top: logoDropdownPos.top - 24,
+                          left: logoDropdownPos.left,
+                          width: Math.max(logoDropdownPos.width, 192),
+                          height: 24,
+                        }}
+                        onMouseEnter={() => setIsDropdownOpen(true)}
+                        onMouseLeave={(e) =>
+                          closeLogoDropdownUnlessHovered(e.relatedTarget)
+                        }
+                      />
+                      <motion.div
+                        id="navbar-dropdown"
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.2 }}
+                        className="fixed z-[60] w-48 rounded-lg border border-border-light bg-white p-2 text-sm shadow-lg dark:border-white/5 dark:bg-surface-overlay"
+                        style={{
+                          top: logoDropdownPos.top,
+                          left: logoDropdownPos.left,
+                        }}
+                        onMouseEnter={() => setIsDropdownOpen(true)}
+                        onMouseLeave={(e) =>
+                          closeLogoDropdownUnlessHovered(e.relatedTarget)
+                        }
                       >
-                        Home
-                      </Link>
-                    )}
-                    {!pathname.startsWith("/blog") && (
-                      <Link
-                        href="/blog"
-                        className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5 sm:hidden"
-                        onClick={() => setIsDropdownOpen(false)}
-                      >
-                        Blog
-                      </Link>
-                    )}
-                    <Link
-                      href="/terms"
-                      className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
-                      onClick={() => setIsDropdownOpen(false)}
-                    >
-                      Terms
-                    </Link>
-                    <Link
-                      href="/privacy-policy"
-                      className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
-                      onClick={() => setIsDropdownOpen(false)}
-                    >
-                      Privacy Policy
-                    </Link>
-                  </motion.div>
-                </>
+                        {pathname !== "/" && (
+                          <Link
+                            href="/"
+                            className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
+                            onClick={() => setIsDropdownOpen(false)}
+                          >
+                            Home
+                          </Link>
+                        )}
+                        {!pathname.startsWith("/blog") && (
+                          <Link
+                            href="/blog"
+                            className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5 sm:hidden"
+                            onClick={() => setIsDropdownOpen(false)}
+                          >
+                            Blog
+                          </Link>
+                        )}
+                        <Link
+                          href="/terms"
+                          className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
+                          onClick={() => setIsDropdownOpen(false)}
+                        >
+                          Terms
+                        </Link>
+                        <Link
+                          href="/privacy-policy"
+                          className="flex w-full rounded-lg px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-accent-gray dark:bg-surface-overlay dark:text-white/80 dark:hover:bg-white/5"
+                          onClick={() => setIsDropdownOpen(false)}
+                        >
+                          Privacy Policy
+                        </Link>
+                      </motion.div>
+                    </div>
+                  )}
+                </AnimatePresence>,
+                document.body,
               )}
-            </AnimatePresence>
           </div>
         </div>
 

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -172,6 +172,22 @@ export const Navbar = () => {
     [],
   );
 
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+
+    const handlePointerDownOutside = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (dropdownRef.current?.contains(target)) return;
+      if (portaledDropdownRef.current?.contains(target)) return;
+      setIsDropdownOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDownOutside);
+    return () =>
+      document.removeEventListener("pointerdown", handlePointerDownOutside);
+  }, [isDropdownOpen]);
+
   if (!mounted) return null;
 
   return (

--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -14,8 +14,9 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { IoClose } from "react-icons/io5";
+import { ArrowDown01Icon } from "hugeicons-react";
 import { Dialog, DialogPanel } from "@headlessui/react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import config from "../lib/config";
 import { NoblocksAnimatedIcon } from "./NoblocksAnimatedIcon";
 
@@ -29,7 +30,7 @@ const ASSET = (name: string) => `/images/play-promo/${name}`;
 // ---------------------------------------------------------------------------
 
 const ModalBackdrop = () => (
-  <>
+  <div className="pointer-events-none absolute inset-0" aria-hidden="true">
     <img
       src={ASSET("vector7984.svg")}
       alt=""
@@ -41,7 +42,7 @@ const ModalBackdrop = () => (
       alt=""
       className="pointer-events-none absolute inset-0 h-full w-full"
     />
-  </>
+  </div>
 );
 
 const BannerBackdrop = () => (
@@ -66,7 +67,7 @@ const BannerBackdrop = () => (
 // ---------------------------------------------------------------------------
 
 const Collage = () => (
-  <>
+  <div className="pointer-events-none absolute inset-0 z-[1]" aria-hidden="true">
     <img
       src={ASSET("trophy.svg")}
       alt=""
@@ -91,7 +92,7 @@ const Collage = () => (
       className="pointer-events-none absolute object-cover"
       style={{ left: "5.60%", top: "18.83%", width: "100.13%", height: "71.21%" }}
     />
-  </>
+  </div>
 );
 
 // ---------------------------------------------------------------------------
@@ -99,23 +100,47 @@ const Collage = () => (
 // ---------------------------------------------------------------------------
 
 const MODAL_STORAGE_KEY = "noblocks_play_promo_dismissed";
+const BANNER_STORAGE_KEY = "noblocks_play_promo_banner_dismissed";
 
 const BANNER_DISMISS_EVENT = "noblocks-play-promo-banner-dismiss";
 
-/** Banner visibility for AppLayout margin; resets on full page load. */
+function isBannerDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem(BANNER_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Banner visibility for AppLayout margin. Once dismissed it stays hidden
+ * across visits (localStorage); the Play button takes its place.
+ */
 export function usePlayPromoBannerVisible() {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
-    const hide = () => setVisible(false);
-    window.addEventListener(BANNER_DISMISS_EVENT, hide);
-    return () => window.removeEventListener(BANNER_DISMISS_EVENT, hide);
+    const sync = () => setVisible(!isBannerDismissed());
+    sync();
+    window.addEventListener(BANNER_DISMISS_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(BANNER_DISMISS_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
   }, []);
 
   return visible;
 }
 
 function markBannerDismissed() {
+  try {
+    localStorage.setItem(BANNER_STORAGE_KEY, "1");
+  } catch {
+    // Storage may be unavailable (private browsing etc.) — worst case the
+    // banner shows again next visit, never worse than that.
+  }
   window.dispatchEvent(new Event(BANNER_DISMISS_EVENT));
 }
 
@@ -138,133 +163,119 @@ function markModalDismissed() {
 }
 
 export function PlayPromoModal() {
+  const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
-    if (!config.fantasyEnabled) return;
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || !config.fantasyEnabled) return;
     if (isModalDismissed()) return;
-    // Small delay so it doesn't flash on initial page load.
     const timer = setTimeout(() => setIsOpen(true), 500);
     return () => clearTimeout(timer);
-  }, []);
+  }, [mounted]);
 
   const dismiss = useCallback(() => {
     markModalDismissed();
     setIsOpen(false);
   }, []);
 
-  if (!config.fantasyEnabled) return null;
+  if (!config.fantasyEnabled || !mounted) return null;
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <Dialog open={isOpen} onClose={dismiss} className="relative z-[70]">
+    <Dialog open={isOpen} onClose={dismiss} className="relative z-[100]">
+      <div
+        className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+
+      <div className="pointer-events-none fixed inset-0 z-[101] flex items-center justify-center p-4">
+        <DialogPanel className="pointer-events-auto relative w-full max-w-[450px]">
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
-            className="fixed inset-0 bg-black/50 backdrop-blur-sm"
-            aria-hidden="true"
-          />
-
-          <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+          >
+            <div
+              className="relative overflow-hidden rounded-[28px] bg-lavender-500 shadow-2xl w-[315px] h-[393px] md:w-[450px] md:h-[560px]"
+              style={{ containerType: "inline-size" }}
             >
-              <DialogPanel>
-                {/* Fixed to the mobile design size on every breakpoint — the
-                    promo is intentionally not "responsive" here. */}
-                <div
-                  className="relative overflow-hidden rounded-[28px] bg-lavender-500 shadow-2xl w-[315px] h-[393px] md:w-[450px] md:h-[560px]"
-                  style={{ containerType: "inline-size" }}
-                >
-                  <ModalBackdrop />
-                  <Collage />
+              <ModalBackdrop />
+              <Collage />
 
-                  {/* The FIFA World Cup emblem in the design is licensed and
-                      can't ship here — swapped for our own animated mark,
-                      cycling ball/trophy only (no "n" — this spot shouldn't
-                      show the Noblocks brand icon). */}
-                  <div
-                    className="absolute flex items-center justify-center"
-                    style={{ left: "5.99%", top: "5.52%", width: "13.71%", height: "11.13%" }}
-                  >
-                    <NoblocksAnimatedIcon phases={["ball", "trophy"]} className="size-[32px]" />
-                  </div>
+              <div
+                className="absolute z-20 flex items-center justify-center"
+                style={{ left: "5.99%", top: "5.52%", width: "13.71%", height: "11.13%" }}
+              >
+                <NoblocksAnimatedIcon phases={["ball", "trophy"]} className="size-[32px]" />
+              </div>
 
-                  <button
-                    type="button"
-                    onClick={dismiss}
-                    aria-label="Dismiss"
-                    className="absolute flex items-center justify-center rounded-full border border-white/30 bg-white/30 backdrop-blur-sm transition-colors hover:bg-white/40"
-                    style={{ left: "88.23%", top: "4.19%", width: "8.54%", height: "6.91%" }}
-                  >
-                    <img src={ASSET("close-icon.svg")} alt="" className="h-1/2 w-1/2" />
-                  </button>
+              <button
+                type="button"
+                onClick={dismiss}
+                aria-label="Dismiss"
+                className="absolute z-30 flex items-center justify-center rounded-full border border-white/30 bg-white/30 backdrop-blur-sm transition-colors hover:bg-white/40"
+                style={{ left: "88.23%", top: "4.19%", width: "8.54%", height: "6.91%" }}
+              >
+                <img src={ASSET("close-icon.svg")} alt="" className="pointer-events-none h-1/2 w-1/2" />
+              </button>
 
-                  {/* Font sizes/tracking are in cqw (container-query width),
-                      scaled from the exact design px values at the 318px
-                      reference card, so they stay pixel-accurate whether the
-                      card renders at 318px or the 450px desktop size above. */}
-                  <h2
-                    className="absolute font-bold text-[#F5F5F5]"
-                    style={{
-                      left: "8.4943%",
-                      top: "54.2398%",
-                      width: "47.6834%",
-                      fontSize: "10.821cqw",
-                      lineHeight: 0.761,
-                      letterSpacing: "-0.7575cqw",
-                    }}
-                  >
-                    Predict.
-                    <br />
-                    Compete.
-                    <br />
-                    Win.
-                  </h2>
+              <h2
+                className="absolute z-10 font-bold text-[#F5F5F5]"
+                style={{
+                  left: "8.4943%",
+                  top: "54.2398%",
+                  width: "47.6834%",
+                  fontSize: "10.821cqw",
+                  lineHeight: 0.761,
+                  letterSpacing: "-0.7575cqw",
+                }}
+              >
+                Predict.
+                <br />
+                Compete.
+                <br />
+                Win.
+              </h2>
 
-                  <p
-                    className="absolute text-[#F5F5F5]"
-                    style={{
-                      left: "8.4943%",
-                      top: "76.5802%",
-                      width: "53.0245%",
-                      fontSize: "2.28cqw",
-                      lineHeight: 1.351,
-                      letterSpacing: "-0.0456cqw",
-                    }}
-                  >
-                    Build your fantasy squad, earn points from real World Cup
-                    performances, climb the leaderboard, and win exclusive
-                    rewards.
-                  </p>
+              <p
+                className="absolute z-10 text-[#F5F5F5]"
+                style={{
+                  left: "8.4943%",
+                  top: "76.5802%",
+                  width: "53.0245%",
+                  fontSize: "2.28cqw",
+                  lineHeight: 1.351,
+                  letterSpacing: "-0.0456cqw",
+                }}
+              >
+                Build your fantasy squad, earn points from real World Cup
+                performances, climb the leaderboard, and win exclusive
+                rewards.
+              </p>
 
-                  <Link
-                    href="/play"
-                    onClick={dismiss}
-                    className="absolute flex items-center justify-center rounded-full bg-white font-semibold text-black transition-transform active:scale-[0.98]"
-                    style={{
-                      left: "6.9182%",
-                      top: "86.9085%",
-                      width: "86.1635%",
-                      height: "8.9036%",
-                      fontSize: "3.33cqw",
-                    }}
-                  >
-                    Play now
-                  </Link>
-                </div>
-              </DialogPanel>
-            </motion.div>
-          </div>
-        </Dialog>
-      )}
-    </AnimatePresence>
+              <Link
+                href="/play"
+                onClick={dismiss}
+                className="absolute z-30 flex items-center justify-center rounded-full bg-white font-semibold text-black transition-transform active:scale-[0.98]"
+                style={{
+                  left: "6.9182%",
+                  top: "86.9085%",
+                  width: "86.1635%",
+                  height: "8.9036%",
+                  fontSize: "3.33cqw",
+                }}
+              >
+                Play now
+              </Link>
+            </div>
+          </motion.div>
+        </DialogPanel>
+      </div>
+    </Dialog>
   );
 }
 
@@ -285,19 +296,19 @@ const MiniCollage = () => (
     <img
       src={ASSET("olise.png")}
       alt=""
-      className="pointer-events-none absolute object-cover"
+      className="pointer-events-none absolute object-cover object-top"
       style={{ left: "23.68%", top: "10.01%", width: "62.74%", height: "109.42%" }}
     />
     <img
       src={ASSET("ronaldo.png")}
       alt=""
-      className="pointer-events-none absolute object-cover"
+      className="pointer-events-none absolute object-cover object-top"
       style={{ left: "33.86%", top: "2.73%", width: "63.08%", height: "223.80%" }}
     />
     <img
       src={ASSET("messi.png")}
       alt=""
-      className="pointer-events-none absolute object-cover"
+      className="pointer-events-none absolute object-cover object-top"
       style={{ left: "-35.09%", top: "14.14%", width: "134.57%", height: "147.26%" }}
     />
   </div>
@@ -314,8 +325,11 @@ export function PlayPromoBanner() {
   if (!config.fantasyEnabled || dismissed) return null;
 
   return (
+    <>
     <motion.div
-      className="fixed left-0 right-0 top-16 z-30 mt-1 bg-lavender-500"
+      // Below the navbar (z-50) so the logo dropdown shows above the banner.
+      // Still above page content; dropdowns/modals (z-50+) stay on top.
+      className="pointer-events-none fixed left-0 right-0 top-16 z-[30] mt-1 overflow-visible"
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, ease: "easeOut" }}
@@ -324,146 +338,145 @@ export function PlayPromoBanner() {
         type="button"
         onClick={dismiss}
         aria-label="Dismiss promo banner"
-        className="absolute -right-1.5 -top-1.5 z-20 flex size-6 items-center justify-center rounded-full bg-black/25 text-black shadow-sm transition-colors hover:bg-black/35 md:hidden"
+        className="pointer-events-auto absolute right-0.5 top-1/2 z-30 flex size-8 -translate-y-1/2 items-center justify-center text-white/90 transition-colors hover:text-white md:hidden"
       >
-        <IoClose className="size-3.5" />
+        <IoClose className="size-[22px]" strokeWidth={2.5} />
       </button>
-      <button
-        type="button"
-        onClick={dismiss}
-        aria-label="Dismiss promo banner"
-        className="absolute right-4 top-1/2 z-10 hidden size-8 -translate-y-1/2 items-center justify-center rounded-full bg-black/25 text-black shadow-sm transition-colors hover:bg-black/35 md:flex"
-      >
-        <IoClose className="size-5" />
-      </button>
-      <div className="relative overflow-hidden">
-        <BannerBackdrop />
-
-      {/* Mobile: pixel-exact recreation of the Figma banner (375px-wide
-          reference strip, node 2135-79717). Font sizes/tracking are in cqw
-          so they stay accurate across real device widths near the 375px
-          reference. */}
-      <div
-        className="relative h-[65px] md:hidden"
-        style={{ containerType: "inline-size" }}
-      >
-        <div
-          className="absolute"
-          style={{ left: "0.18%", top: "-5.36%", width: "22.24%", height: "134.68%" }}
-        >
-          <MiniCollage />
+      {/* Mobile */}
+      <div className="relative h-[65px] md:hidden">
+        <div className="absolute inset-0 overflow-hidden bg-lavender-500">
+          <BannerBackdrop />
         </div>
-
-        <div
-          className="absolute"
-          style={{ left: "25.0656%", top: "10.9111%", width: "74.6287%", height: "78.3714%" }}
+        <div className="relative z-20 flex h-full items-center gap-1 pr-[3.25rem] pl-[24%] xsm:gap-1.5 xsm:pr-[3.5rem]">
+          <h2 className="ml-1 shrink-0 text-[19px] font-bold leading-[0.76] tracking-[-0.07em] text-black xsm:text-[20px]">
+            Predict.
+            <br />
+            Compete.
+            <br />
+            Win.
+          </h2>
+          <p className="ml-0.5 min-w-0 flex-1 -translate-y-0.5 whitespace-nowrap text-[8px] font-normal leading-[1.35] tracking-[-0.02em] text-[#F5F5F5] xsm:ml-1.5 xsm:text-[9px]">
+            Build your fantasy squad, earn points
+            <br />
+            from real World Cup performances,
+            <br />
+            and win exclusive rewards.
+          </p>
+        </div>
+        <Link
+          href="/play"
+          onClick={dismiss}
+          className="pointer-events-auto absolute right-8 top-1/2 z-30 -translate-y-1/2 shrink-0 rounded-md bg-white px-1.5 py-1.5 text-[8px] font-semibold leading-none text-black transition-colors hover:bg-white/90 xsm:right-9 xsm:px-2 xsm:text-[9px]"
         >
-          <h2
-            className="absolute font-bold text-black leading-[0.95]"
-            style={{
-              left: "0%",
-              top: "0%",
-              width: "28.32%",
-              height: "100%",
-              fontSize: "4.656cqw",
-              letterSpacing: "-0.3259cqw",
-            }}
-          >
+          Join
+        </Link>
+      </div>
+
+      {/* Desktop — Figma: strip with the collage flush left, popping above */}
+      <div className="relative hidden h-[64px] items-center md:flex">
+        <div className="absolute inset-0 overflow-hidden bg-lavender-500">
+          <BannerBackdrop />
+        </div>
+        <div className="relative z-20 flex h-full w-full items-center gap-4 pl-[min(210px,16.5vw)] pr-[220px] lg:gap-5 lg:pr-[260px]">
+          <h2 className="ml-12 shrink-0 whitespace-nowrap text-[26px] font-bold leading-[0.76] tracking-[-0.07em] text-black lg:ml-24 xl:text-[35px]">
             Predict. Compete. Win.
           </h2>
-          <p
-            className="absolute text-[#F5F5F5]"
-            style={{
-              left: "30.54%",
-              top: "19.23%",
-              width: "42.68%",
-              height: "61.54%",
-              fontSize: "1.498cqw",
-              lineHeight: 1.351,
-              letterSpacing: "-0.0299cqw",
-            }}
-          >
+          <p className="max-w-[26rem] shrink-0 text-[13px] leading-[1.3] text-[#F5F5F5] xl:max-w-[28rem] xl:text-sm">
             Build your fantasy squad, earn points from real World Cup
             performances, climb the leaderboard, and win exclusive rewards.
           </p>
-          <Link
-            href="/play"
-            className="absolute flex items-center justify-center rounded-md bg-white font-semibold text-black"
-            style={{
-              left: "77.44%",
-              top: "23.32%",
-              width: "20.56%",
-              height: "53.36%",
-              fontSize: "1.789cqw",
-            }}
-          >
-            Join the league
-          </Link>
-        </div>
-      </div>
-
-      {/* Desktop: adapted layout — no desktop frame exists in the design, so
-          this is a reinterpretation (larger thumbnail, roomier text/button)
-          rather than a pixel clone. */}
-      <div className="relative hidden h-20 md:flex">
-        <div
-          className="absolute scale-[0.65]"
-          style={{ left: "-0.28%", top: "-60.36%", width: "22.24%", height: "334.68%" }}
-        >
-          <MiniCollage />
         </div>
 
-        {/* Explicit height (not fit-content): every child here is absolute
-            (out of flow), so a fit-content parent collapses to zero and any
-            child using height:"100%" would resolve against that zero. */}
-        <div
-          className="absolute"
-          style={{ left: "25.0656%", top: "0%", width: "74.6287%", height: "100%" }}
-        >
-          <h2
-            className="absolute flex items-center font-bold text-black leading-[0.95]"
-            style={{
-              left: "-7%",
-              top: "0%",
-              width: "48.32%",
-              height: "100%",
-              fontSize: "1.156cqw",
-              letterSpacing: "-0.1259cqw",
-            }}
-          >
-            Predict. Compete. Win.
-          </h2>
-          <p
-            className="absolute flex items-center text-[#F5F5F5]"
-            style={{
-              left: "35.54%",
-              top: "0%",
-              width: "32.68%",
-              height: "100%",
-              fontSize: "0.798cqw",
-              lineHeight: 0.951,
-              letterSpacing: "-0.0299cqw",
-            }}
-          >
-            Build your fantasy squad, earn points from real World Cup
-            performances, climb the leaderboard, and win exclusive rewards.
-          </p>
-          <Link
-            href="/play"
-            className="absolute flex items-center justify-center rounded-xl px-4 py-4 bg-white hover:bg-white/90  font-semibold text-black transition-transform"
-            style={{
-              left: "82.44%",
-              top: "50%",
-              width: "fit-content",
-              height: "57%",
-              transform: "translateY(-50%)",
-              fontSize: "0.79cqw",
-            }}
-          >
-            Join the league
-          </Link>
+        {/* Align with navbar Network + Settings (same container + wallet offset) */}
+        <div className="pointer-events-none absolute inset-x-0 top-1/2 z-30 hidden -translate-y-1/2 md:block">
+          <div className="mx-auto flex w-full max-w-screen-2xl justify-end px-4 lg:px-8">
+            <div className="flex items-center gap-3 sm:gap-4">
+              {/* Skip wallet chip width so actions sit under Network + Settings */}
+              <div className="hidden h-9 w-[5.75rem] shrink-0 sm:block" aria-hidden />
+              <Link
+                href="/play"
+                onClick={dismiss}
+                className="pointer-events-auto shrink-0 rounded-xl bg-white px-5 py-2 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+              >
+                Join a league
+              </Link>
+              <button
+                type="button"
+                onClick={dismiss}
+                aria-label="Dismiss promo banner"
+                className="pointer-events-auto flex size-6 shrink-0 items-center justify-center text-white/90 transition-colors hover:text-white"
+              >
+                <IoClose className="size-5" strokeWidth={2} />
+              </button>
+            </div>
+          </div>
         </div>
       </div>
+    </motion.div>
+
+    {/* Collage on its own fixed layer above the banner strip (z-30) so the trophy
+        tip + heads pop over the strip's top edge. Logo dropdown is portaled at
+        z-[60] in Navbar so it still appears above this layer. */}
+    <div className="pointer-events-none fixed left-0 right-0 top-16 z-[55] mt-1 overflow-visible">
+      {/* Mobile */}
+      <div className="relative h-[65px] md:hidden">
+        <div
+          className="absolute bottom-0 left-0 w-[26%] min-w-[80px] max-w-[116px] overflow-hidden"
+          style={{ top: "-28px" }}
+        >
+          <div className="absolute inset-0" style={{ transform: "translate(-10px, 22px)" }}>
+            <MiniCollage />
+          </div>
+        </div>
+      </div>
+      {/* Desktop */}
+      <div className="relative hidden h-[64px] md:block">
+        <div
+          className="absolute bottom-0 left-0 w-[min(240px,18vw)] overflow-hidden"
+          style={{ top: "-42px" }}
+        >
+          <div className="absolute inset-0" style={{ transform: "translateY(22px)" }}>
+            <MiniCollage />
+          </div>
+        </div>
+      </div>
+    </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Play button — shown in place of the banner once it has been dismissed
+// (via the X or "Join a league"). Persists across visits and links to /play.
+// ---------------------------------------------------------------------------
+
+export function PlayPromoButton() {
+  const bannerVisible = usePlayPromoBannerVisible();
+
+  // Only takes the banner's place: hidden while the banner is showing, and
+  // gone entirely once the campaign (fantasy) is switched off.
+  if (!config.fantasyEnabled || bannerVisible) return null;
+
+  return (
+    <motion.div
+      className="pointer-events-none fixed left-0 right-0 top-[72px] z-30"
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <div className="mx-auto flex max-w-screen-2xl justify-end px-4 lg:px-8">
+        <Link
+          href="/play"
+          aria-label="Open Noblocks Play"
+          className="pointer-events-auto flex h-[34px] items-center gap-1 rounded-[7.31px] border border-icon-outline-secondary px-2.5 text-[11.81px] font-semibold leading-none text-text-body transition-colors hover:bg-accent-gray/50 dark:border-white/50 dark:text-white dark:hover:bg-white/5"
+        >
+          <NoblocksAnimatedIcon phases={["ball"]} className="size-[18px] shrink-0" />
+          Play
+          <ArrowDown01Icon
+            className="size-4 shrink-0 -rotate-90 text-icon-outline-secondary dark:text-white/50"
+            strokeWidth={4}
+          />
+        </Link>
       </div>
     </motion.div>
   );

--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 import { IoClose } from "react-icons/io5";
 import { ArrowDown01Icon } from "hugeicons-react";
 import { Dialog, DialogPanel } from "@headlessui/react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import config from "../lib/config";
 import { NoblocksAnimatedIcon } from "./NoblocksAnimatedIcon";
 
@@ -118,11 +118,15 @@ function isBannerDismissed(): boolean {
  * across visits (localStorage); the Play button takes its place.
  */
 export function usePlayPromoBannerVisible() {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(() =>
+    typeof window === "undefined" ? false : !isBannerDismissed(),
+  );
+  const [ready, setReady] = useState(() => typeof window !== "undefined");
 
   useEffect(() => {
     const sync = () => setVisible(!isBannerDismissed());
     sync();
+    setReady(true);
     window.addEventListener(BANNER_DISMISS_EVENT, sync);
     window.addEventListener("storage", sync);
     return () => {
@@ -131,6 +135,7 @@ export function usePlayPromoBannerVisible() {
     };
   }, []);
 
+  if (!ready) return false;
   return visible;
 }
 
@@ -185,97 +190,110 @@ export function PlayPromoModal() {
   if (!config.fantasyEnabled || !mounted) return null;
 
   return (
-    <Dialog open={isOpen} onClose={dismiss} className="relative z-[100]">
-      <div
-        className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm"
-        aria-hidden="true"
-      />
-
-      <div className="pointer-events-none fixed inset-0 z-[101] flex items-center justify-center p-4">
-        <DialogPanel className="pointer-events-auto relative w-full max-w-[450px]">
+    <AnimatePresence>
+      {isOpen && (
+        <Dialog
+          static
+          open={isOpen}
+          onClose={dismiss}
+          className="relative z-[100]"
+        >
           <motion.div
-            initial={{ scale: 0.95, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.95, opacity: 0 }}
-            transition={{ type: "spring", stiffness: 300, damping: 30 }}
-          >
-            <div
-              className="relative overflow-hidden rounded-[28px] bg-lavender-500 shadow-2xl w-[315px] h-[393px] md:w-[450px] md:h-[560px]"
-              style={{ containerType: "inline-size" }}
-            >
-              <ModalBackdrop />
-              <Collage />
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm"
+            aria-hidden="true"
+          />
 
-              <div
-                className="absolute z-20 flex items-center justify-center"
-                style={{ left: "5.99%", top: "5.52%", width: "13.71%", height: "11.13%" }}
+          <div className="pointer-events-none fixed inset-0 z-[101] flex items-center justify-center p-4">
+            <DialogPanel className="pointer-events-auto relative w-full max-w-[450px]">
+              <motion.div
+                initial={{ scale: 0.95, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.95, opacity: 0 }}
+                transition={{ type: "spring", stiffness: 300, damping: 30 }}
               >
-                <NoblocksAnimatedIcon phases={["ball", "trophy"]} className="size-[32px]" />
-              </div>
+                <div
+                  className="relative overflow-hidden rounded-[28px] bg-lavender-500 shadow-2xl w-[315px] h-[393px] md:w-[450px] md:h-[560px]"
+                  style={{ containerType: "inline-size" }}
+                >
+                  <ModalBackdrop />
+                  <Collage />
 
-              <button
-                type="button"
-                onClick={dismiss}
-                aria-label="Dismiss"
-                className="absolute z-30 flex items-center justify-center rounded-full border border-white/30 bg-white/30 backdrop-blur-sm transition-colors hover:bg-white/40"
-                style={{ left: "88.23%", top: "4.19%", width: "8.54%", height: "6.91%" }}
-              >
-                <img src={ASSET("close-icon.svg")} alt="" className="pointer-events-none h-1/2 w-1/2" />
-              </button>
+                  <div
+                    className="absolute z-20 flex items-center justify-center"
+                    style={{ left: "5.99%", top: "5.52%", width: "13.71%", height: "11.13%" }}
+                  >
+                    <NoblocksAnimatedIcon phases={["ball", "trophy"]} className="size-[32px]" />
+                  </div>
 
-              <h2
-                className="absolute z-10 font-bold text-[#F5F5F5]"
-                style={{
-                  left: "8.4943%",
-                  top: "54.2398%",
-                  width: "47.6834%",
-                  fontSize: "10.821cqw",
-                  lineHeight: 0.761,
-                  letterSpacing: "-0.7575cqw",
-                }}
-              >
-                Predict.
-                <br />
-                Compete.
-                <br />
-                Win.
-              </h2>
+                  <button
+                    type="button"
+                    onClick={dismiss}
+                    aria-label="Dismiss"
+                    className="absolute z-30 flex items-center justify-center rounded-full border border-white/30 bg-white/30 backdrop-blur-sm transition-colors hover:bg-white/40"
+                    style={{ left: "88.23%", top: "4.19%", width: "8.54%", height: "6.91%" }}
+                  >
+                    <img src={ASSET("close-icon.svg")} alt="" className="pointer-events-none h-1/2 w-1/2" />
+                  </button>
 
-              <p
-                className="absolute z-10 text-[#F5F5F5]"
-                style={{
-                  left: "8.4943%",
-                  top: "76.5802%",
-                  width: "53.0245%",
-                  fontSize: "2.28cqw",
-                  lineHeight: 1.351,
-                  letterSpacing: "-0.0456cqw",
-                }}
-              >
-                Build your fantasy squad, earn points from real World Cup
-                performances, climb the leaderboard, and win exclusive
-                rewards.
-              </p>
+                  <h2
+                    className="absolute z-10 font-bold text-[#F5F5F5]"
+                    style={{
+                      left: "8.4943%",
+                      top: "54.2398%",
+                      width: "47.6834%",
+                      fontSize: "10.821cqw",
+                      lineHeight: 0.761,
+                      letterSpacing: "-0.7575cqw",
+                    }}
+                  >
+                    Predict.
+                    <br />
+                    Compete.
+                    <br />
+                    Win.
+                  </h2>
 
-              <Link
-                href="/play"
-                onClick={dismiss}
-                className="absolute z-30 flex items-center justify-center rounded-full bg-white font-semibold text-black transition-transform active:scale-[0.98]"
-                style={{
-                  left: "6.9182%",
-                  top: "86.9085%",
-                  width: "86.1635%",
-                  height: "8.9036%",
-                  fontSize: "3.33cqw",
-                }}
-              >
-                Play now
-              </Link>
-            </div>
-          </motion.div>
-        </DialogPanel>
-      </div>
-    </Dialog>
+                  <p
+                    className="absolute z-10 text-[#F5F5F5]"
+                    style={{
+                      left: "8.4943%",
+                      top: "76.5802%",
+                      width: "53.0245%",
+                      fontSize: "2.28cqw",
+                      lineHeight: 1.351,
+                      letterSpacing: "-0.0456cqw",
+                    }}
+                  >
+                    Build your fantasy squad, earn points from real World Cup
+                    performances, climb the leaderboard, and win exclusive
+                    rewards.
+                  </p>
+
+                  <Link
+                    href="/play"
+                    onClick={dismiss}
+                    className="absolute z-30 flex items-center justify-center rounded-full bg-white font-semibold text-black transition-transform active:scale-[0.98]"
+                    style={{
+                      left: "6.9182%",
+                      top: "86.9085%",
+                      width: "86.1635%",
+                      height: "8.9036%",
+                      fontSize: "3.33cqw",
+                    }}
+                  >
+                    Play now
+                  </Link>
+                </div>
+              </motion.div>
+            </DialogPanel>
+          </div>
+        </Dialog>
+      )}
+    </AnimatePresence>
   );
 }
 
@@ -315,132 +333,140 @@ const MiniCollage = () => (
 );
 
 export function PlayPromoBanner() {
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(() =>
+    typeof window === "undefined" ? false : isBannerDismissed(),
+  );
+  const [ready, setReady] = useState(() => typeof window !== "undefined");
+
+  useEffect(() => {
+    setDismissed(isBannerDismissed());
+    setReady(true);
+  }, []);
 
   const dismiss = useCallback(() => {
     markBannerDismissed();
     setDismissed(true);
   }, []);
 
-  if (!config.fantasyEnabled || dismissed) return null;
+  if (!config.fantasyEnabled || !ready || dismissed) return null;
 
   return (
     <>
-    <motion.div
-      // Below the navbar (z-50) so the logo dropdown shows above the banner.
-      // Still above page content; dropdowns/modals (z-50+) stay on top.
-      className="pointer-events-none fixed left-0 right-0 top-16 z-[30] mt-1 overflow-visible"
-      initial={{ opacity: 0, y: -20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: "easeOut" }}
-    >
-      <button
-        type="button"
-        onClick={dismiss}
-        aria-label="Dismiss promo banner"
-        className="pointer-events-auto absolute right-0.5 top-1/2 z-30 flex size-8 -translate-y-1/2 items-center justify-center text-white/90 transition-colors hover:text-white md:hidden"
+      <motion.div
+        // Below the navbar (z-50) so the logo dropdown shows above the banner.
+        // Still above page content; dropdowns/modals (z-50+) stay on top.
+        className="pointer-events-none fixed left-0 right-0 top-16 z-[30] mt-1 overflow-visible"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
       >
-        <IoClose className="size-[22px]" strokeWidth={2.5} />
-      </button>
-      {/* Mobile */}
-      <div className="relative h-[65px] md:hidden">
-        <div className="absolute inset-0 overflow-hidden bg-lavender-500">
-          <BannerBackdrop />
-        </div>
-        <div className="relative z-20 flex h-full items-center gap-1 pr-[3.25rem] pl-[24%] xsm:gap-1.5 xsm:pr-[3.5rem]">
-          <h2 className="ml-1 shrink-0 text-[19px] font-bold leading-[0.76] tracking-[-0.07em] text-black xsm:text-[20px]">
-            Predict.
-            <br />
-            Compete.
-            <br />
-            Win.
-          </h2>
-          <p className="ml-0.5 min-w-0 flex-1 -translate-y-0.5 whitespace-nowrap text-[8px] font-normal leading-[1.35] tracking-[-0.02em] text-[#F5F5F5] xsm:ml-1.5 xsm:text-[9px]">
-            Build your fantasy squad, earn points
-            <br />
-            from real World Cup performances,
-            <br />
-            and win exclusive rewards.
-          </p>
-        </div>
-        <Link
-          href="/play"
+        <button
+          type="button"
           onClick={dismiss}
-          className="pointer-events-auto absolute right-8 top-1/2 z-30 -translate-y-1/2 shrink-0 rounded-md bg-white px-1.5 py-1.5 text-[8px] font-semibold leading-none text-black transition-colors hover:bg-white/90 xsm:right-9 xsm:px-2 xsm:text-[9px]"
+          aria-label="Dismiss promo banner"
+          className="pointer-events-auto absolute right-0.5 top-1/2 z-30 flex size-8 -translate-y-1/2 items-center justify-center text-white/90 transition-colors hover:text-white md:hidden"
         >
-          Join
-        </Link>
-      </div>
-
-      {/* Desktop — Figma: strip with the collage flush left, popping above */}
-      <div className="relative hidden h-[64px] items-center md:flex">
-        <div className="absolute inset-0 overflow-hidden bg-lavender-500">
-          <BannerBackdrop />
+          <IoClose className="size-[22px]" strokeWidth={2.5} />
+        </button>
+        {/* Mobile */}
+        <div className="relative h-[65px] md:hidden">
+          <div className="absolute inset-0 overflow-hidden bg-lavender-500">
+            <BannerBackdrop />
+          </div>
+          <div className="relative z-20 flex h-full items-center gap-1 pr-[3.25rem] pl-[24%] xsm:gap-1.5 xsm:pr-[3.5rem]">
+            <h2 className="ml-1 shrink-0 text-[19px] font-bold leading-[0.76] tracking-[-0.07em] text-black xsm:text-[20px]">
+              Predict.
+              <br />
+              Compete.
+              <br />
+              Win.
+            </h2>
+            <p className="ml-0.5 min-w-0 flex-1 -translate-y-0.5 whitespace-nowrap text-[8px] font-normal leading-[1.35] tracking-[-0.02em] text-[#F5F5F5] xsm:ml-1.5 xsm:text-[9px]">
+              Build your fantasy squad, earn points
+              <br />
+              from real World Cup performances,
+              <br />
+              and win exclusive rewards.
+            </p>
+          </div>
+          <Link
+            href="/play"
+            onClick={dismiss}
+            className="pointer-events-auto absolute right-8 top-1/2 z-30 -translate-y-1/2 shrink-0 rounded-md bg-white px-1.5 py-1.5 text-[8px] font-semibold leading-none text-black transition-colors hover:bg-white/90 xsm:right-9 xsm:px-2 xsm:text-[9px]"
+          >
+            Join
+          </Link>
         </div>
-        <div className="relative z-20 flex h-full w-full items-center gap-4 pl-[min(210px,16.5vw)] pr-[220px] lg:gap-5 lg:pr-[260px]">
-          <h2 className="ml-12 shrink-0 whitespace-nowrap text-[26px] font-bold leading-[0.76] tracking-[-0.07em] text-black lg:ml-24 xl:text-[35px]">
-            Predict. Compete. Win.
-          </h2>
-          <p className="max-w-[26rem] shrink-0 text-[13px] leading-[1.3] text-[#F5F5F5] xl:max-w-[28rem] xl:text-sm">
-            Build your fantasy squad, earn points from real World Cup
-            performances, climb the leaderboard, and win exclusive rewards.
-          </p>
-        </div>
 
-        {/* Align with navbar Network + Settings (same container + wallet offset) */}
-        <div className="pointer-events-none absolute inset-x-0 top-1/2 z-30 hidden -translate-y-1/2 md:block">
-          <div className="mx-auto flex w-full max-w-screen-2xl justify-end px-4 lg:px-8">
-            <div className="flex items-center gap-3 sm:gap-4">
-              {/* Skip wallet chip width so actions sit under Network + Settings */}
-              <div className="hidden h-9 w-[5.75rem] shrink-0 sm:block" aria-hidden />
-              <Link
-                href="/play"
-                onClick={dismiss}
-                className="pointer-events-auto shrink-0 rounded-xl bg-white px-5 py-2 text-sm font-semibold text-black transition-colors hover:bg-white/90"
-              >
-                Join a league
-              </Link>
-              <button
-                type="button"
-                onClick={dismiss}
-                aria-label="Dismiss promo banner"
-                className="pointer-events-auto flex size-6 shrink-0 items-center justify-center text-white/90 transition-colors hover:text-white"
-              >
-                <IoClose className="size-5" strokeWidth={2} />
-              </button>
+        {/* Desktop — Figma: strip with the collage flush left, popping above */}
+        <div className="relative hidden h-[64px] items-center md:flex">
+          <div className="absolute inset-0 overflow-hidden bg-lavender-500">
+            <BannerBackdrop />
+          </div>
+          <div className="relative z-20 flex h-full w-full items-center gap-4 pl-[min(210px,16.5vw)] pr-[220px] lg:gap-5 lg:pr-[260px]">
+            <h2 className="ml-12 shrink-0 whitespace-nowrap text-[26px] font-bold leading-[0.76] tracking-[-0.07em] text-black lg:ml-24 xl:text-[35px]">
+              Predict. Compete. Win.
+            </h2>
+            <p className="max-w-[26rem] shrink-0 text-[13px] leading-[1.3] text-[#F5F5F5] xl:max-w-[28rem] xl:text-sm">
+              Build your fantasy squad, earn points from real World Cup
+              performances, climb the leaderboard, and win exclusive rewards.
+            </p>
+          </div>
+
+          {/* Align with navbar Network + Settings (same container + wallet offset) */}
+          <div className="pointer-events-none absolute inset-x-0 top-1/2 z-30 hidden -translate-y-1/2 md:block">
+            <div className="mx-auto flex w-full max-w-screen-2xl justify-end px-4 lg:px-8">
+              <div className="flex items-center gap-3 sm:gap-4">
+                {/* Skip wallet chip width so actions sit under Network + Settings */}
+                <div className="hidden h-9 w-[5.75rem] shrink-0 sm:block" aria-hidden />
+                <Link
+                  href="/play"
+                  onClick={dismiss}
+                  className="pointer-events-auto shrink-0 rounded-xl bg-white px-5 py-2 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+                >
+                  Join a league
+                </Link>
+                <button
+                  type="button"
+                  onClick={dismiss}
+                  aria-label="Dismiss promo banner"
+                  className="pointer-events-auto flex size-6 shrink-0 items-center justify-center text-white/90 transition-colors hover:text-white"
+                >
+                  <IoClose className="size-5" strokeWidth={2} />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Collage on its own fixed layer above the banner strip (z-30) so the trophy
+        tip + heads pop over the strip's top edge. Logo dropdown is portaled at
+        z-[60] in Navbar so it still appears above this layer. */}
+      <div className="pointer-events-none fixed left-0 right-0 top-16 z-[55] mt-1 overflow-visible">
+        {/* Mobile */}
+        <div className="relative h-[65px] md:hidden">
+          <div
+            className="absolute bottom-0 left-0 w-[26%] min-w-[80px] max-w-[116px] overflow-hidden"
+            style={{ top: "-28px" }}
+          >
+            <div className="absolute inset-0" style={{ transform: "translate(-10px, 22px)" }}>
+              <MiniCollage />
+            </div>
+          </div>
+        </div>
+        {/* Desktop */}
+        <div className="relative hidden h-[64px] md:block">
+          <div
+            className="absolute bottom-0 left-0 w-[min(240px,18vw)] overflow-hidden"
+            style={{ top: "-42px" }}
+          >
+            <div className="absolute inset-0" style={{ transform: "translateY(22px)" }}>
+              <MiniCollage />
             </div>
           </div>
         </div>
       </div>
-    </motion.div>
-
-    {/* Collage on its own fixed layer above the banner strip (z-30) so the trophy
-        tip + heads pop over the strip's top edge. Logo dropdown is portaled at
-        z-[60] in Navbar so it still appears above this layer. */}
-    <div className="pointer-events-none fixed left-0 right-0 top-16 z-[55] mt-1 overflow-visible">
-      {/* Mobile */}
-      <div className="relative h-[65px] md:hidden">
-        <div
-          className="absolute bottom-0 left-0 w-[26%] min-w-[80px] max-w-[116px] overflow-hidden"
-          style={{ top: "-28px" }}
-        >
-          <div className="absolute inset-0" style={{ transform: "translate(-10px, 22px)" }}>
-            <MiniCollage />
-          </div>
-        </div>
-      </div>
-      {/* Desktop */}
-      <div className="relative hidden h-[64px] md:block">
-        <div
-          className="absolute bottom-0 left-0 w-[min(240px,18vw)] overflow-hidden"
-          style={{ top: "-42px" }}
-        >
-          <div className="absolute inset-0" style={{ transform: "translateY(22px)" }}>
-            <MiniCollage />
-          </div>
-        </div>
-      </div>
-    </div>
     </>
   );
 }

--- a/app/components/play/PlayShell.tsx
+++ b/app/components/play/PlayShell.tsx
@@ -4,7 +4,7 @@
  * Noblocks Play — standalone game chrome. The global Navbar/Footer are
  * intentionally NOT rendered on /play* (see AppLayout): the game is its own
  * full experience, with the animated World Cup wordmark as its identity and
- * a CTA back to the main Noblocks app.
+ * a CTA back to the main Noblocks homepage (swap).
  *
  * Desktop: collapsed icon rail on the left that expands in flow on hover,
  * pushing the content right like a slide-out panel.
@@ -40,7 +40,8 @@ export const PlayHeader = ({ right }: { right?: ReactNode }) => (
           href="/"
           className="flex min-h-9 items-center gap-1.5 rounded-xl border border-border-light px-3 text-xs font-medium text-text-secondary transition-colors hover:bg-accent-gray hover:text-text-body dark:border-white/10 dark:text-white/60 dark:hover:bg-white/5 dark:hover:text-white sm:min-h-10 sm:px-4 sm:text-sm"
         >
-          Back to Noblocks
+          <span className="sm:hidden">Home</span>
+          <span className="max-sm:hidden">Back to homepage</span>
           <ArrowUpRight01Icon className="size-4" />
         </Link>
       </div>


### PR DESCRIPTION
### Description

This PR polishes the Noblocks Play homepage promo experience and fixes several UI layering and form-feedback issues introduced while aligning the banner/modal with Figma.

**Noblocks Play promo (homepage)**

- Adds `PlayPromoButton` to `AppLayout` so a compact **Play** CTA remains in the navbar area after the promo banner is dismissed.
- Refines `PlayPromoBanner` layout for mobile and desktop:
  - Mobile: shorter **Join** CTA, adjusted typography/spacing for headline and subcopy, larger dismiss (X) control.
  - Desktop: **Join a league** + dismiss aligned under navbar **Network** and **Settings** using the same `max-w-screen-2xl` container.
- Improves `PlayPromoModal` dismiss behavior and persistence:
  - Modal dismiss is stored in `localStorage` (`noblocks_play_promo_dismissed`) so it only shows once per visitor.
  - Banner dismiss is stored separately (`noblocks_play_promo_banner_dismissed`) and drives `usePlayPromoBannerVisible()` for layout spacing and `PlayPromoButton` visibility.
  - Modal renders only after client mount to avoid hydration/click issues; overlay uses `pointer-events-none` with interactive content on `pointer-events-auto`.
- Fixes z-index/stacking conflicts between the promo banner, player collage, and navbar:
  - Banner strip stays below the navbar (`z-[30]`).
  - Player/trophy collage is rendered on a separate fixed layer (`z-[55]`) so the cup tip and heads can pop above the strip.
  - Navbar logo dropdown is portaled to `document.body` at `z-[60]` so it remains visible above the collage.

**Navbar**

- Refines logo dropdown behavior with fixed positioning, resize/scroll repositioning, and improved hover bridge / mouse-leave handling between the trigger and portaled menu.

**Refund account modal**

- Updates `AddRefundAccountModal` to show dynamic error styling on the account number input (`border-red-500`) and inline `InputError` when validation fails.

**Play experience**

- Updates `PlayShell` copy/labels so navigation back to swap is clearer (**Home** on mobile, **Back to homepage** on desktop).

**Impacts**

- UI-only changes; no API or contract changes.
- No breaking changes expected for consumers of Noblocks routes/components.

**Alternatives considered**

- Raising only navbar or banner z-index without splitting collage/dropdown layers — rejected because it caused either the cup tip or logo dropdown to be clipped/hidden.
- Keeping the logo dropdown inside the navbar stacking context — rejected because the promo collage layer painted over it.

### References

_No linked issues for this PR._

### Testing

Manual verification on homepage with `fantasyEnabled` enabled:

- [ ] Promo modal opens once, **Play now** and **X** remain clickable after page load; dismiss persists across refresh.
- [ ] Promo banner shows under navbar; player collage cup tip is visible above the strip.
- [ ] Hover/open Noblocks logo dropdown while banner is visible — menu appears above collage and is fully clickable.
- [ ] Dismiss banner via **X** or **Join**/**Join a league** — banner hides, `PlayPromoButton` appears, spacing updates correctly.
- [ ] Mobile banner: **Join**, **X**, headline, and subcopy spacing look correct.
- [ ] Desktop banner: **Join a league** + **X** align under Network/Settings.
- [ ] `AddRefundAccountModal`: invalid account number shows red border + error message.
- [ ] `/play`: **Back to homepage** / **Home** link returns to `/`.

<img width="1217" height="142" alt="Screenshot 2026-07-07 161948" src="https://github.com/user-attachments/assets/72c3853a-2f3e-48c9-9553-74520d588ebb" />
<img width="1574" height="283" alt="Screenshot 2026-07-07 161932" src="https://github.com/user-attachments/assets/f3867963-8b46-4697-ad93-5262b418642b" />
<img width="556" height="233" alt="Screenshot 2026-07-07 161910" src="https://github.com/user-attachments/assets/9bd59fa4-3045-4e9a-abf5-67a3c032e3e9" />
<img width="611" height="240" alt="Screenshot 2026-07-07 161850" src="https://github.com/user-attachments/assets/e1b11fd8-727e-48d0-aa74-98c1e2054bea" />
<img width="2099" height="241" alt="Screenshot 2026-07-07 161819" src="https://github.com/user-attachments/assets/31a219c5-e224-4b40-ad9a-0e8997c0ec86" />


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

---

If you want this committed or opened as a PR via `gh`, switch to **Agent mode** and I can do that for you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Play promo button and banner to the homepage.
  * Improved Play navigation labels for small screens.

* **Bug Fixes**
  * Improved the navbar logo dropdown behavior so it remains open when moving between the related menu areas.
  * Made the Play promo banner dismissal persist across sessions and browser tabs.
  * Updated account number input styling to clearly show and highlight validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->