### PR TITLE
feat: Implement public manager team view and bridge consent flow

### DIFF
--- a/__tests__/fantasy-worker-scoring.test.ts
+++ b/__tests__/fantasy-worker-scoring.test.ts
@@ -4,7 +4,7 @@
  * pipeline app/lib/fantasy/worker.ts runs on every stats sync.
  */
 import { getNormalizedFixtureStats } from "@/app/lib/fantasy/provider";
-import { computePoints, computeSquadPoints } from "@/app/lib/fantasy/scoring";
+import { computePoints, computeSquadPoints, countsForScoring } from "@/app/lib/fantasy/scoring";
 import type { ScoringMatrix } from "@/app/lib/fantasy/types";
 
 const matrix: ScoringMatrix = {
@@ -229,5 +229,23 @@ describe("stats normalization from stubbed provider", () => {
     });
     // 13 + 8 + 3 − 1 = 23, +13 captain double, −3 transfers = 33
     expect(total).toBe(33);
+  });
+});
+
+describe("countsForScoring (XI membership banked at kickoff)", () => {
+  it("uses the current slot while the fixture hasn't kicked off", () => {
+    expect(countsForScoring({ slot: 5, xi_at_kickoff: null })).toBe(true);
+    expect(countsForScoring({ slot: 12, xi_at_kickoff: null })).toBe(false);
+    expect(countsForScoring({ slot: 11 })).toBe(true);
+  });
+
+  it("keeps points for an XI-at-kickoff player benched after playing", () => {
+    expect(countsForScoring({ slot: 14, xi_at_kickoff: true })).toBe(true);
+  });
+
+  it("never counts a player who was on the bench at kickoff", () => {
+    expect(countsForScoring({ slot: 13, xi_at_kickoff: false })).toBe(false);
+    // Can't happen under the rolling lockout, but the stamp must still win.
+    expect(countsForScoring({ slot: 3, xi_at_kickoff: false })).toBe(false);
   });
 });

--- a/app/api/play/manager/[username]/route.ts
+++ b/app/api/play/manager/[username]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  fantasyDisabledResponse,
+  getPublicManagerTeam,
+  isFantasyEnabled,
+  jsonError,
+} from "@/app/lib/fantasy/server";
+
+/**
+ * GET /api/play/manager/[username] — public view of a manager's team:
+ * rank, total points and the squad for the most recent LOCKED matchday
+ * (open-round picks never leak). `team` is null until they have one.
+ */
+export const GET = withRateLimit(
+  async (
+    _request: NextRequest,
+    context: { params: Promise<{ username: string }> },
+  ) => {
+    if (!isFantasyEnabled()) return fantasyDisabledResponse();
+
+    try {
+      const { username } = await context.params;
+      const manager = await getPublicManagerTeam(username);
+      if (!manager) return jsonError("Manager not found", 404);
+
+      return NextResponse.json(
+        { success: true, data: manager },
+        { headers: { "Cache-Control": "public, s-maxage=30" } },
+      );
+    } catch (error) {
+      console.error("[play] manager team fetch failed:", error);
+      return jsonError("Failed to load manager", 500);
+    }
+  },
+);

--- a/app/api/play/og/route.tsx
+++ b/app/api/play/og/route.tsx
@@ -6,6 +6,8 @@ import { createAvatar } from "@dicebear/core";
 import { bigSmile, openPeeps } from "@dicebear/collection";
 import config from "@/app/lib/config";
 import { withRateLimit } from "@/app/lib/rate-limit";
+import { getPublicManagerTeam } from "@/app/lib/fantasy/server";
+import type { Position } from "@/app/lib/fantasy/types";
 
 const CACHE_CONTROL = "public, max-age=60, s-maxage=300";
 
@@ -71,12 +73,361 @@ const PHOTO = { top: 62, right: 16, width: 246, height: 258 };
 const PHOTO_MASK =
   "radial-gradient(ellipse 66% 88% at 52% 55%, #000 56%, transparent 90%)";
 
