### PR TITLE
feat: Improve date formatting with relative time calculation

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1787,15 +1787,23 @@ export const generatePaginationItems = (
   return items;
 };
 
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function startOfDay(d: Date): Date {
+  const copy = new Date(d);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
 /**
  * Formats a date into a relative time string (e.g., "Today", "Yesterday", "2 days ago")
  * @param date - The date to format
  * @returns A string representing the relative time
  */
 export const getRelativeDate = (date: Date): string => {
-  const now = new Date();
-  const diffTime = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  const today = startOfDay(new Date());
+  const target = startOfDay(date);
+  const diffDays = Math.round((today.getTime() - target.getTime()) / DAY_MS);
 
   if (diffDays === 0) {
     return "Today";


### PR DESCRIPTION
### Description

Transaction and earn-activity lists group items under labels like **Today**, **Yesterday**, and **N days ago** via `getRelativeDate()` in `noblocks/app/utils.ts`.

**Problem:** The previous implementation measured **elapsed time in 24-hour windows** (`Math.floor(diffTime / DAY_MS)`). A transaction from yesterday evening could still appear under **Today** the next morning if less than 24 hours had passed (e.g. 11 PM yesterday → 9 AM today).

**Fix:** Compare **calendar days** in the user's local timezone by normalizing both dates to midnight with a new `startOfDay()` helper, then computing the day difference. This makes grouping match what users expect from date headers.

**Impacts:**
- **Wallet → Transactions** (`TransactionList.tsx`) — section headers use corrected labels.
- **Earn activity** (`EarnActivityPanel.tsx`) — same grouping logic.

**Implementation details:**
- Added private `startOfDay()` and `DAY_MS` constant in `utils.ts`.
- `getRelativeDate()` signature and return shape are unchanged — no API or contract changes.
- Week/month/year buckets still use the same thresholds; only the `diffDays` input is more accurate.

**Alternatives considered:**
- Using a date library (e.g. `date-fns` `startOfDay` / `differenceInCalendarDays`) — rejected to avoid a new dependency for a small, localized fix.
- Keeping elapsed-time logic — rejected because it does not match calendar-day UX.

**Breaking changes:** None.

### Testing

Manual verification (local dev, `pnpm dev`):

1. Open wallet **Transactions** (or **Earn** activity if available).
2. Confirm a transaction from **yesterday** (any time) appears under **Yesterday**, not **Today**.
3. Confirm today's transactions still appear under **Today**.
4. Spot-check older items still show **N days ago** / weeks / months as before.

- before
<img width="375" height="866" alt="Screenshot 2026-07-07 171044" src="https://github.com/user-attachments/assets/a7149d6a-a7e7-42ef-b1f7-5e383deaa537" />

- after
<img width="405" height="890" alt="Screenshot 2026-07-07 171240" src="https://github.com/user-attachments/assets/93f9f9d0-2731-4c66-9b55-ebfb8f1e7d34" />


Environment: Noblocks frontend, Node/pnpm, Chrome (desktop).

- [ ] This change adds test coverage for new/changed/fixed functionality

_No automated tests were added; `getRelativeDate` had no existing unit tests in this repo._

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative date display so day-based labels like “Today,” “Yesterday,” and “X days ago” are calculated consistently using whole-day boundaries.
  * Fixed edge cases where times later in the day could cause off-by-one differences in date labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->