### PR TITLE
fix: Update PlayPromo component text and reconciliation timing

### DIFF
--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -424,7 +424,7 @@ export function PlayPromoBanner() {
                   onClick={dismiss}
                   className="pointer-events-auto shrink-0 rounded-xl bg-white px-5 py-2 text-sm font-semibold text-black transition-colors hover:bg-white/90"
                 >
-                  Join a league
+                  Join the league
                 </Link>
                 <button
                   type="button"
@@ -473,7 +473,7 @@ export function PlayPromoBanner() {
 
 // ---------------------------------------------------------------------------
 // Play button — shown in place of the banner once it has been dismissed
-// (via the X or "Join a league"). Persists across visits and links to /play.
+// (via the X or "Join the league"). Persists across visits and links to /play.
 // ---------------------------------------------------------------------------
 
 export function PlayPromoButton() {

--- a/app/lib/fantasy/worker.ts
+++ b/app/lib/fantasy/worker.ts
@@ -44,8 +44,11 @@ const STATS_MIN_INTERVAL_MS = 90_000;
 // seeding mid-round) must not burn the provider quota.
 const POST_FT_MIN_INTERVAL_MS = 5 * 60_000;
 const POST_FT_CONTINUOUS_MS = 15 * 60_000;
-const RECONCILE_1_MS = 2 * 60 * 60_000;
-const RECONCILE_2_MS = 12 * 60 * 60_000;
+// Stats freeze at FT+2h so the round can go final (and the next round's squad
+// building open) the same evening instead of ~12h later. Vendor corrections
+// landing after the freeze are recoverable by hand: reset the fixture's
+// stats_finalized + last_stats_sync and the next tick re-pulls and rescores.
+const RECONCILE_FINAL_MS = 2 * 60 * 60_000;
 const ACTIVE_WINDOW_TAIL_MS = 4 * 60 * 60_000;
 const MAX_EMAILS_PER_TICK = 50;
 const PAGE = 1000;
@@ -132,10 +135,10 @@ function isWindowActive(md: MatchdayRow, fixtures: FixtureRow[], now: number): b
   return now <= lastKickoffMs(mdFixtures) + ACTIVE_WINDOW_TAIL_MS;
 }
 
-type StatsPass = "live" | "post_ft" | "reconcile_2h" | "reconcile_12h";
+type StatsPass = "live" | "post_ft" | "reconcile_final";
 
 /** Reconciliation schedule per fixture (TRD §3): FT+15m continuous, then one
- * pass at ≥FT+2h and one at ≥FT+12h, after which stats freeze. */
+ * reconciliation pass at ≥FT+2h, after which stats freeze. */
 function statsSyncDue(f: FixtureRow, now: number): StatsPass | null {
   if (f.stats_finalized) return null;
   const lastSync = f.last_stats_sync ? new Date(f.last_stats_sync).getTime() : 0;
@@ -147,11 +150,8 @@ function statsSyncDue(f: FixtureRow, now: number): StatsPass | null {
   if (!FINISHED_STATUSES.has(f.status) || !f.finished_at) return null;
   const finished = new Date(f.finished_at).getTime();
 
-  if (now >= finished + RECONCILE_2_MS) {
-    return lastSync < finished + RECONCILE_2_MS ? "reconcile_12h" : null;
-  }
-  if (now >= finished + RECONCILE_1_MS) {
-    return lastSync < finished + RECONCILE_1_MS ? "reconcile_2h" : null;
+  if (now >= finished + RECONCILE_FINAL_MS) {
+    return lastSync < finished + RECONCILE_FINAL_MS ? "reconcile_final" : null;
   }
   if (now <= finished + POST_FT_CONTINUOUS_MS) {
     return now - lastSync >= POST_FT_MIN_INTERVAL_MS ? "post_ft" : null;
@@ -186,7 +186,7 @@ async function refreshFixturesFromProvider(
       home_score: f.homeScore,
       away_score: f.awayScore,
       // First observation of a finished status stamps finished_at (drives the
-      // FT+15m / +2h / +12h reconciliation clocks).
+      // FT+15m / +2h reconciliation clocks).
       finished_at: justFinished ? now : (prev?.finished_at ?? null),
     };
   });
@@ -236,7 +236,7 @@ async function syncFixtureStats(
   now: string,
 ): Promise<void> {
   const normalized = await getNormalizedFixtureStats(fixture.provider_fixture_id);
-  const finalize = pass === "reconcile_12h";
+  const finalize = pass === "reconcile_final";
 
   const rows: Record<string, unknown>[] = [];
   for (const [playerId, entry] of normalized.byPlayer) {
@@ -876,7 +876,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           await syncFixtureStats(fixture, pass, settings, positions, nowIso);
           report.stats_synced++;
           statsSyncedMatchdays.add(fixture.matchday_id);
-          if (pass === "reconcile_12h") report.fixtures_finalized++;
+          if (pass === "reconcile_final") report.fixtures_finalized++;
         } catch (error) {
           report.alerts.push(
             `stats sync failed for fixture ${fixture.provider_fixture_id} (${pass}): ${String(error)}`,

--- a/docs/fantasy-league.md
+++ b/docs/fantasy-league.md
@@ -59,8 +59,10 @@ Everything is isolated behind the `fantasy_` DB prefix, `/play` pages,
    inside an active window (lock → last kickoff +4h); once per 15 min while a
    round is upcoming; never otherwise. User traffic never hits the provider.
 3. Per-fixture stats sync: continuous while live and until FT+15m, then one
-   reconciliation pass at ≥FT+2h and one at ≥FT+12h, after which the fixture's
-   stats freeze (`stats_finalized`).
+   reconciliation pass at ≥FT+2h, after which the fixture's stats freeze
+   (`stats_finalized`). Late vendor corrections are recoverable by resetting
+   the fixture's `stats_finalized` + `last_stats_sync` in SQL — the next tick
+   re-pulls and rescores.
 4. Status transitions from fixture state: `live→finalizing` (all fixtures
    finished — triggers **rollover**: previous_rank snapshot, squads cloned to
    the next matchday with fresh free transfers, eliminated teams deactivated


### PR DESCRIPTION


### Description

- Changed button text from "Join a league" to "Join the league" for clarity.
- Updated comments in PlayPromo and worker files to reflect the new reconciliation timing, replacing references to "reconcile_12h" with "reconcile_final" for accuracy in stats synchronization.

### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the “Play” banner CTA copy from “Join a league” to “Join the league.”
  - Fantasy fixture stats now finalize sooner after a match ends, reducing delayed score updates and improving consistency when late corrections occur.

- **Documentation**
  - Updated the fantasy league runbook to match the new stats finalization behavior and recovery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->