+// ─── Squad snapshot (layout=squad) ───────────────────────────────────────────
+
+const POS_ORDER: Position[] = ["GK", "DEF", "MID", "FWD"];
+const POS_COLOR: Record<Position, { bg: string; fg: string }> = {
+  GK: { bg: "#eab308", fg: "#1c1400" },
+  DEF: { bg: "#0ea5e9", fg: "#ffffff" },
+  MID: { bg: "#10b981", fg: "#ffffff" },
+  FWD: { bg: "#f43f5e", fg: "#ffffff" },
+};
+
+const playerInitials = (name: string) =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+
+const lastName = (name: string) => name.split(" ").slice(-1)[0] ?? name;
+
+/**
+ * Player headshot as a data URI so satori never does its own (uncontrolled)
+ * remote fetch. Tight timeout + size cap; any failure falls back to the
+ * initials chip for that player only — one flaky CDN image can't break or
+ * stall the whole card.
+ */
+async function fetchPhotoDataUri(url: string | null): Promise<string | null> {
+  if (!url || !/^https:\/\//.test(url)) return null;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 2500);
+  try {
+    const res = await fetch(url, { signal: controller.signal, cache: "no-store" });
+    if (!res.ok) return null;
+    const type = res.headers.get("content-type") ?? "image/png";
+    if (!type.startsWith("image/")) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length === 0 || buf.length > 400_000) return null;
+    return `data:${type};base64,${buf.toString("base64")}`;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * 1200×630 squad snapshot: the XI on a pitch panel (real headshots with
+ * initials fallback, C/V badges, effective points) + manager stats and the
+ * #NoblocksPlay hashtag.
+ */
+async function squadImage(usernameParam: string, anton: Buffer) {
+  const manager = await getPublicManagerTeam(usernameParam);
+  if (!manager?.team) {
+    return Response.json(
+      { success: false, error: "No shareable squad yet" },
+      { status: 404 },
+    );
+  }
+  const { team } = manager;
+
+  const xi = team.players.filter((p) => p.slot <= 11);
+  const bench = team.players.filter((p) => p.slot > 11);
+
+  const photos = new Map<number, string | null>();
+  await Promise.all(
+    xi.map(async (p) => photos.set(p.player_id, await fetchPhotoDataUri(p.photo_url))),
+  );
+
+  const slot = (p: (typeof team.players)[number]) => (
+    <div
+      key={p.player_id}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        width: 104,
+      }}
+    >
+      <div style={{ display: "flex", position: "relative" }}>
+        {photos.get(p.player_id) ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={photos.get(p.player_id)!}
+            alt=""
+            width={58}
+            height={58}
+            style={{
+              width: 58,
+              height: 58,
+              borderRadius: 999,
+              objectFit: "cover",
+              objectPosition: "top",
+              backgroundColor: "rgba(255,255,255,0.92)",
+              border: `3px solid ${POS_COLOR[p.position].bg}`,
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              width: 58,
+              height: 58,
+              borderRadius: 999,
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 22,
+              letterSpacing: 1,
+              backgroundColor: POS_COLOR[p.position].bg,
+              color: POS_COLOR[p.position].fg,
+              border: "3px solid rgba(255,255,255,0.85)",
+            }}
+          >
+            {playerInitials(p.name)}
+          </div>
+        )}
+        {(p.is_captain || p.is_vice) && (
+          <div
+            style={{
+              display: "flex",
+              position: "absolute",
+              top: -6,
+              left: -8,
+              width: 24,
+              height: 24,
+              borderRadius: 999,
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 13,
+              backgroundColor: p.is_captain ? "#000000" : "#ffffff",
+              color: p.is_captain ? "#ffffff" : "#000000",
+              border: "2px solid rgba(255,255,255,0.9)",
+            }}
+          >
+            {p.is_captain ? "C" : "V"}
+          </div>
+        )}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          marginTop: 7,
+          maxWidth: 104,
+          fontSize: 16,
+          letterSpacing: 1,
+          color: "#ffffff",
+        }}
+      >
+        {lastName(p.name).toUpperCase().slice(0, 11)}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontSize: 14,
+          color: "rgba(255,255,255,0.75)",
+        }}
+      >
+        {`${p.points} PTS`}
+      </div>
+    </div>
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          backgroundImage:
+            "radial-gradient(circle at 30% 40%, #06281c 0%, #041b13 55%, #02100b 100%)",
+          padding: "36px 48px",
+          fontFamily: "Anton",
+        }}
+      >
+        {/* pitch panel */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            width: 660,
+            height: 558,
+            borderRadius: 24,
+            padding: "20px 12px 14px",
+            backgroundImage:
+              "linear-gradient(180deg, #059669 0%, #047857 55%, #065f46 100%)",
+            border: "2px solid rgba(255,255,255,0.25)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flexGrow: 1,
+              justifyContent: "space-between",
+            }}
+          >
+            {POS_ORDER.map((pos) => (
+              <div
+                key={pos}
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                }}
+              >
+                {xi.filter((p) => p.position === pos).map(slot)}
+              </div>
+            ))}
+          </div>
+          {bench.length > 0 && (
+            <div
+              style={{
+                display: "flex",
+                marginTop: 12,
+                justifyContent: "center",
+                fontSize: 15,
+                letterSpacing: 1,
+                color: "rgba(255,255,255,0.65)",
+              }}
+            >
+              {`BENCH — ${bench.map((p) => lastName(p.name).toUpperCase()).join(" · ")}`}
+            </div>
+          )}
+        </div>
+
+        {/* right column: brand + stats + hashtag */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flexGrow: 1,
+            height: 558,
+            justifyContent: "space-between",
+            paddingLeft: 44,
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 26,
+                letterSpacing: 6,
+                color: "#e0bd57",
+              }}
+            >
+              NOBLOCKS PLAY
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginTop: 10,
+                fontSize: manager.username.length > 12 ? 40 : 52,
+                letterSpacing: 2,
+                color: "#ffffff",
+              }}
+            >
+              {manager.username.toUpperCase()}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginTop: 6,
+                fontSize: 23,
+                letterSpacing: 2,
+                color: "rgba(255,255,255,0.55)",
+              }}
+            >
+              {team.matchday.display_name.toUpperCase()}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "baseline" }}>
+              <span style={{ fontSize: 96, lineHeight: 1, color: "#e7c55e" }}>
+                {team.points}
+              </span>
+              <span
+                style={{
+                  marginLeft: 16,
+                  fontSize: 30,
+                  letterSpacing: 1,
+                  color: "rgba(255,255,255,0.85)",
+                }}
+              >
+                PTS
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginTop: 10,
+                fontSize: 22,
+                letterSpacing: 1,
+                color: "rgba(255,255,255,0.5)",
+              }}
+            >
+              {`${manager.total_points} TOTAL${manager.rank != null ? ` · RANK #${manager.rank}` : ""}`}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginTop: 18,
+                fontSize: 32,
+                letterSpacing: 1,
+                color: "#e7c55e",
+              }}
+            >
+              #NoblocksPlay
+            </div>
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <div
+              style={{
+                display: "flex",
+                padding: "10px 20px",
+                borderRadius: 14,
+                backgroundImage: "linear-gradient(160deg, #ecd276, #c3a038)",
+                fontSize: 22,
+                letterSpacing: 1,
+                color: INK,
+              }}
+            >
+              300 USDC IN PRIZES
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginLeft: 20,
+                fontSize: 22,
+                color: "rgba(255,255,255,0.65)",
+              }}
+            >
+              noblocks.xyz/play
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [{ name: "Anton", data: anton, style: "normal", weight: 400 }],
+      headers: { "Cache-Control": CACHE_CONTROL },
+    },
+  );
+}
+
 /**
  * GET /api/play/og — share card for Noblocks Play (F-13): the FUT gold card
  * with the manager's stats on a dark backdrop.
  * Query: username, rank, points, refs (activated referrals), code, and
- * layout — "wide" (1200×630, link previews / desktop) or "card" (640×960,
- * portrait: just the shield, big — the mobile presentation).
+ * layout — "wide" (1200×630, link previews / desktop), "card" (640×960,
+ * portrait: just the shield, big — the mobile presentation) or "squad"
+ * (1200×630 squad snapshot for /play/manager/[username] link unfurls).
  * Public route, rate-limited — gated by the feature flag.
  */
 export const GET = withRateLimit(async (request: NextRequest) => {
@@ -88,6 +439,22 @@ export const GET = withRateLimit(async (request: NextRequest) => {
   }
 
   const { searchParams } = request.nextUrl;
+
+  if (searchParams.get("layout") === "squad") {
+    try {
+      return await squadImage(
+        searchParams.get("username") ?? "",
+        await loadAnton(),
+      );
+    } catch (error) {
+      console.error("[play] squad og render failed:", error);
+      return Response.json(
+        { success: false, error: "Failed to render squad card" },
+        { status: 500 },
+      );
+    }
+  }
+
   const username = sanitizeUsername(searchParams.get("username"));
   const rank = sanitizeNumber(searchParams.get("rank"));
   const points = sanitizeNumber(searchParams.get("points"));

--- a/app/api/play/squad/route.ts
+++ b/app/api/play/squad/route.ts
@@ -35,17 +35,28 @@ export const GET = withRateLimit(async (request: NextRequest) => {
     const matchday = await getCurrentMatchday();
     if (!matchday) return jsonError("No active matchday", 404);
 
-    const [squad, lockStates, playerPoints, settings, { data: matchdayScores }] =
-      await Promise.all([
-        getSquad(auth.walletAddress, matchday.id),
-        getTeamLockStates(matchday.id),
-        getMatchdayPlayerPoints(matchday.id),
-        getFantasySettings(),
-        supabaseAdmin
-          .from("fantasy_matchday_scores")
-          .select("matchday_id, points")
-          .eq("wallet_address", auth.walletAddress),
-      ]);
+    const [
+      squad,
+      lockStates,
+      playerPoints,
+      settings,
+      { data: matchdayScores },
+      { data: profile },
+    ] = await Promise.all([
+      getSquad(auth.walletAddress, matchday.id),
+      getTeamLockStates(matchday.id),
+      getMatchdayPlayerPoints(matchday.id),
+      getFantasySettings(),
+      supabaseAdmin
+        .from("fantasy_matchday_scores")
+        .select("matchday_id, points")
+        .eq("wallet_address", auth.walletAddress),
+      supabaseAdmin
+        .from("user_kyc_profiles")
+        .select("username")
+        .eq("wallet_address", auth.walletAddress)
+        .maybeSingle(),
+    ]);
 
     const players = await getPlayersMap();
 
@@ -68,6 +79,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
         : null,
       free_transfers: settings.free_transfers[matchdayLabel(matchday.id)] ?? 0,
       total_points: participant.total_points,
+      username: (profile?.username as string | null) ?? null,
       matchday_scores: (matchdayScores ?? []).map((s) => ({
         matchday_id: Number(s.matchday_id),
         points: Number(s.points),
@@ -205,6 +217,8 @@ export const PUT = withRateLimit(async (request: NextRequest) => {
               { code: "PLAYER_LOCKED" },
             );
           }
+          // Moving a FINISHED player out is fine: their points are banked by
+          // the kickoff snapshot (xi_at_kickoff), not the current slots.
           if (!isXI && state(playerId) === "locked") {
             return jsonError(
               "You can't remove a player while their match is in progress",

--- a/app/components/BridgeConsentModal.tsx
+++ b/app/components/BridgeConsentModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Cancel01Icon } from "hugeicons-react";
+import { classNames } from "../utils";
+import { primaryBtnClasses } from "./Styles";
+
+interface BridgeConsentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAccepted: () => void;
+}
+
+const RISK_COPY =
+  "Conversion works differently from your Noblocks wallet. Your funds leave Noblocks and your stablecoins are routed through Li.Fi and Near Intents; independent third-party bridge protocols that Noblocks does not own, operate, or control.\n\nWe have no visibility once funds leave. Noblocks cannot freeze, recover, reverse, or guarantee your funds while they are in transit across a bridge.\n\nTransactions are irreversible. Confirmed conversions cannot be cancelled, reversed, or refunded. Network gas fees are non-refundable even if a convert fails.\nBridge protocols carry smart contract risks including the possibility of exploits. Returns and execution are not guaranteed.";
+
+const ACK_COPY =
+  "I understand that convert is powered by third-party bridge protocols and that Noblocks is not responsible for the performance or security of those protocols.";
+
+/** Same layer as the earn consent: above the mobile wallet sheet (z-60). */
+const BRIDGE_CONSENT_Z = "z-[65]";
+
+/**
+ * First-time Convert "Terms of use" disclosure: shown once per user before
+ * the bridge/convert flow opens (see useBridgeAccess). Continue stays
+ * disabled until the acknowledgement is ticked.
+ */
+export const BridgeConsentModal: React.FC<BridgeConsentModalProps> = ({
+  isOpen,
+  onClose,
+  onAccepted,
+}) => {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  const handleClose = () => {
+    setAcknowledged(false);
+    onClose();
+  };
+
+  const handleProceed = () => {
+    if (!acknowledged) return;
+    setAcknowledged(false);
+    onAccepted();
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <Dialog
+          open={isOpen}
+          onClose={handleClose}
+          className={classNames("relative", BRIDGE_CONSENT_Z)}
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="fixed inset-0 bg-black/30 backdrop-blur-sm"
+          />
+
+          <div className="fixed inset-0 flex w-screen items-end sm:items-center sm:justify-center sm:p-4">
+            <motion.div
+              initial={{ y: "100%", opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: "100%", opacity: 0 }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              className="w-full sm:max-w-[31.4375rem]"
+            >
+              <DialogPanel className="relative mx-auto flex max-h-[85vh] w-full flex-col overflow-hidden rounded-t-[30px] bg-white text-sm supports-[height:100dvh]:max-h-[90dvh] dark:bg-surface-overlay sm:max-h-[90vh] sm:rounded-[30px]">
+                <div className="relative flex min-h-0 flex-1 flex-col">
+                  {/* Static header */}
+                  <div className="relative shrink-0 px-5 pb-4 pt-6 sm:px-6">
+                    <button
+                      type="button"
+                      aria-label="Close"
+                      onClick={handleClose}
+                      className="absolute right-5 top-5 rounded-lg p-2 hover:bg-accent-gray dark:hover:bg-white/10 sm:right-6"
+                    >
+                      <Cancel01Icon className="size-6 text-outline-gray dark:text-white/50" />
+                    </button>
+                    <DialogTitle className="pr-8 text-center text-lg font-semibold leading-tight text-text-body dark:text-white sm:text-xl">
+                      Terms of use
+                    </DialogTitle>
+                  </div>
+
+                  {/* Scrollable risk copy */}
+                  <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5 sm:px-6">
+                    <div className="rounded-2xl border border-border-light bg-accent-gray/50 px-4 py-4 dark:border-white/10 dark:bg-black/20">
+                      <p className="whitespace-pre-line text-sm leading-5 text-text-secondary dark:text-white/50">
+                        {RISK_COPY}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Acknowledgement + Continue */}
+                  <div className="flex w-full shrink-0 flex-col gap-5 rounded-t-3xl bg-background-neutral px-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-5 dark:bg-[#2c2c2c] sm:px-6 sm:pb-6">
+                    <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border-light bg-white px-4 py-3 dark:border-white/10 dark:bg-white/5">
+                      <input
+                        type="checkbox"
+                        checked={acknowledged}
+                        onChange={(e) => setAcknowledged(e.target.checked)}
+                        className="mt-0.5 size-[19px] shrink-0 cursor-pointer rounded border-2 border-border-light accent-lavender-500 dark:border-white/30"
+                      />
+                      <span className="text-sm leading-5 text-text-secondary dark:text-white/50">
+                        {ACK_COPY}
+                      </span>
+                    </label>
+
+                    <button
+                      type="button"
+                      disabled={!acknowledged}
+                      onClick={handleProceed}
+                      className={classNames(
+                        primaryBtnClasses,
+                        "w-full",
+                        !acknowledged && "cursor-not-allowed opacity-40",
+                      )}
+                    >
+                      Continue
+                    </button>
+                  </div>
+                </div>
+              </DialogPanel>
+            </motion.div>
+          </div>
+        </Dialog>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -39,6 +39,8 @@ import { FundWalletForm } from "./FundWalletForm";
 import { TransferForm } from "./TransferForm";
 import { EarnWalletForm } from "./EarnWalletForm";
 import { EarnConsentModal } from "./EarnConsentModal";
+import { BridgeConsentModal } from "./BridgeConsentModal";
+import { useBridgeAccess } from "../hooks/useBridgeAccess";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 import ProfileView from "./ProfileView";
 import { useEarnAccess } from "../hooks/useEarnAccess";
@@ -283,6 +285,12 @@ export const MobileDropdown = ({
     handleConsentAccepted: handleEarnConsentAccepted,
     dismissConsent: dismissEarnConsent,
   } = useEarnAccess();
+  const {
+    isConsentModalOpen: isBridgeConsentModalOpen,
+    requestBridgeAccess,
+    handleConsentAccepted: handleBridgeConsentAccepted,
+    dismissConsent: dismissBridgeConsent,
+  } = useBridgeAccess();
 
   const onEarnAccessAction = (
     action: "earn-modal" | "earn-tab" | "earn-hub",
@@ -331,7 +339,14 @@ export const MobileDropdown = ({
                           getTokenImageUrl={getTokenImageUrl}
                           onTransfer={() => setCurrentView("transfer")}
                           onFund={() => setCurrentView("fund")}
-                          onConvert={isBridgeUiVisible() ? () => setCurrentView("bridge") : undefined}
+                          onConvert={
+                            isBridgeUiVisible()
+                              ? () =>
+                                  requestBridgeAccess(() =>
+                                    setCurrentView("bridge"),
+                                  )
+                              : undefined
+                          }
                           smartWallet={walletForCopy}
                           handleCopyAddress={handleCopyAddress}
                           isNetworkListOpen={isNetworkListOpen}
@@ -481,6 +496,12 @@ export const MobileDropdown = ({
               isOpen={isEarnConsentModalOpen}
               onClose={dismissEarnConsent}
               onAccepted={() => handleEarnConsentAccepted(onEarnAccessAction)}
+            />
+
+            <BridgeConsentModal
+              isOpen={isBridgeConsentModalOpen}
+              onClose={dismissBridgeConsent}
+              onAccepted={handleBridgeConsentAccepted}
             />
 
             <CopyAddressWarningModal

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -60,6 +60,8 @@ import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useCNGNRate } from "../hooks/useCNGNRate";
 import { EarnConsentModal } from "./EarnConsentModal";
 import { useEarnAccess } from "../hooks/useEarnAccess";
+import { BridgeConsentModal } from "./BridgeConsentModal";
+import { useBridgeAccess } from "../hooks/useBridgeAccess";
 import { isEarnUiVisible } from "../lib/earnFeature";
 import { isReferralEnabled, formatTokenAmount } from "../utils";
 import { isBridgeUiVisible } from "../lib/bridgeFeature";
@@ -90,6 +92,12 @@ export const WalletDetails = () => {
     handleConsentAccepted: handleEarnConsentAccepted,
     dismissConsent: dismissEarnConsent,
   } = useEarnAccess();
+  const {
+    isConsentModalOpen: isBridgeConsentModalOpen,
+    requestBridgeAccess,
+    handleConsentAccepted: handleBridgeConsentAccepted,
+    dismissConsent: dismissBridgeConsent,
+  } = useBridgeAccess();
   const [activeTab, setActiveTab] = useState<"balances" | "transactions">(
     "balances",
   );
@@ -513,7 +521,11 @@ export const WalletDetails = () => {
                               <button
                                 type="button"
                                 title="Convert tokens"
-                                onClick={() => setIsConvertModalOpen(true)}
+                                onClick={() =>
+                                  requestBridgeAccess(() =>
+                                    setIsConvertModalOpen(true),
+                                  )
+                                }
                                 className="group flex flex-1 flex-col items-center gap-2"
                               >
                                 <span className="flex size-[60px] items-center justify-center rounded-full bg-accent-gray text-gray-900 transition-all group-hover:scale-[0.98] group-hover:bg-[#EBEBEF] group-active:scale-95 dark:bg-white/5 dark:text-white dark:group-hover:bg-white/10">
@@ -572,7 +584,11 @@ export const WalletDetails = () => {
                               <button
                                 type="button"
                                 title="Convert tokens"
-                                onClick={() => setIsConvertModalOpen(true)}
+                                onClick={() =>
+                                  requestBridgeAccess(() =>
+                                    setIsConvertModalOpen(true),
+                                  )
+                                }
                                 className="group flex flex-1 flex-col items-center gap-2"
                               >
                                 <span className="flex size-[60px] items-center justify-center rounded-full bg-accent-gray text-gray-900 transition-all group-hover:scale-[0.98] group-hover:bg-[#EBEBEF] group-active:scale-95 dark:bg-white/5 dark:text-white dark:group-hover:bg-white/10">
@@ -906,6 +922,12 @@ export const WalletDetails = () => {
         isOpen={isEarnConsentModalOpen}
         onClose={dismissEarnConsent}
         onAccepted={() => handleEarnConsentAccepted(onEarnAccessAction)}
+      />
+
+      <BridgeConsentModal
+        isOpen={isBridgeConsentModalOpen}
+        onClose={dismissBridgeConsent}
+        onAccepted={handleBridgeConsentAccepted}
       />
 
       <CopyAddressWarningModal

--- a/app/components/play/LeaderboardTable.tsx
+++ b/app/components/play/LeaderboardTable.tsx
@@ -4,9 +4,11 @@
  * Leaderboard table rows: rank, movement arrow, username, points and the
  * qualification badge. Other players' referral counts are never shown
  * (PRD §7.3) — the in-progress tooltip carries a count only for the
- * viewer's own row.
+ * viewer's own row. Rows link to the manager's public team view.
  */
 
+import { useRouter } from "next/navigation";
+import Link from "next/link";
 import {
   ArrowDown01Icon,
   ArrowUp01Icon,
@@ -15,6 +17,9 @@ import {
   LaurelWreath01Icon,
 } from "hugeicons-react";
 import type { LeaderboardRowData } from "./types";
+
+const managerHref = (username: string) =>
+  `/play/manager/${encodeURIComponent(username)}`;
 
 const Movement = ({ value }: { value: number }) => {
   if (value > 0) {
@@ -93,7 +98,10 @@ export const LeaderboardTable = ({
   /** Own referral progress (rewards endpoint) for the self-row tooltip. */
   selfProgress?: { activated: number; required: number };
   compact?: boolean;
-}) => (
+}) => {
+  const router = useRouter();
+
+  return (
   <div className="overflow-x-auto rounded-2xl border border-border-light dark:border-white/10">
     <table className="w-full min-w-[20rem] text-left text-sm">
       <thead>
@@ -110,7 +118,16 @@ export const LeaderboardTable = ({
           <tr
             key={`${row.rank}-${row.username ?? "anon"}`}
             id={row.is_me ? "leaderboard-self-row" : undefined}
+            // Whole row navigates to the manager's public team; the username
+            // is also a real link for keyboard/screen-reader users.
+            onClick={
+              row.username
+                ? () => router.push(managerHref(row.username!))
+                : undefined
+            }
             className={`border-b border-border-light last:border-0 dark:border-white/5 ${
+              row.username ? "cursor-pointer" : ""
+            } ${
               row.is_me
                 ? "bg-lavender-50 dark:bg-lavender-500/10"
                 : compact
@@ -125,7 +142,17 @@ export const LeaderboardTable = ({
               <Movement value={row.movement} />
             </td>
             <td className="max-w-[10rem] truncate px-2 py-3 font-medium text-text-body dark:text-white sm:max-w-none">
-              {row.username ?? "—"}
+              {row.username ? (
+                <Link
+                  href={managerHref(row.username)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="hover:underline"
+                >
+                  {row.username}
+                </Link>
+              ) : (
+                "—"
+              )}
               {row.is_me && (
                 <span className="ml-1.5 rounded-full bg-lavender-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
                   You
@@ -145,4 +172,5 @@ export const LeaderboardTable = ({
       </tbody>
     </table>
   </div>
-);
+  );
+};

--- a/app/components/play/ManagerTeamView.tsx
+++ b/app/components/play/ManagerTeamView.tsx
@@ -18,8 +18,6 @@ import type {
 } from "./types";
 import { Chip, secondaryButtonClasses } from "./ui";
 
-const POS_ORDER: Position[] = ["GK", "DEF", "MID", "FWD"];
-
 /** Minimal FantasyPlayer for the slot card (price/team never shown here). */
 const toFantasyPlayer = (p: PublicTeamPlayer): FantasyPlayer => ({
   provider_player_id: p.player_id,
@@ -55,12 +53,11 @@ export const ManagerTeamView = ({
     FWD: [],
   };
   const bench: SlotView[] = [];
-  for (const pos of POS_ORDER) {
-    for (const p of team?.players ?? []) {
-      if (p.position !== pos) continue;
-      if (p.slot <= 11) rows[pos].push(toSlotView(p));
-      else bench.push(toSlotView(p));
-    }
+  // Players arrive sorted by slot; a single pass keeps the bench in slot
+  // order (12–15) while the XI still groups by position via `rows`.
+  for (const p of team?.players ?? []) {
+    if (p.slot <= 11) rows[p.position].push(toSlotView(p));
+    else bench.push(toSlotView(p));
   }
 
   return (

--- a/app/components/play/ManagerTeamView.tsx
+++ b/app/components/play/ManagerTeamView.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Read-only view of another manager's team (/play/manager/[username]):
+ * the latest locked round's XI + bench with effective points (captain
+ * double included). Reuses the same pitch the owner sees on /play/team.
+ */
+
+import Link from "next/link";
+import { ArrowLeft01Icon, ChampionIcon } from "hugeicons-react";
+import { PitchView, type SlotView } from "./PitchView";
+import { BenchRow } from "./BenchRow";
+import type {
+  FantasyPlayer,
+  Position,
+  PublicManagerTeam,
+  PublicTeamPlayer,
+} from "./types";
+import { Chip, secondaryButtonClasses } from "./ui";
+
+const POS_ORDER: Position[] = ["GK", "DEF", "MID", "FWD"];
+
+/** Minimal FantasyPlayer for the slot card (price/team never shown here). */
+const toFantasyPlayer = (p: PublicTeamPlayer): FantasyPlayer => ({
+  provider_player_id: p.player_id,
+  team_id: 0,
+  name: p.name,
+  nation: p.nation,
+  position: p.position,
+  price: 0,
+  photo_url: p.photo_url,
+  is_active: true,
+});
+
+const toSlotView = (p: PublicTeamPlayer): SlotView => ({
+  key: String(p.player_id),
+  player: toFantasyPlayer(p),
+  position: p.position,
+  isCaptain: p.is_captain,
+  isVice: p.is_vice,
+  livePoints: p.points,
+});
+
+export const ManagerTeamView = ({
+  manager,
+}: {
+  manager: PublicManagerTeam;
+}) => {
+  const team = manager.team;
+
+  const rows: Record<Position, SlotView[]> = {
+    GK: [],
+    DEF: [],
+    MID: [],
+    FWD: [],
+  };
+  const bench: SlotView[] = [];
+  for (const pos of POS_ORDER) {
+    for (const p of team?.players ?? []) {
+      if (p.position !== pos) continue;
+      if (p.slot <= 11) rows[pos].push(toSlotView(p));
+      else bench.push(toSlotView(p));
+    }
+  }
+
+  return (
+    <div className="space-y-4 max-lg:pb-10">
+      <Link
+        href="/play/leaderboard"
+        className="inline-flex items-center gap-1 text-sm text-text-secondary transition-colors hover:text-text-body dark:text-white/50 dark:hover:text-white"
+      >
+        <ArrowLeft01Icon className="size-4" />
+        Leaderboard
+      </Link>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="flex items-center gap-2 text-xl font-semibold text-text-body dark:text-white">
+          {manager.username}
+          {manager.badge === "qualified" && (
+            <span title="Qualified for the giveaway">
+              <ChampionIcon className="size-5 text-yellow-primary" />
+            </span>
+          )}
+        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          {manager.rank != null && <Chip>Rank #{manager.rank}</Chip>}
+          <Chip>{manager.total_points} pts total</Chip>
+        </div>
+      </div>
+
+      {team ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <Chip>{team.matchday.display_name}</Chip>
+            <Chip>{team.points} pts this round</Chip>
+          </div>
+          <PitchView rows={rows} showPrice={false} onSlotClick={() => {}} />
+          {bench.length > 0 && (
+            <BenchRow slots={bench} showPrice={false} onSlotClick={() => {}} />
+          )}
+        </>
+      ) : (
+        <div className="space-y-2 rounded-2xl border border-dashed border-border-light px-6 py-10 text-center dark:border-white/10">
+          <p className="text-sm font-semibold text-text-body dark:text-white">
+            Squad under wraps
+          </p>
+          <p className="mx-auto max-w-sm text-sm text-text-secondary dark:text-white/50">
+            Teams only become visible once their round locks — check back
+            after kickoff.
+          </p>
+        </div>
+      )}
+
+      <Link href="/play/team" className={`${secondaryButtonClasses} inline-flex`}>
+        Build your own squad
+      </Link>
+    </div>
+  );
+};

--- a/app/components/play/ShareSquadCard.tsx
+++ b/app/components/play/ShareSquadCard.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * Share-your-squad card on /play/team: previews the squad snapshot from
+ * /api/play/og?layout=squad and shares the public team page
+ * (/play/manager/[username]) with the #NoblocksPlay hashtag — X unfurls
+ * that link into the snapshot. Renders nothing until the manager has a
+ * squad in a locked round (open-round picks stay private).
+ */
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { NewTwitterIcon, Share08Icon } from "hugeicons-react";
+import { trackEvent } from "@/app/hooks/analytics/client";
+import { useManagerTeam } from "./hooks";
+import { PlayCard, Skeleton, secondaryButtonClasses } from "./ui";
+
+export const ShareSquadCard = ({ username }: { username: string }) => {
+  const { data: manager } = useManagerTeam(username);
+  const [imageFailed, setImageFailed] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const ogUrl = manager
+    ? `/api/play/og?layout=squad&username=${encodeURIComponent(manager.username)}`
+    : null;
+  useEffect(() => {
+    setImageLoaded(false);
+    setImageFailed(false);
+  }, [ogUrl]);
+
+  if (!manager?.team) return null;
+
+  const pageUrl = `https://noblocks.xyz/play/manager/${encodeURIComponent(manager.username)}`;
+  const shareText = `My ${manager.team.matchday.display_name} squad on Noblocks Play ⚽ ${manager.team.points} pts this round. Think you can beat me? #NoblocksPlay`;
+  const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(pageUrl)}`;
+
+  const handleNativeShare = async () => {
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: "Noblocks Play",
+          text: shareText,
+          url: pageUrl,
+        });
+      } else {
+        await navigator.clipboard.writeText(`${shareText} ${pageUrl}`);
+        toast.success("Share text copied to clipboard");
+      }
+      trackEvent("squad_shared", { source: "native" });
+    } catch {
+      // user dismissed the share sheet — not an error
+    }
+  };
+
+  return (
+    <PlayCard className="space-y-3">
+      <h2 className="text-base font-semibold text-text-body dark:text-white">
+        Share your squad
+      </h2>
+
+      {!imageFailed && ogUrl && (
+        <div className="overflow-hidden rounded-xl border border-border-light dark:border-white/10">
+          {!imageLoaded && <Skeleton className="aspect-[1200/630] w-full" />}
+          {/* Dynamic OG endpoint image — next/image adds nothing here. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            key={ogUrl}
+            src={ogUrl}
+            alt={`${manager.username}'s ${manager.team.matchday.display_name} squad on Noblocks Play`}
+            className={`w-full ${imageLoaded ? "" : "hidden"}`}
+            onLoad={() => setImageLoaded(true)}
+            onError={() => setImageFailed(true)}
+          />
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <a
+          href={tweetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackEvent("squad_shared", { source: "tweet" })}
+          className={`${secondaryButtonClasses} inline-flex items-center gap-2`}
+        >
+          <NewTwitterIcon className="size-4" />
+          Post on X
+        </a>
+        <button
+          type="button"
+          onClick={handleNativeShare}
+          className={`${secondaryButtonClasses} inline-flex items-center gap-2`}
+        >
+          <Share08Icon className="size-4" />
+          Share
+        </button>
+      </div>
+    </PlayCard>
+  );
+};

--- a/app/components/play/ShareSquadCard.tsx
+++ b/app/components/play/ShareSquadCard.tsx
@@ -35,21 +35,27 @@ export const ShareSquadCard = ({ username }: { username: string }) => {
   const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(pageUrl)}`;
 
   const handleNativeShare = async () => {
-    try {
-      if (navigator.share) {
+    if (navigator.share) {
+      try {
         await navigator.share({
           title: "Noblocks Play",
           text: shareText,
           url: pageUrl,
         });
-      } else {
+      } catch {
+        // user dismissed the share sheet — not an error
+        return;
+      }
+    } else {
+      try {
         await navigator.clipboard.writeText(`${shareText} ${pageUrl}`);
         toast.success("Share text copied to clipboard");
+      } catch {
+        toast.error("Couldn't copy to clipboard — try the Post on X button");
+        return;
       }
-      trackEvent("squad_shared", { source: "native" });
-    } catch {
-      // user dismissed the share sheet — not an error
     }
+    trackEvent("squad_shared", { source: "native" });
   };
 
   return (

--- a/app/components/play/TeamManager.tsx
+++ b/app/components/play/TeamManager.tsx
@@ -134,10 +134,22 @@ export const TeamManager = ({
       squad?.players.find((p) => p.player_id === id)?.lock_state ?? "unlocked",
     [squad],
   );
+  // The armband holder whose points currently count double: the captain once
+  // they've played, otherwise the vice (mirrors computeSquadPoints server-side).
+  const doubledId = useMemo(() => {
+    const captain = squad?.players.find((p) => p.is_captain);
+    const vice = squad?.players.find((p) => p.is_vice);
+    if (captain && captain.live.minutes > 0) return captain.player_id;
+    if (vice && vice.live.minutes > 0) return vice.player_id;
+    return null;
+  }, [squad]);
   const livePointsOf = useCallback(
-    (id: number) =>
-      squad?.players.find((p) => p.player_id === id)?.live.points ?? 0,
-    [squad],
+    (id: number) => {
+      const points =
+        squad?.players.find((p) => p.player_id === id)?.live.points ?? 0;
+      return id === doubledId ? points * 2 : points;
+    },
+    [squad, doubledId],
   );
 
   /* --------------------------- editor state --------------------------- */
@@ -380,7 +392,9 @@ export const TeamManager = ({
         counts[incoming.position]++;
         if (!isFormationValid(counts, settings)) return false;
         if (locked) {
-          // Rolling lockout: incoming must be pre-kickoff; outgoing not mid-match.
+          // Rolling lockout: incoming must be pre-kickoff; outgoing not
+          // mid-match. Benching a FINISHED player is allowed — the points
+          // they earned in the XI are banked at kickoff server-side.
           const incomingId = isBenched ? playerId : otherId;
           const outgoingId = isBenched ? otherId : playerId;
           if (lockStateOf(incomingId) !== "unlocked") return false;
@@ -1042,7 +1056,9 @@ export const TeamManager = ({
                     {locked && lockStateOf(id) === "played" && (
                       <p className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-white/50">
                         <Tick02Icon className="size-3.5 shrink-0 text-emerald-500" />
-                        This player&apos;s match has finished.
+                        This player&apos;s match has finished — the points they
+                        earned in your XI are banked for this round, even if
+                        you bench them now.
                       </p>
                     )}
                   </div>

--- a/app/components/play/api.ts
+++ b/app/components/play/api.ts
@@ -10,6 +10,7 @@ import type {
   LeaderboardResponse,
   MatchdayResponse,
   PlayersResponse,
+  PublicManagerTeam,
   RewardsResponse,
   SaveSquadBody,
   SquadResponse,
@@ -114,6 +115,11 @@ export const fetchLeaderboard = (params: {
     { token: params.token },
   );
 };
+
+export const fetchManager = (username: string) =>
+  playRequest<PublicManagerTeam>(
+    `/api/play/manager/${encodeURIComponent(username)}`,
+  );
 
 /* ----------------------------- Authenticated ---------------------------- */
 

--- a/app/components/play/hooks.ts
+++ b/app/components/play/hooks.ts
@@ -18,6 +18,7 @@ import {
   PlayApiError,
   checkUsername,
   fetchLeaderboard,
+  fetchManager,
   fetchMatchday,
   fetchMatchdays,
   fetchPlayers,
@@ -43,7 +44,18 @@ export const playKeys = {
   leaderboard: (page: number, findMe: boolean, authed: boolean) =>
     ["play", "leaderboard", page, findMe, authed] as const,
   matchday: (id: number | string) => ["play", "matchday", id] as const,
+  manager: (username: string) => ["play", "manager", username] as const,
 };
+
+/** Public view of a manager's team (latest locked round only). */
+export function useManagerTeam(username: string | null | undefined) {
+  return useQuery({
+    queryKey: playKeys.manager(username ?? ""),
+    queryFn: () => fetchManager(username!),
+    enabled: Boolean(username),
+    staleTime: 30_000,
+  });
+}
 
 /** Public player pool + builder settings + current matchday. */
 export function usePlayersPool() {

--- a/app/components/play/types.ts
+++ b/app/components/play/types.ts
@@ -9,10 +9,20 @@ import type {
   FantasyPlayer,
   MatchdayStatus,
   Position,
+  PublicManagerTeam,
+  PublicTeamPlayer,
   ScoringMatrix,
 } from "@/app/lib/fantasy/types";
 
-export type { BadgeState, FantasyPlayer, MatchdayStatus, Position, ScoringMatrix };
+export type {
+  BadgeState,
+  FantasyPlayer,
+  MatchdayStatus,
+  Position,
+  PublicManagerTeam,
+  PublicTeamPlayer,
+  ScoringMatrix,
+};
 
 export interface PlayMatchday {
   id: number;
@@ -71,6 +81,8 @@ export interface SquadResponse {
   /** Free transfers granted for the current matchday (settings value). */
   free_transfers: number;
   total_points: number;
+  /** Own leaderboard handle — drives the squad share card. */
+  username: string | null;
   /** Own points per matchday (drives the round strip's pills). */
   matchday_scores: { matchday_id: number; points: number }[];
 }

--- a/app/hooks/useBridgeAccess.ts
+++ b/app/hooks/useBridgeAccess.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { hasBridgeConsent, setBridgeConsentAccepted } from "../lib/bridgeConsent";
+
+/**
+ * First-time Convert gate (same architecture as useEarnAccess): wrap the
+ * action that opens the convert/bridge flow in requestBridgeAccess — users
+ * who already accepted the disclosure pass straight through, everyone else
+ * sees the Terms of use modal first and the action runs on acceptance.
+ */
+export function useBridgeAccess() {
+  const { user } = usePrivy();
+  const [isConsentModalOpen, setIsConsentModalOpen] = useState(false);
+  const pendingRef = useRef<(() => void) | null>(null);
+
+  const requestBridgeAccess = useCallback(
+    (proceed: () => void) => {
+      if (hasBridgeConsent(user?.id)) {
+        proceed();
+        return;
+      }
+      pendingRef.current = proceed;
+      setIsConsentModalOpen(true);
+    },
+    [user?.id],
+  );
+
+  const handleConsentAccepted = useCallback(() => {
+    setBridgeConsentAccepted(user?.id);
+    setIsConsentModalOpen(false);
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    pending?.();
+  }, [user?.id]);
+
+  const dismissConsent = useCallback(() => {
+    pendingRef.current = null;
+    setIsConsentModalOpen(false);
+  }, []);
+
+  return {
+    isConsentModalOpen,
+    requestBridgeAccess,
+    handleConsentAccepted,
+    dismissConsent,
+  };
+}

--- a/app/lib/bridgeConsent.ts
+++ b/app/lib/bridgeConsent.ts
@@ -6,16 +6,33 @@
  */
 const BRIDGE_CONSENT_STORAGE_PREFIX = "noblocksBridgeConsentAccepted";
 
+// localStorage can throw (private browsing, blocked third-party storage,
+// quota). Consent accepted while persistence is unavailable is kept here so
+// the flow still proceeds for the rest of the session.
+const sessionConsent = new Set<string>();
+
 function bridgeConsentKey(userId: string): string {
   return `${BRIDGE_CONSENT_STORAGE_PREFIX}-${userId}`;
 }
 
 export function hasBridgeConsent(userId: string | undefined): boolean {
   if (typeof window === "undefined" || !userId) return false;
-  return localStorage.getItem(bridgeConsentKey(userId)) === "true";
+  const key = bridgeConsentKey(userId);
+  if (sessionConsent.has(key)) return true;
+  try {
+    return localStorage.getItem(key) === "true";
+  } catch {
+    return false;
+  }
 }
 
 export function setBridgeConsentAccepted(userId: string | undefined): void {
   if (typeof window === "undefined" || !userId) return;
-  localStorage.setItem(bridgeConsentKey(userId), "true");
+  const key = bridgeConsentKey(userId);
+  sessionConsent.add(key);
+  try {
+    localStorage.setItem(key, "true");
+  } catch {
+    // persistence unavailable — sessionConsent above keeps this session going
+  }
 }

--- a/app/lib/bridgeConsent.ts
+++ b/app/lib/bridgeConsent.ts
@@ -1,0 +1,21 @@
+/**
+ * Persists one-time acceptance of the Convert (Li.Fi / Near Intents
+ * third-party bridge) risk disclosure. Keyed per user for the same reason as
+ * earnConsent.ts: a device-global key would let the first account that
+ * accepted suppress the disclosure for every other account on the device.
+ */
+const BRIDGE_CONSENT_STORAGE_PREFIX = "noblocksBridgeConsentAccepted";
+
+function bridgeConsentKey(userId: string): string {
+  return `${BRIDGE_CONSENT_STORAGE_PREFIX}-${userId}`;
+}
+
+export function hasBridgeConsent(userId: string | undefined): boolean {
+  if (typeof window === "undefined" || !userId) return false;
+  return localStorage.getItem(bridgeConsentKey(userId)) === "true";
+}
+
+export function setBridgeConsentAccepted(userId: string | undefined): void {
+  if (typeof window === "undefined" || !userId) return;
+  localStorage.setItem(bridgeConsentKey(userId), "true");
+}

--- a/app/lib/fantasy/scoring.ts
+++ b/app/lib/fantasy/scoring.ts
@@ -83,8 +83,24 @@ export function computePoints(
   return { points, breakdown };
 }
 
+/**
+ * Whether a squad row's points count toward the matchday score: the
+ * kickoff-banked XI membership wins; the current slot only decides for
+ * fixtures that haven't kicked off yet (stamp still NULL).
+ */
+export const countsForScoring = (p: {
+  slot: number;
+  xi_at_kickoff?: boolean | null;
+}): boolean => p.xi_at_kickoff ?? p.slot <= 11;
+
 export interface SquadPointsInput {
-  /** Starting XI only — bench never auto-counts (auto-subs dropped, TRD §6.3). */
+  /**
+   * Players whose points count: XI membership is banked at each fixture's
+   * kickoff (xi_at_kickoff stamp), with the current slot deciding only for
+   * fixtures that haven't kicked off. Bench never auto-counts (auto-subs
+   * dropped, TRD §6.3), but points earned while in the XI survive a later
+   * benching — so this list can exceed 11 entries.
+   */
   startingXI: { playerId: number; isCaptain: boolean; isVice: boolean }[];
   /** playerId → summed matchday stats-derived values. */
   playerPoints: Map<number, { points: number; minutes: number }>;

--- a/app/lib/fantasy/server.ts
+++ b/app/lib/fantasy/server.ts
@@ -4,7 +4,12 @@ import { supabaseAdmin } from "../supabase";
 import config from "../config";
 import { getPrivyUserIdFromRequest, getWalletAddressFromPrivyUserId } from "../privy";
 import { LIVE_STATUSES, FINISHED_STATUSES } from "./provider";
-import type { FantasyPlayer, MatchdayStatus } from "./types";
+import type {
+  FantasyPlayer,
+  MatchdayStatus,
+  Position,
+  PublicManagerTeam,
+} from "./types";
 
 /** Shared helpers for /api/play/* route handlers and the scoring worker. */
 
@@ -165,6 +170,124 @@ export async function getTeamLockStates(
     states.set(Number(fixture.away_team_id), state);
   }
   return states;
+}
+
+/**
+ * Public view of a manager's team (leaderboard drill-in, share links, OG
+ * cards). Privacy: only the most recent LOCKED matchday's squad is exposed —
+ * picks for a round that is still open never leak.
+ */
+export async function getPublicManagerTeam(
+  usernameRaw: string,
+): Promise<PublicManagerTeam | null> {
+  const username = usernameRaw.trim();
+  if (!/^[A-Za-z0-9_]{3,20}$/.test(username)) return null;
+
+  // ilike with escaped `_` (a LIKE wildcard) = case-insensitive equality.
+  const { data: row, error } = await supabaseAdmin
+    .from("fantasy_leaderboard")
+    .select("wallet_address, username, total_points, rank, badge")
+    .ilike("username", username.replace(/_/g, "\\_"))
+    .maybeSingle();
+  if (error) throw error;
+  if (!row?.username) return null;
+
+  // Same "current round" the rest of the app uses (lowest non-final). Its
+  // squad goes public once it locks; while it's still open, fall back to the
+  // last played round. Never "any locked matchday": rollover clones squads
+  // into the NEXT round ahead of time, and picking those up would show a
+  // not-yet-played 0-pt squad instead of the round that's actually on.
+  const matchdays = await getMatchdays();
+  const current =
+    matchdays.find((md) => md.status !== "final") ??
+    matchdays[matchdays.length - 1];
+  const ceilingId = current
+    ? isMatchdayLocked(current)
+      ? current.id
+      : current.id - 1
+    : null;
+
+  let team: PublicManagerTeam["team"] = null;
+  if (ceilingId != null && matchdays.some((md) => md.id <= ceilingId)) {
+    const { data: squadRow, error: squadError } = await supabaseAdmin
+      .from("fantasy_squads")
+      .select(
+        "matchday_id, players:fantasy_squad_players(player_id, slot, is_captain, is_vice)",
+      )
+      .eq("wallet_address", row.wallet_address)
+      .lte("matchday_id", ceilingId)
+      .order("matchday_id", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (squadError) throw squadError;
+
+    if (squadRow) {
+      const matchdayId = Number(squadRow.matchday_id);
+      const matchday = matchdays.find((md) => md.id === matchdayId)!;
+      const [players, playerPoints, { data: score }] = await Promise.all([
+        getPlayersMap(),
+        getMatchdayPlayerPoints(matchdayId),
+        supabaseAdmin
+          .from("fantasy_matchday_scores")
+          .select("points")
+          .eq("wallet_address", row.wallet_address)
+          .eq("matchday_id", matchdayId)
+          .maybeSingle(),
+      ]);
+
+      const entries = (squadRow.players ?? []).map((p) => ({
+        player_id: Number(p.player_id),
+        slot: Number(p.slot),
+        is_captain: Boolean(p.is_captain),
+        is_vice: Boolean(p.is_vice),
+      }));
+      const live = (id: number) =>
+        playerPoints.get(id) ?? { points: 0, minutes: 0 };
+      const captain = entries.find((p) => p.is_captain);
+      const vice = entries.find((p) => p.is_vice);
+      // Same doubling rule as computeSquadPoints: captain once they've
+      // played, otherwise the vice.
+      const doubledId =
+        captain && live(captain.player_id).minutes > 0
+          ? captain.player_id
+          : vice && live(vice.player_id).minutes > 0
+            ? vice.player_id
+            : null;
+
+      team = {
+        matchday: {
+          id: matchday.id,
+          display_name: matchday.display_name,
+          status: matchday.status,
+        },
+        points: Number(score?.points ?? 0),
+        players: entries
+          .sort((a, b) => a.slot - b.slot)
+          .map((entry) => {
+            const player = players.get(entry.player_id);
+            const stats = live(entry.player_id);
+            return {
+              ...entry,
+              name: player?.name ?? "Unknown",
+              position: player?.position ?? ("MID" as Position),
+              nation: player?.nation ?? "",
+              photo_url: player?.photo_url ?? null,
+              points:
+                stats.points * (entry.player_id === doubledId ? 2 : 1),
+              minutes: stats.minutes,
+            };
+          }),
+      };
+    }
+  }
+
+  return {
+    username: row.username as string,
+    rank: row.rank != null ? Number(row.rank) : null,
+    total_points: Number(row.total_points),
+    badge: String(row.badge),
+    team,
+  };
 }
 
 /** Sum of live/final points per player for a matchday (from stats upserts). */

--- a/app/lib/fantasy/server.ts
+++ b/app/lib/fantasy/server.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from "../supabase";
 import config from "../config";
 import { getPrivyUserIdFromRequest, getWalletAddressFromPrivyUserId } from "../privy";
 import { LIVE_STATUSES, FINISHED_STATUSES } from "./provider";
+import { countsForScoring } from "./scoring";
 import type {
   FantasyPlayer,
   MatchdayStatus,
@@ -212,7 +213,7 @@ export async function getPublicManagerTeam(
     const { data: squadRow, error: squadError } = await supabaseAdmin
       .from("fantasy_squads")
       .select(
-        "matchday_id, players:fantasy_squad_players(player_id, slot, is_captain, is_vice)",
+        "matchday_id, players:fantasy_squad_players(player_id, slot, is_captain, is_vice, xi_at_kickoff)",
       )
       .eq("wallet_address", row.wallet_address)
       .lte("matchday_id", ceilingId)
@@ -224,7 +225,7 @@ export async function getPublicManagerTeam(
     if (squadRow) {
       const matchdayId = Number(squadRow.matchday_id);
       const matchday = matchdays.find((md) => md.id === matchdayId)!;
-      const [players, playerPoints, { data: score }] = await Promise.all([
+      const [players, playerPoints, scoreResult] = await Promise.all([
         getPlayersMap(),
         getMatchdayPlayerPoints(matchdayId),
         supabaseAdmin
@@ -234,19 +235,24 @@ export async function getPublicManagerTeam(
           .eq("matchday_id", matchdayId)
           .maybeSingle(),
       ]);
+      if (scoreResult.error) throw scoreResult.error;
+      const score = scoreResult.data;
 
       const entries = (squadRow.players ?? []).map((p) => ({
         player_id: Number(p.player_id),
         slot: Number(p.slot),
         is_captain: Boolean(p.is_captain),
         is_vice: Boolean(p.is_vice),
+        xi_at_kickoff: (p.xi_at_kickoff ?? null) as boolean | null,
       }));
       const live = (id: number) =>
         playerPoints.get(id) ?? { points: 0, minutes: 0 };
-      const captain = entries.find((p) => p.is_captain);
-      const vice = entries.find((p) => p.is_vice);
-      // Same doubling rule as computeSquadPoints: captain once they've
-      // played, otherwise the vice.
+      // Same rules as recomputeScores/computeSquadPoints: a player's points
+      // count only per the kickoff-banked stamp (current slot decides for
+      // fixtures not kicked off yet), and the captain doubles once they've
+      // played, otherwise the vice — both only while they count for scoring.
+      const captain = entries.find((p) => p.is_captain && countsForScoring(p));
+      const vice = entries.find((p) => p.is_vice && countsForScoring(p));
       const doubledId =
         captain && live(captain.player_id).minutes > 0
           ? captain.player_id
@@ -263,17 +269,25 @@ export async function getPublicManagerTeam(
         points: Number(score?.points ?? 0),
         players: entries
           .sort((a, b) => a.slot - b.slot)
-          .map((entry) => {
+          .map(({ xi_at_kickoff: _stamp, ...entry }) => {
             const player = players.get(entry.player_id);
             const stats = live(entry.player_id);
+            // Effective points: zero for a player whose points are excluded
+            // from team.points (e.g. moved into the XI after kickoff), so
+            // the public card always sums to the banked score.
+            const counts = countsForScoring({
+              slot: entry.slot,
+              xi_at_kickoff: _stamp,
+            });
             return {
               ...entry,
               name: player?.name ?? "Unknown",
               position: player?.position ?? ("MID" as Position),
               nation: player?.nation ?? "",
               photo_url: player?.photo_url ?? null,
-              points:
-                stats.points * (entry.player_id === doubledId ? 2 : 1),
+              points: counts
+                ? stats.points * (entry.player_id === doubledId ? 2 : 1)
+                : 0,
               minutes: stats.minutes,
             };
           }),

--- a/app/lib/fantasy/types.ts
+++ b/app/lib/fantasy/types.ts
@@ -77,6 +77,12 @@ export interface FantasySettings {
   campaign_start: string;
   campaign_end: string;
   features: { emails: boolean; share_cards: boolean; join_open: boolean };
+  /**
+   * One-shot rescore queue: migrations that rewrite kickoff stamps directly
+   * (bypassing the stamp RPC) enqueue affected matchday ids here; the worker
+   * recomputes them on its next tick and clears the key.
+   */
+  pending_rescore_matchdays?: number[];
 }
 
 export interface FantasyPlayer {

--- a/app/lib/fantasy/types.ts
+++ b/app/lib/fantasy/types.ts
@@ -97,6 +97,34 @@ export interface SquadSelection {
   viceId: number;
 }
 
+export interface PublicTeamPlayer {
+  player_id: number;
+  slot: number;
+  is_captain: boolean;
+  is_vice: boolean;
+  name: string;
+  position: Position;
+  nation: string;
+  photo_url: string | null;
+  /** Effective points — includes the captain double / vice fallback. */
+  points: number;
+  minutes: number;
+}
+
+/** Public view of a manager's team (leaderboard drill-in, share links). */
+export interface PublicManagerTeam {
+  username: string;
+  rank: number | null;
+  total_points: number;
+  badge: string;
+  /** null until the manager has a squad in a locked round. */
+  team: {
+    matchday: { id: number; display_name: string; status: MatchdayStatus };
+    points: number;
+    players: PublicTeamPlayer[];
+  } | null;
+}
+
 export interface LeaderboardRow {
   rank: number;
   username: string | null;

--- a/app/lib/fantasy/worker.ts
+++ b/app/lib/fantasy/worker.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { supabaseAdmin } from "../supabase";
-import { computePoints, computeSquadPoints } from "./scoring";
+import { computePoints, computeSquadPoints, countsForScoring } from "./scoring";
 import {
   FINISHED_STATUSES,
   LIVE_STATUSES,
@@ -60,6 +60,8 @@ export interface WorkerReport {
   live_window_active: boolean;
   fixtures_refreshed: boolean;
   transitions: string[];
+  /** Squad-player rows stamped with their XI/bench state at kickoff this tick. */
+  kickoff_stamps: number;
   stats_synced: number;
   fixtures_finalized: number;
   scores_recomputed: number;
@@ -267,8 +269,9 @@ async function syncFixtureStats(
   if (error) throw error;
 }
 
-/** Recompute matchday scores, participant totals and ranks (idempotent). */
-async function recomputeScores(matchdayIds: number[]): Promise<number> {
+/** Recompute matchday scores, participant totals and ranks (idempotent).
+ * Exported for the admin restore-banked repair route. */
+export async function recomputeScores(matchdayIds: number[]): Promise<number> {
   if (matchdayIds.length === 0) return 0;
   let updated = 0;
 
@@ -305,12 +308,18 @@ async function recomputeScores(matchdayIds: number[]): Promise<number> {
     const squads = await fetchAll<{
       wallet_address: string;
       transfer_points_deduction: number;
-      players: { player_id: number; slot: number; is_captain: boolean; is_vice: boolean }[];
+      players: {
+        player_id: number;
+        slot: number;
+        is_captain: boolean;
+        is_vice: boolean;
+        xi_at_kickoff: boolean | null;
+      }[];
     }>((from, to) =>
       supabaseAdmin
         .from("fantasy_squads")
         .select(
-          "wallet_address, transfer_points_deduction, players:fantasy_squad_players(player_id, slot, is_captain, is_vice)",
+          "wallet_address, transfer_points_deduction, players:fantasy_squad_players(player_id, slot, is_captain, is_vice, xi_at_kickoff)",
         )
         .eq("matchday_id", matchdayId)
         .range(from, to),
@@ -320,8 +329,12 @@ async function recomputeScores(matchdayIds: number[]): Promise<number> {
       wallet_address: squad.wallet_address,
       matchday_id: matchdayId,
       points: computeSquadPoints({
+        // Points count for players who were in the XI when their fixture
+        // kicked off (banked stamp); current slot only decides for fixtures
+        // that haven't kicked off yet. Benching a played player keeps the
+        // points they already earned.
         startingXI: (squad.players ?? [])
-          .filter((p) => p.slot <= 11)
+          .filter(countsForScoring)
           .map((p) => ({
             playerId: Number(p.player_id),
             isCaptain: p.is_captain,
@@ -797,6 +810,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
     live_window_active: false,
     fixtures_refreshed: false,
     transitions: [],
+    kickoff_stamps: 0,
     stats_synced: 0,
     fixtures_finalized: 0,
     scores_recomputed: 0,
@@ -886,6 +900,47 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
       fixtures = await loadFixtures();
     }
 
+    // 3.5 Bank XI membership at kickoff (fairness): stamp squad players of
+    // teams whose fixture has kicked off so later bench moves can't erase
+    // points already earned in the XI. Row-idempotent (NULL-only stamping),
+    // and DB-cheap once a round is fully stamped (0-row updates) — so this
+    // runs on every tick a non-final matchday has kicked-off fixtures, not
+    // just inside the active window, so late bench moves during a long
+    // 'finalizing' tail can't dodge the stamp. Matchdays whose stamps
+    // changed are rescored below — that's also what folds the migration's
+    // amnesty backfill into the leaderboard automatically on the first tick
+    // after deploy.
+    const stampedMatchdays = new Set<number>();
+    for (const md of matchdays) {
+      if (md.status === "final") continue;
+      const kickedOffTeams = [
+        ...new Set(
+          fixtures
+            .filter(
+              (f) =>
+                f.matchday_id === md.id &&
+                (LIVE_STATUSES.has(f.status) ||
+                  FINISHED_STATUSES.has(f.status) ||
+                  new Date(f.kickoff).getTime() <= now),
+            )
+            .flatMap((f) => [f.home_team_id, f.away_team_id]),
+        ),
+      ].filter(Boolean);
+      if (kickedOffTeams.length === 0) continue;
+      const { data: stamped, error } = await supabaseAdmin.rpc(
+        "fantasy_stamp_kickoff",
+        { p_matchday_id: md.id, p_team_ids: kickedOffTeams },
+      );
+      if (error) {
+        report.alerts.push(`kickoff stamp failed for MD${md.id}: ${String(error.message)}`);
+        continue;
+      }
+      if (Number(stamped ?? 0) > 0) {
+        report.kickoff_stamps += Number(stamped);
+        stampedMatchdays.add(md.id);
+      }
+    }
+
     // 4. Status-based transitions from fresh fixture state.
     const finalizedThisTick: MatchdayRow[] = [];
     for (const md of matchdays) {
@@ -927,13 +982,19 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           )
           .map((md) => md.id),
         ...statsSyncedMatchdays,
+        ...stampedMatchdays,
         // Forced ticks always recompute the current round (manual ops).
         ...(force
           ? matchdays.filter((md) => md.status !== "final").slice(0, 1).map((md) => md.id)
           : []),
       ]),
     ];
-    if (report.stats_synced > 0 || report.transitions.length > 0 || force) {
+    if (
+      report.stats_synced > 0 ||
+      report.transitions.length > 0 ||
+      stampedMatchdays.size > 0 ||
+      force
+    ) {
       try {
         report.scores_recomputed = await recomputeScores(scoreTargets);
       } catch (error) {

--- a/app/lib/fantasy/worker.ts
+++ b/app/lib/fantasy/worker.ts
@@ -9,7 +9,11 @@ import {
   getProviderRateLimit,
   getWorldCupFixtures,
 } from "./provider";
-import { getFantasySettings, matchdayLabel } from "./settings";
+import {
+  getFantasySettings,
+  invalidateFantasySettingsCache,
+  matchdayLabel,
+} from "./settings";
 import { getPlayersMap, type MatchdayRow } from "./server";
 import {
   claimNotification,
@@ -413,6 +417,34 @@ export async function recomputeScores(matchdayIds: number[]): Promise<number> {
   }
 
   return updated;
+}
+
+/**
+ * Drain the one-shot pending_rescore_matchdays queue (written by migrations
+ * that rewrite kickoff stamps directly) after a successful recompute. A
+ * failed clear just repeats the rescore next tick — recompute is idempotent.
+ */
+async function clearPendingRescore(alerts: string[]): Promise<void> {
+  const { data, error } = await supabaseAdmin
+    .from("fantasy_settings")
+    .select("config")
+    .eq("id", 1)
+    .single();
+  if (error || !data) {
+    alerts.push(`pending rescore clear failed: ${String(error?.message ?? "no row")}`);
+    return;
+  }
+  const { pending_rescore_matchdays: _drained, ...config } =
+    data.config as FantasySettings;
+  const { error: updateError } = await supabaseAdmin
+    .from("fantasy_settings")
+    .update({ config, updated_at: new Date().toISOString() })
+    .eq("id", 1);
+  if (updateError) {
+    alerts.push(`pending rescore clear failed: ${String(updateError.message)}`);
+    return;
+  }
+  invalidateFantasySettingsCache();
 }
 
 /**
@@ -971,6 +1003,11 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
     // fixtures just synced are always included — even while 'upcoming'
     // (possible when a round was seeded mid-play, e.g. R16 test mode; in a
     // normal campaign an upcoming round has no stats, so this is a no-op).
+    // pending_rescore_matchdays is a one-shot queue for migrations that
+    // rewrite kickoff stamps directly (the amnesty backfill): those writes
+    // bypass the stamp RPC, and final rounds are skipped by the stamp loop
+    // above, so they'd otherwise never be rescored.
+    const pendingRescore = (settings.pending_rescore_matchdays ?? []).map(Number);
     const scoreTargets = [
       ...new Set([
         ...matchdays
@@ -983,6 +1020,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           .map((md) => md.id),
         ...statsSyncedMatchdays,
         ...stampedMatchdays,
+        ...pendingRescore,
         // Forced ticks always recompute the current round (manual ops).
         ...(force
           ? matchdays.filter((md) => md.status !== "final").slice(0, 1).map((md) => md.id)
@@ -993,10 +1031,12 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
       report.stats_synced > 0 ||
       report.transitions.length > 0 ||
       stampedMatchdays.size > 0 ||
+      pendingRescore.length > 0 ||
       force
     ) {
       try {
         report.scores_recomputed = await recomputeScores(scoreTargets);
+        if (pendingRescore.length > 0) await clearPendingRescore(report.alerts);
       } catch (error) {
         report.alerts.push(`score recompute failed: ${String(error)}`);
       }

--- a/app/play/manager/[username]/page.tsx
+++ b/app/play/manager/[username]/page.tsx
@@ -1,0 +1,54 @@
+import { cache } from "react";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPublicManagerTeam } from "@/app/lib/fantasy/server";
+import { ManagerTeamView } from "@/app/components/play/ManagerTeamView";
+
+/**
+ * /play/manager/[username] — public, read-only view of a manager's team
+ * (latest locked round). Also the share target for squad snapshots: its OG
+ * image is the squad card, so links unfurl the pitch on X.
+ */
+
+export const dynamic = "force-dynamic";
+
+// Dedupe the lookup between generateMetadata and the page render.
+const getManager = cache((username: string) =>
+  getPublicManagerTeam(username).catch(() => null),
+);
+
+interface Props {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { username } = await params;
+  const manager = await getManager(decodeURIComponent(username));
+  if (!manager) return { title: "Manager not found — Noblocks Play" };
+
+  const title = `${manager.username}'s squad — Noblocks Play`;
+  const description = manager.team
+    ? `${manager.team.matchday.display_name}: ${manager.team.points} pts · ranked #${manager.rank ?? "—"} in the World Cup fantasy league. #NoblocksPlay`
+    : `Ranked #${manager.rank ?? "—"} in the Noblocks Play World Cup fantasy league. #NoblocksPlay`;
+  const image = `/api/play/og?layout=squad&username=${encodeURIComponent(manager.username)}`;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, images: [image] },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export default async function ManagerPage({ params }: Props) {
+  const { username } = await params;
+  const manager = await getManager(decodeURIComponent(username));
+  if (!manager) notFound();
+
+  return <ManagerTeamView manager={manager} />;
+}

--- a/app/play/manager/[username]/page.tsx
+++ b/app/play/manager/[username]/page.tsx
@@ -12,10 +12,10 @@ import { ManagerTeamView } from "@/app/components/play/ManagerTeamView";
 
 export const dynamic = "force-dynamic";
 
-// Dedupe the lookup between generateMetadata and the page render.
-const getManager = cache((username: string) =>
-  getPublicManagerTeam(username).catch(() => null),
-);
+// Dedupe the lookup between generateMetadata and the page render. Returns
+// null only for a genuinely unknown manager; backend failures propagate so
+// an outage surfaces as a 500, not a misleading 404.
+const getManager = cache((username: string) => getPublicManagerTeam(username));
 
 interface Props {
   params: Promise<{ username: string }>;

--- a/app/play/team/page.tsx
+++ b/app/play/team/page.tsx
@@ -12,6 +12,7 @@ import { useLogin, usePrivy } from "@privy-io/react-auth";
 import { Cancel01Icon, FootballIcon } from "hugeicons-react";
 import { PlayApiError } from "@/app/components/play/api";
 import { TeamManager } from "@/app/components/play/TeamManager";
+import { ShareSquadCard } from "@/app/components/play/ShareSquadCard";
 import { SquadKey } from "@/app/components/play/SquadKey";
 import { RoundStrip } from "@/app/components/play/RoundStrip";
 import { FixturesCard } from "@/app/components/play/FixturesCard";
@@ -116,6 +117,9 @@ export default function TeamPage() {
         />
         <TeamManager squadData={squadQuery.data} poolData={poolQuery.data} />
         <SquadKey onHowToScore={() => setShowScoring(true)} />
+        {squadQuery.data.username && (
+          <ShareSquadCard username={squadQuery.data.username} />
+        )}
         <FixturesCard initialMatchdayId={matchdayId} />
       </div>
       <aside className="hidden xl:sticky xl:top-24 xl:block xl:w-80 xl:shrink-0">

--- a/app/play/terms/page.tsx
+++ b/app/play/terms/page.tsx
@@ -150,7 +150,9 @@ export default function PlayTermsPage() {
             During a live round, lineup and captaincy changes follow a
             rolling lockout: a player whose match is in progress or finished
             cannot be brought into the XI, and a player cannot be moved while
-            their match is in progress.
+            their match is in progress. Points a player earns while in your
+            XI are banked for the round — benching them afterwards does not
+            remove those points.
           </li>
         </ul>
         <p>

--- a/supabase/migrations/20260710120000_bank_xi_points_at_kickoff.sql
+++ b/supabase/migrations/20260710120000_bank_xi_points_at_kickoff.sql
@@ -12,26 +12,46 @@ ALTER TABLE public.fantasy_squad_players
 
 -- One-time amnesty backfill for rounds damaged BEFORE this deploy: a bench
 -- player with positive points this matchday is treated as XI-at-kickoff, so
--- points forfeited by pre-fix bench moves come back on the next rescore
--- (the worker rescores automatically when stamps change). The pre-fix data
--- cannot distinguish these from players who genuinely played from the bench,
--- so those count too — a uniform, one-time generosity. Rows with points <= 0
--- stay NULL so the restore can never lower a score.
-UPDATE public.fantasy_squad_players sp
-   SET xi_at_kickoff = true
-  FROM public.fantasy_squads s
- WHERE sp.squad_id = s.id
-   AND sp.slot >= 12
-   AND sp.xi_at_kickoff IS NULL
-   AND EXISTS (
-     SELECT 1
-       FROM public.fantasy_player_match_stats pms
-       JOIN public.fantasy_fixtures f
-         ON f.provider_fixture_id = pms.provider_fixture_id
-      WHERE pms.player_id = sp.player_id
-        AND f.matchday_id = s.matchday_id
-        AND pms.points > 0
-   );
+-- points forfeited by pre-fix bench moves come back on the next rescore.
+-- The pre-fix data cannot distinguish these from players who genuinely
+-- played from the bench, so those count too — a uniform, one-time
+-- generosity. Rows with points <= 0 stay NULL so the restore can never
+-- lower a score.
+--
+-- The worker only rescores matchdays whose stamps change through the
+-- fantasy_stamp_kickoff RPC, and skips 'final' matchdays entirely — so this
+-- direct UPDATE would leave already-final rounds' totals stale. Enqueue
+-- every affected matchday in fantasy_settings.config->pending_rescore_matchdays;
+-- the worker drains that queue (recomputeScores) on its next tick.
+WITH restored AS (
+  UPDATE public.fantasy_squad_players sp
+     SET xi_at_kickoff = true
+    FROM public.fantasy_squads s
+   WHERE sp.squad_id = s.id
+     AND sp.slot >= 12
+     AND sp.xi_at_kickoff IS NULL
+     AND EXISTS (
+       SELECT 1
+         FROM public.fantasy_player_match_stats pms
+         JOIN public.fantasy_fixtures f
+           ON f.provider_fixture_id = pms.provider_fixture_id
+        WHERE pms.player_id = sp.player_id
+          AND f.matchday_id = s.matchday_id
+          AND pms.points > 0
+     )
+  RETURNING s.matchday_id
+)
+UPDATE public.fantasy_settings
+   SET config = jsonb_set(
+         config,
+         '{pending_rescore_matchdays}',
+         COALESCE(config->'pending_rescore_matchdays', '[]'::jsonb)
+           || (SELECT COALESCE(jsonb_agg(DISTINCT matchday_id), '[]'::jsonb)
+                 FROM restored)
+       ),
+       updated_at = now()
+ WHERE id = 1
+   AND EXISTS (SELECT 1 FROM restored);
 
 -- Stamp all squad players of a matchday whose team's fixture has kicked off.
 -- Idempotent: only NULL rows are stamped, so later lineup edits can never
@@ -63,6 +83,11 @@ BEGIN
 END;
 $$;
 
+-- SECURITY DEFINER + default PUBLIC EXECUTE would let any RPC caller stamp
+-- kickoff state and permanently alter scoring history — worker only.
+REVOKE EXECUTE ON FUNCTION public.fantasy_stamp_kickoff(INTEGER, BIGINT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fantasy_stamp_kickoff(INTEGER, BIGINT[]) TO service_role;
+
 -- fantasy_save_squad replaces the composition via delete + reinsert; it must
 -- carry the kickoff stamps across, or every lineup save during a live round
 -- would wipe the banked history.
@@ -93,6 +118,25 @@ BEGIN
      WHERE id = p_squad_id
      RETURNING id INTO v_squad_id;
   END IF;
+
+  -- Stamp any not-yet-stamped player whose fixture has kicked off BEFORE
+  -- replacing the composition. The worker's stamp can lag a tick behind
+  -- kickoff; without this, benching a played player in that gap carries a
+  -- NULL stamp into the new bench slot and the later worker stamp records
+  -- false — forfeiting points already earned in the XI. Same kicked-off
+  -- test as the worker: live/finished status, or kickoff time reached.
+  UPDATE fantasy_squad_players sp
+     SET xi_at_kickoff = (sp.slot <= 11)
+    FROM fantasy_players pl, fantasy_fixtures f
+   WHERE sp.squad_id = v_squad_id
+     AND sp.xi_at_kickoff IS NULL
+     AND pl.provider_player_id = sp.player_id
+     AND f.matchday_id = p_matchday_id
+     AND pl.team_id IN (f.home_team_id, f.away_team_id)
+     AND (
+       f.status IN ('1H', 'HT', '2H', 'ET', 'BT', 'P', 'LIVE', 'INT', 'FT', 'AET', 'PEN')
+       OR now() >= f.kickoff
+     );
 
   WITH old AS (
     DELETE FROM fantasy_squad_players

--- a/supabase/migrations/20260710120000_bank_xi_points_at_kickoff.sql
+++ b/supabase/migrations/20260710120000_bank_xi_points_at_kickoff.sql
@@ -1,0 +1,115 @@
+-- Bank XI membership at kickoff.
+--
+-- Matchday scores are recomputed from the CURRENT squad rows, so benching a
+-- player after their match silently forfeited the points they had already
+-- earned in the XI. Fix: snapshot each player's XI/bench state the moment
+-- their fixture kicks off (worker calls fantasy_stamp_kickoff every tick) and
+-- score from that snapshot. NULL = the player's fixture hasn't kicked off yet
+-- (falls back to current slot in the scorer).
+--
+ALTER TABLE public.fantasy_squad_players
+    ADD COLUMN IF NOT EXISTS xi_at_kickoff boolean;
+
+-- One-time amnesty backfill for rounds damaged BEFORE this deploy: a bench
+-- player with positive points this matchday is treated as XI-at-kickoff, so
+-- points forfeited by pre-fix bench moves come back on the next rescore
+-- (the worker rescores automatically when stamps change). The pre-fix data
+-- cannot distinguish these from players who genuinely played from the bench,
+-- so those count too — a uniform, one-time generosity. Rows with points <= 0
+-- stay NULL so the restore can never lower a score.
+UPDATE public.fantasy_squad_players sp
+   SET xi_at_kickoff = true
+  FROM public.fantasy_squads s
+ WHERE sp.squad_id = s.id
+   AND sp.slot >= 12
+   AND sp.xi_at_kickoff IS NULL
+   AND EXISTS (
+     SELECT 1
+       FROM public.fantasy_player_match_stats pms
+       JOIN public.fantasy_fixtures f
+         ON f.provider_fixture_id = pms.provider_fixture_id
+      WHERE pms.player_id = sp.player_id
+        AND f.matchday_id = s.matchday_id
+        AND pms.points > 0
+   );
+
+-- Stamp all squad players of a matchday whose team's fixture has kicked off.
+-- Idempotent: only NULL rows are stamped, so later lineup edits can never
+-- rewrite history.
+CREATE OR REPLACE FUNCTION public.fantasy_stamp_kickoff(
+  p_matchday_id INTEGER,
+  p_team_ids    BIGINT[]
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  PERFORM set_config('search_path', 'public', true);
+
+  UPDATE fantasy_squad_players sp
+     SET xi_at_kickoff = (sp.slot <= 11)
+    FROM fantasy_squads s, fantasy_players pl
+   WHERE sp.squad_id = s.id
+     AND s.matchday_id = p_matchday_id
+     AND pl.provider_player_id = sp.player_id
+     AND pl.team_id = ANY(p_team_ids)
+     AND sp.xi_at_kickoff IS NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- fantasy_save_squad replaces the composition via delete + reinsert; it must
+-- carry the kickoff stamps across, or every lineup save during a live round
+-- would wipe the banked history.
+CREATE OR REPLACE FUNCTION public.fantasy_save_squad(
+  p_squad_id       UUID,
+  p_wallet_address TEXT,
+  p_matchday_id    INTEGER,
+  p_budget_spent   NUMERIC,
+  p_is_initial     BOOLEAN,
+  p_players        JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_squad_id UUID;
+BEGIN
+  PERFORM set_config('search_path', 'public', true);
+
+  IF p_squad_id IS NULL THEN
+    INSERT INTO fantasy_squads (wallet_address, matchday_id, budget_spent, is_initial)
+    VALUES (p_wallet_address, p_matchday_id, p_budget_spent, p_is_initial)
+    RETURNING id INTO v_squad_id;
+  ELSE
+    UPDATE fantasy_squads
+       SET budget_spent = p_budget_spent
+     WHERE id = p_squad_id
+     RETURNING id INTO v_squad_id;
+  END IF;
+
+  WITH old AS (
+    DELETE FROM fantasy_squad_players
+     WHERE squad_id = v_squad_id
+    RETURNING player_id, xi_at_kickoff
+  )
+  INSERT INTO fantasy_squad_players (squad_id, player_id, slot, is_captain, is_vice, xi_at_kickoff)
+  SELECT
+    v_squad_id,
+    (p->>'playerId')::BIGINT,
+    (p->>'slot')::INTEGER,
+    COALESCE((p->>'isCaptain')::BOOLEAN, false),
+    COALESCE((p->>'isVice')::BOOLEAN, false),
+    o.xi_at_kickoff
+  FROM jsonb_array_elements(p_players) AS p
+  LEFT JOIN old o ON o.player_id = (p->>'playerId')::BIGINT;
+
+  RETURN v_squad_id;
+END;
+$$;


### PR DESCRIPTION

### Description
- Added a new API endpoint to fetch a public view of a manager's team, including their latest locked squad and points.
- Introduced the BridgeConsentModal component to handle user consent for third-party bridge transactions, ensuring users acknowledge the associated risks.
- Integrated bridge consent handling into the MobileDropdown and WalletDetails components, prompting users when necessary.
- Enhanced the LeaderboardTable to link rows to the corresponding manager's public team view.
- Updated scoring logic to account for points from players benched after kickoff, ensuring accurate matchday scoring.

This pull request introduces several new features and improvements related to the Noblocks Play fantasy squad and manager experience, along with a new consent modal for bridge/convert actions. The highlights include a new public API route for viewing a manager's team, a new OpenGraph (OG) image layout that visually represents a manager's squad, and improved handling of user profile data in squad APIs. Additionally, a reusable modal for bridge protocol risk acknowledgment is added.

**Fantasy Manager & Squad API Enhancements:**

* Added a new public API route (`app/api/play/manager/[username]/route.ts`) that returns a manager's public team, including rank, points, and the most recent locked matchday squad. This ensures open-round picks are not leaked and provides a clear error if the manager is not found. ([app/api/play/manager/[username]/route.tsR1-R36](diffhunk://#diff-44d0346d9f4c2a16b494e58da93f1a5e78a8dad4a1c3609d5655511e148c93b8R1-R36))
* The squad API (`app/api/play/squad/route.ts`) now fetches and returns the user's `username` from their profile, making it available in squad responses. This enables better personalization and display in the UI. [[1]](diffhunk://#diff-4436617917b37662542b3877ae6d9eb782ac4ca0dae7380c5b0bd424ee1d5fb3R54-R58) [[2]](diffhunk://#diff-4436617917b37662542b3877ae6d9eb782ac4ca0dae7380c5b0bd424ee1d5fb3R82)
* Improved the squad API's handling of moving players: clarified that moving a finished (locked) player out is allowed, as their points are already banked by the kickoff snapshot, not the current slot.

**OpenGraph Image & Share Card Improvements:**

* Added a new "squad" layout to the OG image route (`app/api/play/og/route.tsx`). This generates a 1200×630 visual snapshot of the manager's current XI, including real headshots (with initials fallback), captain/vice badges, and per-player points, plus manager stats and branding. This is used for rich link previews (e.g., when sharing `/play/manager/[username]`). [[1]](diffhunk://#diff-1572f7565582d3a08de548466872c4de35b60f5589589a8d100697b99a5fc417R76-R430) [[2]](diffhunk://#diff-1572f7565582d3a08de548466872c4de35b60f5589589a8d100697b99a5fc417R442-R457)
* The OG image endpoint now supports the "squad" layout via a query parameter and handles errors gracefully if squad rendering fails.

**Testing & Utilities:**

* Added new tests for the `countsForScoring` function to ensure correct logic for XI membership and benching at kickoff, improving reliability of fantasy point calculations. [[1]](diffhunk://#diff-1fb28d7d01f9d3f48bcaa6253b9779cd8dd96486e557e7d24e074d077aa7e715L7-R7) [[2]](diffhunk://#diff-1fb28d7d01f9d3f48bcaa6253b9779cd8dd96486e557e7d24e074d077aa7e715R234-R251)

**UI/UX Enhancements:**

* Introduced a new `BridgeConsentModal` component, which displays a terms-of-use disclosure and risk acknowledgment for first-time users of the convert/bridge feature. The modal requires explicit user consent before proceeding and is styled for both desktop and mobile.

These changes collectively improve the transparency, shareability, and robustness of the fantasy squad experience, while also enhancing user safety and compliance for bridge-related actions.


![Uploading Screenshot 2026-07-10 at 12.04.59 pm.png…]()

### References




### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View other managers’ locked squads, rankings, points, and matchday details.
  * Share your squad via preview cards, social posts, native sharing, or clipboard.
  * Added squad-style social preview images with player photo chips and initials fallbacks.
  * Added first-time consent requirements for bridge/convert access.
* **Bug Fixes**
  * XI points are now banked using kickoff-stamped eligibility; benching afterward won’t remove them.
  * Captain/vice live scoring now doubles only after completed appearances.
* **Documentation**
  * Updated rules and Terms to clarify banked XI points behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->