### PR TITLE
feat: Update prize pool details for Noblocks Play

### DIFF
--- a/app/api/play/admin/winners/route.ts
+++ b/app/api/play/admin/winners/route.ts
@@ -5,12 +5,16 @@ import { requireAdmin } from "@/app/lib/fantasy/admin";
 import { jsonError, jsonOk } from "@/app/lib/fantasy/server";
 
 /**
- * Prize table (PRD): 300 USDC total, paid on Base — positions 1–5 get 40 USDC
- * each, positions 6–10 get 20 USDC each, assigned over the QUALIFIED-only
- * ordering (non-qualified/opted-out/disqualified rows are skipped entirely,
- * per §6 "prize ranking skips non-qualified").
+ * Prize table (PRD): 600 USDC total, paid on Base — positions 1–5 get 50 USDC
+ * each, positions 6–10 get 40 USDC each, positions 11–20 get 15 USDC each,
+ * assigned over the QUALIFIED-only ordering (non-qualified/opted-out/
+ * disqualified rows are skipped entirely, per §6 "prize ranking skips
+ * non-qualified").
  */
-const PRIZES_USDC = [40, 40, 40, 40, 40, 20, 20, 20, 20, 20];
+const PRIZES_USDC = [
+  50, 50, 50, 50, 50, 40, 40, 40, 40, 40, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+  15,
+];
 
 const CSV_COLUMNS = [
   "position",

--- a/app/api/play/og/route.tsx
+++ b/app/api/play/og/route.tsx
@@ -396,7 +396,7 @@ async function squadImage(usernameParam: string, anton: Buffer) {
                 color: INK,
               }}
             >
-              300 USDC IN PRIZES
+              600 USDC IN PRIZES
             </div>
             <div
               style={{
@@ -722,8 +722,8 @@ export const GET = withRateLimit(async (request: NextRequest) => {
             }}
           >
             {code
-              ? `300 USDC IN PRIZES · noblocks.xyz?ref=${code}`
-              : "300 USDC IN PRIZES · noblocks.xyz/play"}
+              ? `600 USDC IN PRIZES · noblocks.xyz?ref=${code}`
+              : "600 USDC IN PRIZES · noblocks.xyz/play"}
           </div>
         </div>
       ),
@@ -847,7 +847,7 @@ export const GET = withRateLimit(async (request: NextRequest) => {
                 color: INK,
               }}
             >
