### PR TITLE
feat: Enhance BridgeForm and related components for improved user experience

### DIFF
--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -448,7 +448,6 @@ export const MobileDropdown = ({
                       {currentView === "bridge" && (
                         <BridgeForm
                           onClose={onClose}
-                          showBackButton
                           layout="mobile"
                           setCurrentView={setCurrentView}
                           onBridgeSubmit={trackBridge}

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -394,27 +394,37 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
 
   return (
     <div className="relative flex flex-col gap-5">
-      {/* Header */}
+      {/* Header — mobile: centered title, back arrow only on the form step, never a close icon.
+          Desktop: unaffected — title left-aligned, close icon always present. */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          {showBackButton && (
+        {layout === "mobile" ? (
+          <>
+            <div className="flex size-8 shrink-0 items-center justify-center">
+              {showBackButton && step === "form" && (
+                <button
+                  type="button"
+                  onClick={() => setCurrentView?.("wallet")}
+                  className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
+                >
+                  <ArrowLeft02Icon className="size-4" />
+                </button>
+              )}
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
+            <div className="size-8 shrink-0" />
+          </>
+        ) : (
+          <>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
             <button
               type="button"
-              onClick={() => setCurrentView?.("wallet")}
-              className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20 sm:hidden"
+              onClick={onClose}
+              className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
             >
-              <ArrowLeft02Icon className="size-4" />
+              <Cancel01Icon className="size-4" />
             </button>
-          )}
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
-        >
-          <Cancel01Icon className="size-4" />
-        </button>
+          </>
+        )}
       </div>
 
       {!authenticated ? (

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -39,7 +39,6 @@ export interface BridgeSubmitInfo {
 
 interface BridgeFormProps {
   onClose: () => void;
-  showBackButton?: boolean;
   setCurrentView?: React.Dispatch<React.SetStateAction<MobileSheetView>>;
   layout?: "modal" | "mobile";
   onBridgeSubmit?: (info: BridgeSubmitInfo) => void;
@@ -53,7 +52,6 @@ function getNetworkImgSrc(network: (typeof networks)[0]): string {
 
 export const BridgeForm: React.FC<BridgeFormProps> = ({
   onClose,
-  showBackButton = false,
   setCurrentView,
   layout = "modal",
   onBridgeSubmit,
@@ -255,7 +253,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
             amountSent: parsedAmount,
             amountReceived: parseFloat(quote.amountOut),
             // Fee consolidated to the receiving token (existing NUMERIC column, stored in to_currency).
-            fee: bridgeFeeInReceivingToken(quote),
+            fee: bridgeFeeInReceivingToken(quote, to.decimals),
             recipient: {
               account_name: "Convert",
               institution: quote.kind === "lifi-tx" ? "LI.FI" : "NEAR Intents",
@@ -284,7 +282,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
         toNetwork: to.network,
         amountSent: amount,
         amountReceived: quote.amountOut,
-        fee: bridgeFeeInReceivingToken(quote),
+        fee: bridgeFeeInReceivingToken(quote, to.decimals),
         timestamp: Date.now(),
       });
       setStep("status");
@@ -394,37 +392,23 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
 
   return (
     <div className="relative flex flex-col gap-5">
-      {/* Header — mobile: centered title, back arrow only on the form step, never a close icon.
-          Desktop: unaffected — title left-aligned, close icon always present. */}
+      {/* Header — centered title, back arrow only on the form step, never a close icon.
+          Same on desktop and mobile: on desktop there's no view stack to go "back" to, so the
+          arrow just closes the modal instead. */}
       <div className="flex items-center justify-between">
-        {layout === "mobile" ? (
-          <>
-            <div className="flex size-8 shrink-0 items-center justify-center">
-              {showBackButton && step === "form" && (
-                <button
-                  type="button"
-                  onClick={() => setCurrentView?.("wallet")}
-                  className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
-                >
-                  <ArrowLeft02Icon className="size-4" />
-                </button>
-              )}
-            </div>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
-            <div className="size-8 shrink-0" />
-          </>
-        ) : (
-          <>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
+        <div className="flex size-8 shrink-0 items-center justify-center">
+          {step === "form" && (
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => (setCurrentView ? setCurrentView("wallet") : onClose())}
               className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
             >
-              <Cancel01Icon className="size-4" />
+              <ArrowLeft02Icon className="size-4" />
             </button>
-          </>
-        )}
+          )}
+        </div>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Convert</h2>
+        <div className="size-8 shrink-0" />
       </div>
 
       {!authenticated ? (

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -157,7 +157,6 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   const isDone = liveStatus === "SUCCESS";
   const isRefunded = liveStatus === "REFUNDED";
   const isFailed = liveStatus === "FAILED";
-  const isTerminal = isDone || isRefunded || isFailed;
 
   // Prefer the destination-chain tx on success (where funds landed); otherwise the source tx.
   const explorerLink = statusInfo
@@ -253,7 +252,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
             amountSent: parsedAmount,
             amountReceived: parseFloat(quote.amountOut),
             // Fee consolidated to the receiving token (existing NUMERIC column, stored in to_currency).
-            fee: bridgeFeeInReceivingToken(quote, to.decimals),
+            fee: bridgeFeeInReceivingToken(quote),
             recipient: {
               account_name: "Convert",
               institution: quote.kind === "lifi-tx" ? "LI.FI" : "NEAR Intents",
@@ -282,7 +281,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
         toNetwork: to.network,
         amountSent: amount,
         amountReceived: quote.amountOut,
-        fee: bridgeFeeInReceivingToken(quote, to.decimals),
+        fee: bridgeFeeInReceivingToken(quote),
         timestamp: Date.now(),
       });
       setStep("status");
@@ -651,7 +650,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                   onClick={onClose}
                   className={classNames(primaryBtnClasses, "w-full")}
                 >
-                  {isTerminal ? "Close" : "Done"}
+                  {isDone ? "Done" : "Close"}
                 </button>
               )}
             </div>
@@ -661,9 +660,15 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
 
       {/* ── Picker overlay ── */}
       {activePicker && layout === "mobile" && (
-        <div className="absolute w-full inset-0 z-60 w-full" onClick={() => setActivePicker(null)}>
+        <div
+          className="absolute inset-0 z-40 rounded-2xl bg-black/40"
+          onClick={() => setActivePicker(null)}
+        >
           {/* True bottom sheet — docks to the bottom, doesn't cover the whole form */}
-          <div className="absolute inset-x-0 -bottom-12 z-50 flex min-h-[195px] max-h-[75%] flex-col rounded-t-2xl border border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-neutral-900">
+          <div
+            className="absolute inset-x-0 bottom-0 z-50 flex min-h-[195px] max-h-[75%] flex-col rounded-t-2xl border border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-neutral-900"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex shrink-0 justify-center pb-1 pt-2.5">
               <div className="h-1 w-10 rounded-full bg-gray-300 dark:bg-white/20" />
             </div>

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -12,15 +12,22 @@ import type { BridgeLeg, BridgeEngine } from "@/app/lib/bridge";
 import { BridgeRouteSelector } from "./BridgeRouteSelector";
 import type { PickerTarget } from "./BridgeRouteSelector";
 import { BridgeQuoteCard } from "./BridgeQuoteCard";
-import { ArrowLeft02Icon, Cancel01Icon } from "hugeicons-react";
+import {
+  ArrowLeft02Icon,
+  ArrowRight03Icon,
+  Cancel01Icon,
+  InformationSquareIcon,
+  SadDizzyIcon,
+} from "hugeicons-react";
 import { useDelegationContractAuth } from "@/app/hooks/useEIP7702Account";
-import { primaryBtnClasses } from "../Styles";
-import { classNames, getExplorerLink } from "@/app/utils";
+import { primaryBtnClasses, outlineBtnClasses } from "../Styles";
+import { classNames, formatTokenAmount, getExplorerLink } from "@/app/utils";
 import type { MobileSheetView } from "@/app/types";
 import { saveTransaction } from "@/app/api/aggregator";
 import { networks } from "@/app/mocks";
 import Link from "next/link";
 import { mapReportAndAct } from "@/app/lib/toastMappedError";
+import { format } from "date-fns";
 
 const CONVERSION_FAILED_MESSAGE = "Please try again.";
 
@@ -48,6 +55,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   onClose,
   showBackButton = false,
   setCurrentView,
+  layout = "modal",
   onBridgeSubmit,
 }) => {
   const { authenticated, getAccessToken } = usePrivy();
@@ -67,6 +75,14 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     depositRefId: string;
     engine: BridgeEngine;
     savedTxId: string | null;
+    fromToken: string;
+    fromNetwork: string;
+    toToken: string;
+    toNetwork: string;
+    amountSent: string;
+    amountReceived: string;
+    fee: number;
+    timestamp: number;
   } | null>(null);
   const [from, setFrom] = useState<BridgeLeg | null>(null);
   const [to, setTo] = useState<BridgeLeg | null>(null);
@@ -257,7 +273,20 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
         savedTxId = saved?.data?.id ?? null;
       }
 
-      setStatusInfo({ txHash, depositRefId, engine: resolvedEngine, savedTxId });
+      setStatusInfo({
+        txHash,
+        depositRefId,
+        engine: resolvedEngine,
+        savedTxId,
+        fromToken: from.token,
+        fromNetwork: from.network,
+        toToken: to.token,
+        toNetwork: to.network,
+        amountSent: amount,
+        amountReceived: quote.amountOut,
+        fee: bridgeFeeInReceivingToken(quote),
+        timestamp: Date.now(),
+      });
       setStep("status");
 
       // Notify parent to track status updates
@@ -302,6 +331,16 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   // ── Picker overlay content ───────────────────────────────────────────────────
 
   const isNetworkPicker = activePicker === "fromNet" || activePicker === "toNet";
+  const pickerHeaderText =
+    activePicker === "fromNet"
+      ? "Select 'from' network"
+      : activePicker === "toNet"
+        ? "Select 'to' network"
+        : activePicker === "fromToken"
+          ? "Select 'from' token"
+          : activePicker === "toToken"
+            ? "Select 'to' token"
+            : "";
   const pickerItems = isNetworkPicker
     ? networks.map((n) => ({
         id: n.chain.name,
@@ -317,6 +356,39 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
           sub: t.name,
         }),
       );
+
+  const pickerListContent =
+    pickerItems.length === 0 ? (
+      <p className="px-4 py-3 text-sm text-gray-400 dark:text-white/40">
+        No options available for this network.
+      </p>
+    ) : (
+      pickerItems.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          onClick={() => handlePickerSelect(item.id)}
+          className="flex w-full items-center gap-3 px-4 py-3 text-left text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-white/5 active:bg-gray-100 dark:active:bg-white/10 transition-colors"
+        >
+          <img
+            src={item.imgSrc}
+            alt={item.label}
+            className="size-8 rounded-full shrink-0 bg-gray-100 dark:bg-white/10"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+          <div className="min-w-0">
+            <p className="font-semibold text-sm leading-tight">{item.label}</p>
+            {item.sub && (
+              <p className="text-xs text-gray-400 dark:text-white/40 truncate">
+                {item.sub}
+              </p>
+            )}
+          </div>
+        </button>
+      ))
+    );
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
@@ -368,7 +440,18 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                 outputAmount={quote?.amountOut ?? undefined}
                 engine={engine}
                 timeEstimate={timeEstimate}
+                isQuoteLoading={quoteLoading}
               />
+
+              {fromNetworkName !== toNetworkName && (
+                <div className="flex items-start gap-2 rounded-xl bg-gray-100 dark:bg-neutral-800/60 border border-gray-200 dark:border-white/5 p-3 text-sm text-text-secondary dark:text-white/50">
+                  <InformationSquareIcon className="size-4 shrink-0 mt-0.5" />
+                  <span>
+                    Funds route through {fromNetworkName} to {toNetworkName} and
+                    may take a few minutes longer.
+                  </span>
+                </div>
+              )}
 
               {noRailAvailable ? (
                 <div className="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-900/30 p-3 text-sm text-amber-700 dark:text-amber-400">
@@ -405,18 +488,8 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
 
           {step === "failed" && (
             <div className="flex flex-col items-center gap-5 py-6 text-center">
-              <div className="flex size-16 items-center justify-center rounded-full border-2 border-red-500">
-                <svg
-                  className="size-8 text-red-500"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
+              <div className="flex size-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+                <SadDizzyIcon className="size-8 text-red-500 dark:text-red-400" />
               </div>
               <div className="space-y-1.5">
                 <p className="text-lg font-bold text-gray-900 dark:text-white">
@@ -462,7 +535,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                 </div>
               ) : isFailed ? (
                 <div className="flex size-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
-                  <Cancel01Icon className="size-8 text-red-600 dark:text-red-400" />
+                  <SadDizzyIcon className="size-8 text-red-500 dark:text-red-400" />
                 </div>
               ) : (
                 <div className="size-16 animate-spin rounded-full border-4 border-gray-200 border-t-blue-500 dark:border-gray-700 dark:border-t-blue-400" />
@@ -486,7 +559,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                         ? "The conversion failed. Any funds that left your wallet will be refunded."
                         : "Your transaction is being processed. You can close this window and track its progress in transaction history."}
                 </p>
-                {explorerLink && (
+                {!isDone && explorerLink && (
                   <a
                     href={explorerLink}
                     target="_blank"
@@ -497,20 +570,120 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                   </a>
                 )}
               </div>
-              <button
-                type="button"
-                onClick={onClose}
-                className={classNames(primaryBtnClasses, "w-full")}
-              >
-                {isTerminal ? "Close" : "Done"}
-              </button>
+
+              {isDone && statusInfo && (
+                <div className="w-full space-y-3 rounded-2xl border border-gray-200 bg-gray-100 p-4 text-left dark:border-white/5 dark:bg-neutral-800/60">
+                  <div className="flex items-center gap-2">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <img
+                        src={`/logos/${statusInfo.fromToken.toLowerCase()}-logo.svg`}
+                        alt={statusInfo.fromToken}
+                        className="size-6 shrink-0 rounded-full"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = "none";
+                        }}
+                      />
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                          {formatTokenAmount(statusInfo.amountSent)}{" "}
+                          {statusInfo.fromToken}
+                        </p>
+                        <p className="truncate text-xs text-gray-400 dark:text-white/40">
+                          {statusInfo.fromNetwork}
+                        </p>
+                      </div>
+                    </div>
+                    <ArrowRight03Icon className="size-4 shrink-0 text-gray-400 dark:text-white/40" />
+                    <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
+                      <div className="min-w-0 text-right">
+                        <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                          {formatTokenAmount(statusInfo.amountReceived)}{" "}
+                          {statusInfo.toToken}
+                        </p>
+                        <p className="truncate text-xs text-gray-400 dark:text-white/40">
+                          {statusInfo.toNetwork}
+                        </p>
+                      </div>
+                      <img
+                        src={`/logos/${statusInfo.toToken.toLowerCase()}-logo.svg`}
+                        alt={statusInfo.toToken}
+                        className="size-6 shrink-0 rounded-full"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = "none";
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2 border-t border-gray-200 pt-3 dark:border-white/10">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-500 dark:text-white/50">
+                        Transaction fee
+                      </span>
+                      <span className="text-gray-700 dark:text-white/70">
+                        {formatTokenAmount(statusInfo.fee)} {statusInfo.toToken}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-500 dark:text-white/50">Date</span>
+                      <span className="text-gray-700 dark:text-white/70">
+                        {format(new Date(statusInfo.timestamp), "MMM d, yyyy '·' h:mm a")}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {isDone && explorerLink ? (
+                <div className="flex w-full gap-3">
+                  <a
+                    href={explorerLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={classNames(outlineBtnClasses, "flex-1")}
+                  >
+                    View on explorer
+                  </a>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className={classNames(primaryBtnClasses, "flex-1")}
+                  >
+                    Done
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className={classNames(primaryBtnClasses, "w-full")}
+                >
+                  {isTerminal ? "Close" : "Done"}
+                </button>
+              )}
             </div>
           )}
         </>
       )}
 
-      {/* ── Picker overlay — covers the entire BridgeForm ── */}
-      {activePicker && (
+      {/* ── Picker overlay ── */}
+      {activePicker && layout === "mobile" && (
+        <div className="absolute w-full inset-0 z-60 w-full" onClick={() => setActivePicker(null)}>
+          {/* True bottom sheet — docks to the bottom, doesn't cover the whole form */}
+          <div className="absolute inset-x-0 -bottom-12 z-50 flex min-h-[195px] max-h-[75%] flex-col rounded-t-2xl border border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-neutral-900">
+            <div className="flex shrink-0 justify-center pb-1 pt-2.5">
+              <div className="h-1 w-10 rounded-full bg-gray-300 dark:bg-white/20" />
+            </div>
+            <div className="shrink-0 px-4 pb-3 pt-1">
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {pickerHeaderText}
+              </span>
+            </div>
+            <div className="flex-1 overflow-y-auto pb-2">{pickerListContent}</div>
+          </div>
+        </div>
+      )}
+
+      {activePicker && layout !== "mobile" && (
         <div className="absolute inset-0 z-50 flex flex-col rounded-2xl bg-white dark:bg-neutral-900 border border-gray-200 dark:border-white/10 overflow-hidden">
           <div className="flex items-center gap-3 border-b border-gray-200 dark:border-white/10 p-4 shrink-0">
             <button
@@ -525,39 +698,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
             </span>
           </div>
 
-          <div className="flex-1 overflow-y-auto py-1.5">
-            {pickerItems.length === 0 ? (
-              <p className="px-4 py-3 text-sm text-gray-400 dark:text-white/40">
-                No options available for this network.
-              </p>
-            ) : (
-              pickerItems.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => handlePickerSelect(item.id)}
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-white/5 active:bg-gray-100 dark:active:bg-white/10 transition-colors"
-                >
-                  <img
-                    src={item.imgSrc}
-                    alt={item.label}
-                    className="size-8 rounded-full shrink-0 bg-gray-100 dark:bg-white/10"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = "none";
-                    }}
-                  />
-                  <div className="min-w-0">
-                    <p className="font-semibold text-sm leading-tight">{item.label}</p>
-                    {item.sub && (
-                      <p className="text-xs text-gray-400 dark:text-white/40 truncate">
-                        {item.sub}
-                      </p>
-                    )}
-                  </div>
-                </button>
-              ))
-            )}
-          </div>
+          <div className="flex-1 overflow-y-auto py-1.5">{pickerListContent}</div>
         </div>
       )}
     </div>

--- a/app/components/bridge/BridgeQuoteCard.tsx
+++ b/app/components/bridge/BridgeQuoteCard.tsx
@@ -28,8 +28,11 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
       setSecondsLeft(null);
       return;
     }
+    // `deadline` is how long the deposit address stays open (often days), not a short-lived
+    // price guarantee — cap the displayed countdown to 5 minutes so stale rates get refreshed.
+    const cappedDeadline = Math.min(quote.deadline, Date.now() + 5 * 60 * 1000);
     const tick = () => {
-      const remaining = Math.max(0, Math.floor((quote.deadline - Date.now()) / 1000));
+      const remaining = Math.max(0, Math.floor((cappedDeadline - Date.now()) / 1000));
       setSecondsLeft(remaining);
       if (remaining === 0) onExpire?.();
     };
@@ -101,13 +104,6 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
         bold
       />
 
-      {quote.kind === "lifi-tx" && Number(quote.feeReceivingToken) > 0 && (
-        <Row
-          label="Transaction fee"
-          value={`${formatTokenAmount(quote.feeReceivingToken)} ${toToken || ""}`}
-        />
-      )}
-
       {quote.kind === "lifi-tx" &&
         parseInt(String(quote.estimate.executionDuration)) > 0 && (
           <Row
@@ -129,6 +125,13 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
               : "Expired"}
           </span>
         </div>
+      )}
+
+      {quote.kind === "lifi-tx" && Number(quote.feeReceivingToken) > 0 && (
+        <Row
+          label="Transaction fee"
+          value={`${formatTokenAmount(quote.feeReceivingToken)} ${toToken || ""}`}
+        />
       )}
     </div>
   );

--- a/app/components/bridge/BridgeRouteSelector.tsx
+++ b/app/components/bridge/BridgeRouteSelector.tsx
@@ -245,7 +245,7 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
         <div className="flex items-center justify-between">
           <TokenPill symbol={to?.token} target="toToken" />
           <span className="text-xs text-text-secondary dark:text-white/40">
-            On {toNetworkName}
+            on {toNetworkName}
           </span>
         </div>
         <div className="flex items-end justify-between">

--- a/app/components/bridge/BridgeRouteSelector.tsx
+++ b/app/components/bridge/BridgeRouteSelector.tsx
@@ -2,7 +2,13 @@
 
 import React, { useMemo } from "react";
 import { classNames, formatDecimalPrecision, formatTokenAmount } from "@/app/utils";
-import { Exchange01Icon, ArrowDown01Icon, ArrowUpDownIcon } from "hugeicons-react";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  ArrowRight03Icon,
+  ArrowUpDownIcon,
+  Wallet01Icon,
+} from "hugeicons-react";
 import { useBalance } from "@/app/context/BalanceContext";
 import { networks } from "@/app/mocks";
 import type { BridgeLeg } from "@/app/lib/bridge";
@@ -24,6 +30,7 @@ interface BridgeRouteSelectorProps {
   outputAmount?: string;
   engine?: "near" | "lifi" | null;
   timeEstimate?: string;
+  isQuoteLoading?: boolean;
 }
 
 function getNetworkImgSrc(network: (typeof networks)[0]): string {
@@ -47,6 +54,7 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
   outputAmount,
   engine,
   timeEstimate,
+  isQuoteLoading,
 }) => {
   const { crossChainBalances } = useBalance();
 
@@ -130,43 +138,59 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
     <button
       type="button"
       onClick={() => onOpenPicker(target)}
-      className="flex items-center gap-1.5 rounded-full bg-white dark:bg-neutral-700 px-3 py-2 text-xs font-semibold capitalize tracking-wide text-text-secondary dark:text-white/60 hover:bg-none dark:hover:bg-neutral-600 active:scale-95 transition-all"
+      className="flex min-w-0 max-w-[45%] items-center gap-1.5 rounded-full bg-white dark:bg-neutral-700 px-3 py-2 text-xs font-semibold capitalize tracking-wide text-text-secondary dark:text-white/60 hover:bg-none dark:hover:bg-neutral-600 active:scale-95 transition-all"
     >
       {networkObj && (
         <img
           src={getNetworkImgSrc(networkObj)}
           alt={networkName}
-          className="size-3.5 rounded-full"
+          className="size-3.5 shrink-0 rounded-full"
           onError={(e) => {
             (e.target as HTMLImageElement).style.display = "none";
           }}
         />
       )}
-      <span>{networkName}</span>
-      <ArrowDown01Icon className="size-3 text-gray-400 dark:text-white/40" />
+      <span className="min-w-0 truncate">{networkName}</span>
+      <ArrowDown01Icon className="size-3 shrink-0 text-gray-400 dark:text-white/40" />
     </button>
   );
 
   return (
     <div className="space-y-2">
-      {/* FROM label + balance */}
-      <div className=" flex items-end justify-end px-1">
-        {from && fromBalance > 0 && (
-          <span className="self-end text-xs text-text-secondary dark:text-white/40">
-            Balance: {formatTokenAmount(fromBalance)} {from.token}
-          </span>
-        )}
+      {/* Network route bar */}
+      <div className="rounded-2xl bg-gray-100 dark:bg-neutral-800/60 border border-gray-200 dark:border-white/5 p-4 space-y-2">
+        <p className="text-xs text-text-secondary dark:text-white/40">
+          Select network route
+        </p>
+        <div className="flex items-center justify-between gap-2">
+          <NetworkChip
+            networkName={fromNetworkName}
+            networkObj={fromNetworkObj}
+            target="fromNet"
+          />
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gray-200 dark:bg-neutral-700 text-gray-400 dark:text-white/40">
+            <ArrowRight03Icon className="size-4" />
+          </div>
+          <NetworkChip
+            networkName={toNetworkName}
+            networkObj={toNetworkObj}
+            target="toNet"
+          />
+        </div>
+      </div>
+
+      {/* FROM label */}
+      <div className="flex items-end justify-between px-1">
+        <span className="text-xs text-text-secondary dark:text-white/40">From</span>
       </div>
 
       {/* FROM card */}
       <div className={cardCls}>
         <div className="flex items-center justify-between">
           <TokenPill symbol={from?.token} target="fromToken" />
-          <NetworkChip
-            networkName={fromNetworkName}
-            networkObj={fromNetworkObj}
-            target="fromNet"
-          />
+          <span className="text-xs text-text-secondary dark:text-white/40">
+            on {fromNetworkName}
+          </span>
         </div>
         <div className="flex items-end justify-between gap-2">
           <input
@@ -177,37 +201,52 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
             placeholder="0.00"
             className="text-3xl font-light bg-transparent text-gray-900 dark:text-white placeholder-gray-300 dark:placeholder-white/20 outline-none w-full min-w-0"
           />
-          <button
-            type="button"
-            onClick={handleMax}
-            disabled={fromBalance <= 0}
-            className="mb-1 shrink-0 rounded-lg bg-lavender-100 dark:bg-lavender-900/30 px-3 py-1 text-xs font-bold text-lavender-600 dark:text-lavender-400 hover:bg-lavender-200 dark:hover:bg-lavender-900/50 disabled:opacity-40 transition-colors"
-          >
-            MAX
-          </button>
+          {from && fromBalance > 0 && (
+            <div className="mb-1 flex shrink-0 flex-col items-end gap-1">
+              <span className="flex items-center gap-1 text-xs text-text-secondary dark:text-white/40">
+                <Wallet01Icon className="size-3.5" />
+                {formatTokenAmount(fromBalance)} {from.token}
+              </span>
+              <button
+                type="button"
+                onClick={handleMax}
+                className="text-xs font-bold text-lavender-600 dark:text-lavender-400 hover:underline"
+              >
+                Max
+              </button>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Middle row: TO label + engine badge + est time + flip */}
-      <div className="flex items-center justify-center px-1 py-0.5">
+      {/* Flip control */}
+      <div className="relative flex items-center justify-center py-0.5">
+        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-gray-200 dark:bg-white/10" />
         <button
           type="button"
           onClick={handleFlip}
-          className="flex size-10 items-center justify-center rounded-full bg-gray-200 dark:bg-neutral-700 text-gray-500 dark:text-white/60 hover:bg-gray-300 dark:hover:bg-neutral-600 active:scale-95 transition-all"
+          className="relative flex size-10 items-center justify-center rounded-full bg-gray-200 dark:bg-neutral-700 text-gray-500 dark:text-white/60 hover:bg-gray-300 dark:hover:bg-neutral-600 active:scale-95 transition-all"
         >
-          <ArrowUpDownIcon className="size-4" />
+          {isQuoteLoading ? (
+            <div className="size-4 animate-spin rounded-full border-2 border-gray-400 border-t-transparent dark:border-white/40 dark:border-t-transparent" />
+          ) : (
+            <ArrowUpDownIcon className="size-4" />
+          )}
         </button>
+      </div>
+
+      {/* TO label */}
+      <div className="flex items-end justify-between px-1">
+        <span className="text-xs text-text-secondary dark:text-white/40">to</span>
       </div>
 
       {/* TO card */}
       <div className={cardCls}>
         <div className="flex items-center justify-between">
           <TokenPill symbol={to?.token} target="toToken" />
-          <NetworkChip
-            networkName={toNetworkName}
-            networkObj={toNetworkObj}
-            target="toNet"
-          />
+          <span className="text-xs text-text-secondary dark:text-white/40">
+            On {toNetworkName}
+          </span>
         </div>
         <div className="flex items-end justify-between">
           <span

--- a/app/hooks/bridge.ts
+++ b/app/hooks/bridge.ts
@@ -83,7 +83,7 @@ export function useBridgeQuote({
         refundType: "ORIGIN_CHAIN",
         deadline: new Date(Date.now() + 600000).toISOString(),
         depositType: "ORIGIN_CHAIN",
-      }, token);
+      }, token, { origin: from.decimals, destination: to.decimals });
     }
 
     const fromChain = toLifiChainId(from.network);

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -216,13 +216,18 @@ export function toRawAmount(amount: string, decimals: number): string {
  * Total conversion fee expressed in the *receiving* token, for the single NUMERIC `fee`
  * column on the transactions table. LI.FI fees come in mixed tokens and are all `included`
  * (already deducted from the amount received); we consolidate them to one USD total and
- * convert to the receiving token (see LifiClient.getQuote). NEAR exposes one fee value.
+ * convert to the receiving token (see LifiClient.getQuote), already human-readable. NEAR's
+ * `fee` (withdrawFee/refundFee) is a raw base-unit string and needs decimals conversion.
  */
-export function bridgeFeeInReceivingToken(quote: BridgeQuote): number {
+export function bridgeFeeInReceivingToken(quote: BridgeQuote, toDecimals: number): number {
   if (quote.kind === "lifi-tx") {
     return parseFloat(quote.feeReceivingToken) || 0;
   }
-  return parseFloat(quote.fee) || 0;
+  try {
+    return parseFloat(formatUnits(BigInt(quote.fee || "0"), toDecimals)) || 0;
+  } catch {
+    return 0;
+  }
 }
 
 // ============================================================================

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -217,17 +217,14 @@ export function toRawAmount(amount: string, decimals: number): string {
  * column on the transactions table. LI.FI fees come in mixed tokens and are all `included`
  * (already deducted from the amount received); we consolidate them to one USD total and
  * convert to the receiving token (see LifiClient.getQuote), already human-readable. NEAR's
- * `fee` (withdrawFee/refundFee) is a raw base-unit string and needs decimals conversion.
+ * `fee` is normalized to a human-readable string in `normalizeQuote` (withdrawFee is in
+ * destination-token units, refundFee in origin-token units — decimals differ per field).
  */
-export function bridgeFeeInReceivingToken(quote: BridgeQuote, toDecimals: number): number {
+export function bridgeFeeInReceivingToken(quote: BridgeQuote): number {
   if (quote.kind === "lifi-tx") {
     return parseFloat(quote.feeReceivingToken) || 0;
   }
-  try {
-    return parseFloat(formatUnits(BigInt(quote.fee || "0"), toDecimals)) || 0;
-  } catch {
-    return 0;
-  }
+  return parseFloat(quote.fee) || 0;
 }
 
 // ============================================================================
@@ -255,9 +252,28 @@ function authHeaders(token?: string | null): Record<string, string> {
 }
 
 export class NearIntentsClient {
-  private normalizeQuote(data: any, params: NearQuoteParams): NearDepositQuote {
+  /**
+   * `withdrawFee` is denominated in the destination asset's smallest units; `refundFee`
+   * (the fallback, charged instead when a refund path is taken) is denominated in the
+   * *origin* asset's units — each needs its own decimals to convert correctly.
+   */
+  private normalizeQuote(
+    data: any,
+    params: NearQuoteParams,
+    decimals: { origin: number; destination: number },
+  ): NearDepositQuote {
     const q = data.quote ?? data; // response nests amounts under data.quote
     const secs: number = q.timeEstimate ?? 30;
+    let fee = "0";
+    try {
+      if (q.withdrawFee) {
+        fee = formatUnits(BigInt(q.withdrawFee), decimals.destination);
+      } else if (q.refundFee) {
+        fee = formatUnits(BigInt(q.refundFee), decimals.origin);
+      }
+    } catch {
+      fee = "0";
+    }
     return {
       kind: "near-deposit",
       depositAddress: data.quote?.depositAddress ?? data.depositAddress ?? "",
@@ -266,17 +282,21 @@ export class NearIntentsClient {
         ? new Date(data.quote.deadline).getTime()
         : Date.now() + 600_000,
       timeEstimate: `~${secs} seconds`,
-      fee: q.withdrawFee ?? q.refundFee ?? "0",
+      fee,
       raw: data,
       _params: params,
     } as NearDepositQuote & { _params: NearQuoteParams };
   }
 
-  async getQuote(params: NearQuoteParams, token?: string | null): Promise<BridgeQuote> {
+  async getQuote(
+    params: NearQuoteParams,
+    token: string | null | undefined,
+    decimals: { origin: number; destination: number },
+  ): Promise<BridgeQuote> {
     const { data } = await axios.post("/api/bridge/near-intents/quote", params, {
       headers: authHeaders(token),
     });
-    return this.normalizeQuote(data, params);
+    return this.normalizeQuote(data, params, decimals);
   }
 
   /** Re-requests with dry:false to get the real deposit address for execution. */

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -214,11 +214,12 @@ export function toRawAmount(amount: string, decimals: number): string {
 
 /**
  * Total conversion fee expressed in the *receiving* token, for the single NUMERIC `fee`
- * column on the transactions table. LI.FI fees come in mixed tokens and are all `included`
+ * column on the transactions table (and for display, which always labels this value with
+ * the receiving token's symbol). LI.FI fees come in mixed tokens and are all `included`
  * (already deducted from the amount received); we consolidate them to one USD total and
  * convert to the receiving token (see LifiClient.getQuote), already human-readable. NEAR's
- * `fee` is normalized to a human-readable string in `normalizeQuote` (withdrawFee is in
- * destination-token units, refundFee in origin-token units — decimals differ per field).
+ * `fee` is normalized to a receiving-token-denominated string in `normalizeQuote` — see the
+ * comment there for how the origin-denominated `refundFee` fallback is converted.
  */
 export function bridgeFeeInReceivingToken(quote: BridgeQuote): number {
   if (quote.kind === "lifi-tx") {
@@ -253,9 +254,12 @@ function authHeaders(token?: string | null): Record<string, string> {
 
 export class NearIntentsClient {
   /**
-   * `withdrawFee` is denominated in the destination asset's smallest units; `refundFee`
+   * `withdrawFee` is already denominated in the destination asset — used as-is. `refundFee`
    * (the fallback, charged instead when a refund path is taken) is denominated in the
-   * *origin* asset's units — each needs its own decimals to convert correctly.
+   * *origin* asset, so it's converted to destination-token terms using the quote's own
+   * exchange rate (amountOut / amountIn) before being stored — callers (BridgeForm's DB
+   * write and receipt card) always label `fee` with the receiving token's symbol, so the
+   * value itself must actually be in those terms, not just correctly-scaled-but-wrong-currency.
    */
   private normalizeQuote(
     data: any,
@@ -269,7 +273,11 @@ export class NearIntentsClient {
       if (q.withdrawFee) {
         fee = formatUnits(BigInt(q.withdrawFee), decimals.destination);
       } else if (q.refundFee) {
-        fee = formatUnits(BigInt(q.refundFee), decimals.origin);
+        const originFee = parseFloat(formatUnits(BigInt(q.refundFee), decimals.origin));
+        const amountIn = parseFloat(q.amountInFormatted ?? "0");
+        const amountOut = parseFloat(q.amountOutFormatted ?? "0");
+        const rate = amountIn > 0 ? amountOut / amountIn : 0;
+        fee = String(originFee * rate);
       }
     } catch {
       fee = "0";


### PR DESCRIPTION
### Description

- Updated BridgeForm to include additional transaction details such as from/to tokens, networks, amounts, fees, and timestamps.
- Improved the picker interface with clearer headers and a message for no available options.
- Enhanced BridgeQuoteCard to cap the displayed countdown for transaction deadlines.
- Refined BridgeRouteSelector with better layout and loading indicators for quotes.
- Added new icons for better visual representation and user feedback during transactions.

This pull request makes several improvements to the `BridgeForm` and related components, focusing on enhancing the user experience during the bridging process. Key changes include improved status and summary displays after a bridge transaction, better handling of picker overlays for mobile and desktop, and UI/UX refinements for transaction feedback and error states.

**User experience and UI improvements:**

* Added a detailed transaction summary after a successful bridge, displaying sent/received amounts, tokens, networks, fees, and date, with improved "Done" and "View on explorer" actions. [[1]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR78-R85) [[2]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL260-R289) [[3]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR573-R686)
* Enhanced error and status feedback with new icons (`SadDizzyIcon`), clearer messages, and improved coloring for failed states. [[1]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL408-R492) [[2]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL465-R538)
* Added an informational message when bridging between different networks, alerting users about potential delays.

**Picker overlay and layout handling:**

* Refactored the picker overlay to support both mobile and desktop layouts, including a true bottom sheet for mobile and contextual header text for different pickers. Picker list rendering is now shared and more robust. [[1]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR334-R343) [[2]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR360-R392) [[3]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL489-R562) [[4]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL528-R701)

**Component and prop enhancements:**

* Added the `isQuoteLoading` prop to `BridgeRouteSelector` and passed it from `BridgeForm` for improved loading state handling. [[1]](diffhunk://#diff-f8ae8c2a0a58a056cbf7c338614c9548513fc9980aeda5eb6c24795e595f5cc0R33) [[2]](diffhunk://#diff-f8ae8c2a0a58a056cbf7c338614c9548513fc9980aeda5eb6c24795e595f5cc0R57) [[3]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR443-R455)
* Improved imports and utility usage, including new icons and formatting helpers.

**Quote and countdown handling:**

* Capped the displayed quote countdown to 5 minutes to prevent showing stale rates, regardless of the longer deposit address deadline.
* Fixed the transaction fee row in `BridgeQuoteCard` to always appear at the bottom of the card for clarity. [[1]](diffhunk://#diff-d38bef80470bcbe633802caffdaf34cadf5b37dcc57635c58c03291893649fcaL104-L110) [[2]](diffhunk://#diff-d38bef80470bcbe633802caffdaf34cadf5b37dcc57635c58c03291893649fcaR129-R135)

**Refactoring and code quality:**

* Consolidated picker list rendering logic and improved code organization for maintainability. [[1]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR360-R392) [[2]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL528-R701)

These changes collectively provide a more informative, responsive, and user-friendly bridging experience.


### References




### Testing
[https://www.loom.com/share/d052807591394a96842643759fbf9c85](https://www.loom.com/share/d052807591394a96842643759fbf9c85)


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced bridge “done” success card with detailed sent/received amounts, route/network details, formatted timestamp, destination-token fee, and token visuals.
  * Improved route selection UX: quote-loading spinner, cross-network info banner, updated picker header/empty states, and redesigned balance/Max area.
  * Refined terminal actions and explorer links: “View on explorer” when applicable, with clearer Done/Close behavior.

* **Bug Fixes**
  * Capped NEAR deposit quote countdown display to 5 minutes while keeping expiration behavior consistent.
  * Normalized NEAR fees into receiving-token terms with a safe fallback on conversion issues.

* **UI/UX**
  * Updated header/back behavior and replaced failure visuals with the SadDizzyIcon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->