### PR TITLE
fix: Update BridgeForm link to open Terms of Use in a new tab

### DIFF
--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -472,7 +472,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                     {execLoading || isFinalizing ? "Confirming…" : "Confirm"}
                   </button>
                   <p className="text-center text-xs text-gray-400 dark:text-white/30 -mt-3">
-                    By clicking Confirm, you agree to the <Link target="_blank" referrerPolicy="no-referrer" href="/terms" className="text-lavender-600 dark:text-lavender-400 hover:underline">Terms of Use</Link>.
+                    By clicking Confirm, you agree to the <Link target="_blank" rel="noopener noreferrer" href="/terms" className="text-lavender-600 dark:text-lavender-400 hover:underline">Terms of Use</Link>.
                   </p>
                 </>
               )}

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -472,7 +472,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                     {execLoading || isFinalizing ? "Confirming…" : "Confirm"}
                   </button>
                   <p className="text-center text-xs text-gray-400 dark:text-white/30 -mt-3">
-                    By clicking Confirm, you agree to the <Link href="/terms" className="text-lavender-600 dark:text-lavender-400 hover:underline">Terms of Use</Link>.
+                    By clicking Confirm, you agree to the <Link target="_blank" referrerPolicy="no-referrer" href="/terms" className="text-lavender-600 dark:text-lavender-400 hover:underline">Terms of Use</Link>.
                   </p>
                 </>
               )}


### PR DESCRIPTION


### Description

- Modified the Terms of Use link in BridgeForm to include target="_blank" and referrerPolicy="no-referrer" for improved user experience and security.


### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Terms of Use” link so it opens in a new browser tab.
  * Improved link safety by adding a `noopener noreferrer` behavior to help prevent referrer sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->