-              300 USDC IN PRIZES
+              600 USDC IN PRIZES
             </div>
             <div
               style={{

--- a/app/components/play/JoinModal.tsx
+++ b/app/components/play/JoinModal.tsx
@@ -166,7 +166,7 @@ export const JoinModal = ({
 
         <label className="flex cursor-pointer items-center justify-between gap-3 rounded-xl bg-background-neutral px-4 py-3 dark:bg-white/5">
           <span className="text-sm text-text-body dark:text-white">
-            Enter the 300 USDC giveaway
+            Enter the 600 USDC giveaway
             <span className="block text-xs text-text-secondary dark:text-white/50">
               Turn off to play for bragging rights only
             </span>

--- a/app/components/play/demo/DemoShell.tsx
+++ b/app/components/play/demo/DemoShell.tsx
@@ -266,7 +266,8 @@ export const DemoShell = () => {
             {st.campaignComplete && (
               <p className="mt-2 text-xs text-text-secondary dark:text-white/60">
                 The Final is done — in production this is where the winners
-                export (top-5 ×40 / ranks 6–10 ×20 USDC among qualified) runs.
+                export (top-5 ×50 / ranks 6–10 ×40 / ranks 11–20 ×15 USDC
+                among qualified) runs.
               </p>
             )}
           </PlayCard>

--- a/app/play/admin/page.tsx
+++ b/app/play/admin/page.tsx
@@ -294,8 +294,8 @@ export default function PlayAdminPage() {
             Winners export
           </h2>
           <p className="text-sm text-text-secondary dark:text-white/50">
-            Qualified-only prize order: positions 1–5 get 40 USDC, 6–10 get 20
-            USDC (300 USDC total, paid on Base).
+            Qualified-only prize order: positions 1–5 get 50 USDC, 6–10 get 40
+            USDC, 11–20 get 15 USDC (600 USDC total, paid on Base).
           </p>
         </div>
         <div className="flex flex-wrap gap-3">

--- a/app/play/layout.tsx
+++ b/app/play/layout.tsx
@@ -6,7 +6,7 @@ import { PlayShell } from "@/app/components/play/PlayShell";
 export const metadata: Metadata = {
   title: "Noblocks Play — World Cup Fantasy League",
   description:
-    "Build your World Cup fantasy squad, climb the leaderboard and qualify for a share of 300 USDC on Base.",
+    "Build your World Cup fantasy squad, climb the leaderboard and qualify for a share of 600 USDC on Base.",
 };
 
 export default function PlayLayout({

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -32,8 +32,9 @@ const HERO_PILL_BUTTON =
   "inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-white px-4 py-2 text-sm font-semibold text-black transition-transform active:scale-[0.98]";
 
 const PRIZE_TIERS = [
-  { ranks: "Ranks 1–5", amount: "40 USDC each" },
-  { ranks: "Ranks 6–10", amount: "20 USDC each" },
+  { ranks: "Ranks 1–5", amount: "50 USDC each" },
+  { ranks: "Ranks 6–10", amount: "40 USDC each" },
+  { ranks: "Ranks 11–20", amount: "15 USDC each" },
 ];
 
 // Every star photo used across the campaign (hero collage + this section) —
@@ -317,7 +318,7 @@ export default function PlayLandingPage() {
           <p className="max-w-xl text-sm text-white/80 sm:text-base">
             Build your dream XI for the knockout rounds, score points every
             matchday, and invite friends to qualify for a share of{" "}
-            <span className="font-semibold text-white">300 USDC on Base</span>.
+            <span className="font-semibold text-white">600 USDC on Base</span>.
             Free to play.
           </p>
           <div className="flex flex-wrap items-center gap-3 pt-1">
@@ -383,7 +384,7 @@ export default function PlayLandingPage() {
           >
             Build your dream XI for the knockout rounds, score points every
             matchday, and invite friends to qualify for a share of{" "}
-            <span className="font-semibold text-white">300 USDC on Base</span>.
+            <span className="font-semibold text-white">600 USDC on Base</span>.
             Free to play.
           </p>
 
@@ -483,9 +484,9 @@ export default function PlayLandingPage() {
       {/* Prize breakdown */}
       <section className="space-y-4">
         <h2 className="text-lg font-semibold text-text-body dark:text-white">
-          Prize pool: 300 USDC on Base
+          Prize pool: 600 USDC on Base
         </h2>
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-3">
           {PRIZE_TIERS.map(({ ranks, amount }, index) => (
             <PlayCard key={ranks} className="flex items-center gap-4">
               <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-yellow-secondary dark:bg-yellow-primary/10">
@@ -505,7 +506,7 @@ export default function PlayLandingPage() {
           ))}
         </div>
         <p className="text-xs text-text-secondary dark:text-white/50">
-          Prizes go to the top 10 qualified managers by final rank. Anyone
+          Prizes go to the top 20 qualified managers by final rank. Anyone
           who has not qualified or has opted out is skipped when prizes are
           assigned. Full details in the{" "}
           <Link

--- a/app/play/rewards/page.tsx
+++ b/app/play/rewards/page.tsx
@@ -168,7 +168,7 @@ export default function RewardsPage() {
       <EmptyState
         icon={<ChampionIcon className="size-8 text-lavender-500" />}
         title="Join the league to unlock rewards"
-        description="The 300 USDC giveaway is for league participants — joining takes under a minute."
+        description="The 600 USDC giveaway is for league participants — joining takes under a minute."
         action={
           <Link href="/play" className={primaryButtonClasses}>
             Join the league
@@ -222,7 +222,7 @@ export default function RewardsPage() {
       <PlayCard className="flex items-center justify-between gap-4">
         <div>
           <p className="text-sm font-semibold text-text-body dark:text-white">
-            300 USDC giveaway
+            600 USDC giveaway
           </p>
           <p className="text-xs text-text-secondary dark:text-white/50">
             {data.giveaway_opt_in

--- a/app/play/terms/page.tsx
+++ b/app/play/terms/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Terms & Conditions — Noblocks Play",
   description:
-    "Terms and conditions for the Noblocks Play World Cup 2026 fantasy league and 300 USDC giveaway.",
+    "Terms and conditions for the Noblocks Play World Cup 2026 fantasy league and 600 USDC giveaway.",
 };
 
 const Section = ({
@@ -32,7 +32,7 @@ export default function PlayTermsPage() {
           Noblocks Play — Terms &amp; Conditions
         </h1>
         <p className="text-sm text-text-secondary dark:text-white/50">
-          World Cup 2026 Fantasy League &amp; 300 USDC giveaway. By joining
+          World Cup 2026 Fantasy League &amp; 600 USDC giveaway. By joining
           the league you accept these terms.
         </p>
       </header>
@@ -65,17 +65,21 @@ export default function PlayTermsPage() {
 
       <Section title="3. Prizes">
         <p>
-          The prize pool is <strong>300 USDC, paid on the Base network</strong>{" "}
+          The prize pool is <strong>600 USDC, paid on the Base network</strong>{" "}
           to the wallet associated with your Noblocks account:
         </p>
         <ul className="list-disc space-y-1 pl-5">
           <li>
             Final leaderboard ranks 1–5 among qualified participants:{" "}
-            <strong>40 USDC each</strong>.
+            <strong>50 USDC each</strong>.
           </li>
           <li>
             Final leaderboard ranks 6–10 among qualified participants:{" "}
-            <strong>20 USDC each</strong>.
+            <strong>40 USDC each</strong>.
+          </li>
+          <li>
+            Final leaderboard ranks 11–20 among qualified participants:{" "}
+            <strong>15 USDC each</strong>.
           </li>
         </ul>
         <p>

--- a/docs/fantasy-league.md
+++ b/docs/fantasy-league.md
@@ -2,8 +2,8 @@
 
 Campaign feature (PRD "Noblocks World Cup Fantasy League" v1.2 / TRD v1.0):
 a free fantasy league over the World Cup knockout rounds (MD6 Quarter-finals,
-MD7 Semi-finals, MD8 Final + bronze) with a 300 USDC giveaway on Base for the
-top 10 **qualified** managers (ranks 1–5 ×40, 6–10 ×20). Qualification =
+MD7 Semi-finals, MD8 Final + bronze) with a 600 USDC giveaway on Base for the
+top 20 **qualified** managers (ranks 1–5 ×50, 6–10 ×40, 11–20 ×15). Qualification =
 5 activated referrals before the deadline; a referral activates when the
 referred user's **cumulative** completed on/off-ramp volume reaches $5
 USD-equivalent inside the campaign window (explicitly not a single-$5 rule).


### PR DESCRIPTION


### Description

- Increased total prize pool from 300 USDC to 600 USDC, with updated distribution: positions 1–5 receive 50 USDC each, positions 6–10 receive 40 USDC each, and positions 11–20 receive 15 USDC each.
- Updated relevant text across multiple components and documentation to reflect the new prize amounts and structure.

This pull request updates the World Cup Fantasy League campaign to double the prize pool from 300 USDC to 600 USDC, expands the prize distribution to the top 20 qualified managers, and adjusts all related copy, documentation, and logic to match the new prize structure.

**Prize logic and distribution changes:**

- Updated the prize pool to 600 USDC and changed the distribution: positions 1–5 receive 50 USDC each, 6–10 receive 40 USDC each, and 11–20 receive 15 USDC each in `app/api/play/admin/winners/route.ts` and related admin/logic files.
- Increased the number of prize winners from top 10 to top 20 in all relevant descriptions and logic.

**User-facing copy and UI updates:**

- Updated all references to the prize pool in UI components, modals, landing pages, and reward pages from 300 USDC to 600 USDC, and reflected the new breakdown and number of winners. [[1]](diffhunk://#diff-1572f7565582d3a08de548466872c4de35b60f5589589a8d100697b99a5fc417L399-R399) [[2]](diffhunk://#diff-1572f7565582d3a08de548466872c4de35b60f5589589a8d100697b99a5fc417L725-R726) [[3]](diffhunk://#diff-1572f7565582d3a08de548466872c4de35b60f5589589a8d100697b99a5fc417L850-R850) [[4]](diffhunk://#diff-a5b6d5f59d81e9e9932eb08ef5642b76f2bb97a53e5375d68691a1482c4f5a0fL169-R169) [[5]](diffhunk://#diff-67bfb2bdf40007f6592a60eb8437998757aa4a15e6511b0a69a7b9cb0ceab936L297-R298) [[6]](diffhunk://#diff-c9269c634fbe50f9f8a617659ed9849dd325d9a5e8cd4c51a7bf46d213e13857L9-R9) [[7]](diffhunk://#diff-495893d6c7ebf55a43718312714ea946a1368ef94c8f7db068cb36f4c28b2388L320-R321) [[8]](diffhunk://#diff-495893d6c7ebf55a43718312714ea946a1368ef94c8f7db068cb36f4c28b2388L386-R387) [[9]](diffhunk://#diff-495893d6c7ebf55a43718312714ea946a1368ef94c8f7db068cb36f4c28b2388L486-R489) [[10]](diffhunk://#diff-fbe1ddf58a0d6bfb223a532d8123dee448e9f596bb29cd58ee2fcf54cc683207L171-R171) [[11]](diffhunk://#diff-fbe1ddf58a0d6bfb223a532d8123dee448e9f596bb29cd58ee2fcf54cc683207L225-R225)

**Documentation and terms updates:**

- Updated `docs/fantasy-league.md` and all terms and conditions pages to reflect the new prize pool, prize breakdown, and qualification requirements. [[1]](diffhunk://#diff-0be792eaf048505e14cd75b0763fead7bbfb6a734cfc18153cddbd1c19a985a5L5-R6) [[2]](diffhunk://#diff-7ca04e803782fe734398a07a6512ddc810243bd416bbb5819ae92e276e8c7a2fL7-R7) [[3]](diffhunk://#diff-7ca04e803782fe734398a07a6512ddc810243bd416bbb5819ae92e276e8c7a2fL35-R35) [[4]](diffhunk://#diff-7ca04e803782fe734398a07a6512ddc810243bd416bbb5819ae92e276e8c7a2fL68-R82)

**Prize breakdown UI enhancements:**

- Adjusted the prize breakdown section to display three prize tiers and updated the grid layout accordingly. [[1]](diffhunk://#diff-495893d6c7ebf55a43718312714ea946a1368ef94c8f7db068cb36f4c28b2388L35-R37) [[2]](diffhunk://#diff-495893d6c7ebf55a43718312714ea946a1368ef94c8f7db068cb36f4c28b2388L486-R489)

**Demo and admin page updates:**

- Updated admin and demo pages to accurately describe the new prize structure and export logic for winners. [[1]](diffhunk://#diff-3e468a4caf336b877d1acaae7615e5321e3730a726ac6cb207be43b479c3a828L269-R270) [[2]](diffhunk://#diff-67bfb2bdf40007f6592a60eb8437998757aa4a15e6511b0a69a7b9cb0ceab936L297-R298)


### References




### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the Play giveaway pool to **600 USDC**.
  - Expanded rewards to the **top 20 qualified managers**.
  - Updated prize tiers: ranks 1–5 receive 50 USDC, ranks 6–10 receive 40 USDC, and ranks 11–20 receive 15 USDC.
  - Updated winner exports, landing pages, rewards, terms, metadata, and promotional images to reflect the new distribution.

- **Documentation**
  - Updated fantasy league campaign terms and payout details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->