### PR TITLE
style: Update icon sizes and component styling in BridgeForm

### DIFF
--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -280,7 +280,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
               onClick={() => (setCurrentView ? setCurrentView("wallet") : onClose())}
               className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-all hover:bg-gray-200 active:scale-95 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/20"
             >
-              <ArrowLeft02Icon className="size-4" />
+              <ArrowLeft02Icon className="size-5" strokeWidth={1.5} />
             </button>
           )}
         </div>
@@ -314,8 +314,8 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
               />
 
               {fromNetworkName !== toNetworkName && (
-                <div className="flex items-start gap-2 rounded-xl bg-gray-100 dark:bg-neutral-800/60 border border-gray-200 dark:border-white/5 p-3 text-sm text-text-secondary dark:text-white/50">
-                  <InformationSquareIcon className="size-4 shrink-0 mt-0.5" />
+                <div className="flex items-start gap-2 rounded-[24px] border border-gray-200 bg-gray-100 p-3 text-sm text-text-secondary dark:border-white/5 dark:bg-neutral-800/60 dark:text-white/50">
+                  <InformationSquareIcon className="mt-0.5 size-5 shrink-0" strokeWidth={1.5} />
                   <span>
                     Funds route through {fromNetworkName} to {toNetworkName} and
                     may take a few minutes longer.

--- a/app/components/bridge/BridgePicker.tsx
+++ b/app/components/bridge/BridgePicker.tsx
@@ -237,8 +237,9 @@ export function BridgePicker({
 export function BridgePickerChevron({ isOpen }: { isOpen: boolean }) {
   return (
     <ArrowDown01Icon
+      strokeWidth={1.5}
       className={classNames(
-        "size-3.5 shrink-0 text-gray-400 transition-transform dark:text-white/40",
+        "size-5 shrink-0 text-gray-400 transition-transform dark:text-white/40",
         isOpen ? "rotate-180" : "",
       )}
     />

--- a/app/components/bridge/BridgeRouteSelector.tsx
+++ b/app/components/bridge/BridgeRouteSelector.tsx
@@ -3,8 +3,8 @@
 import React, { useMemo } from "react";
 import { classNames, formatDecimalPrecision, formatTokenAmount } from "@/app/utils";
 import {
-  ArrowRight03Icon,
-  ArrowUpDownIcon,
+  ArrowDataTransferVerticalIcon,
+  ArrowRight01Icon,
   Wallet01Icon,
 } from "hugeicons-react";
 import { useBalance } from "@/app/context/BalanceContext";
@@ -62,6 +62,13 @@ const chipButtonClass =
 
 const tokenPillClass =
   "flex items-center gap-2 rounded-full bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm transition-all hover:bg-gray-50 active:scale-95 dark:bg-neutral-700 dark:text-white dark:hover:bg-neutral-600";
+
+/** From/to amount cards — 24px corners, 1px border, design spacing. */
+const amountCardCls =
+  "rounded-[24px] border border-gray-200 bg-gray-100 dark:border-white/5 dark:bg-surface-canvas";
+
+const amountInputCls =
+  "w-full min-w-0 bg-transparent text-2xl font-normal text-gray-900 outline-none placeholder-gray-300 dark:text-white dark:placeholder-white/20";
 
 export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
   from,
@@ -172,13 +179,10 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
     if (leg) onToChange(leg);
   };
 
-  const cardCls =
-    "space-y-3 rounded-2xl border border-gray-200 bg-gray-100 p-4 dark:border-white/5 dark:bg-surface-canvas";
-
   return (
-    <div className="space-y-2">
-      {/* Network route bar */}
-      <div className="space-y-2 rounded-2xl border border-gray-200 bg-gray-100 p-4 dark:border-white/5 dark:bg-neutral-800/60">
+    <div className="space-y-3">
+      {/* Network route — 24px corners; pt/pl 12, pr 16 */}
+      <div className="space-y-2 rounded-[24px] border border-gray-200 bg-gray-100 pb-3 pl-3 pr-4 pt-3 dark:border-white/5 dark:bg-neutral-800/60">
         <p className="text-xs text-text-secondary dark:text-white/40">
           Select network route
         </p>
@@ -201,7 +205,7 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
                     <img
                       src={getNetworkImgSrc(fromNetworkObj)}
                       alt={fromNetworkName}
-                      className="size-3.5 shrink-0 rounded-full"
+                      className="size-5 shrink-0 rounded-full"
                       onError={(e) => {
                         (e.target as HTMLImageElement).style.display = "none";
                       }}
@@ -215,7 +219,7 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
           </div>
 
           <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-400 dark:bg-neutral-700 dark:text-white/40">
-            <ArrowRight03Icon className="size-4" />
+            <ArrowRight01Icon className="size-5" strokeWidth={1.5} />
           </div>
 
           <div className="min-w-0 flex-1">
@@ -236,7 +240,7 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
                     <img
                       src={getNetworkImgSrc(toNetworkObj)}
                       alt={toNetworkName}
-                      className="size-3.5 shrink-0 rounded-full"
+                      className="size-5 shrink-0 rounded-full"
                       onError={(e) => {
                         (e.target as HTMLImageElement).style.display = "none";
                       }}
@@ -256,9 +260,9 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
         <span className="text-xs text-text-secondary dark:text-white/40">From</span>
       </div>
 
-      {/* FROM card */}
-      <div className={cardCls}>
-        <div className="flex items-center justify-between">
+      {/* FROM card — compact token row + amount (matches design) */}
+      <div className={amountCardCls}>
+        <div className="flex items-center justify-between pb-4 pl-3 pr-2.5 pt-3">
           <BridgePicker
             title="Select 'from' token"
             items={fromTokenItems}
@@ -291,19 +295,24 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
             on {fromNetworkName}
           </span>
         </div>
-        <div className="flex items-end justify-between gap-2">
+        <div
+          aria-hidden
+          className="w-full bg-gray-200 dark:bg-white/10"
+          style={{ height: "0.3px" }}
+        />
+        <div className="flex items-center justify-between gap-2 px-3 pb-5 pt-4">
           <input
             type="text"
             inputMode="decimal"
             value={amount}
             onChange={(e) => onAmountChange(e.target.value)}
             placeholder="0.00"
-            className="w-full min-w-0 bg-transparent text-3xl font-light text-gray-900 outline-none placeholder-gray-300 dark:text-white dark:placeholder-white/20"
+            className={amountInputCls}
           />
           {from && fromBalance > 0 && (
-            <div className="mb-1 flex shrink-0 flex-col items-end gap-1">
+            <div className="flex shrink-0 flex-col items-end gap-1">
               <span className="flex items-center gap-1 text-xs text-text-secondary dark:text-white/40">
-                <Wallet01Icon className="size-3.5" />
+                <Wallet01Icon className="size-5" strokeWidth={1.5} />
                 {formatTokenAmount(fromBalance)} {from.token}
               </span>
               <button
@@ -318,18 +327,22 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
         </div>
       </div>
 
-      {/* Flip control */}
+      {/* Flip — design uses ↓↑ parallel transfer arrows, not ↑↓ sort icon */}
       <div className="relative flex items-center justify-center py-0.5">
-        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-gray-200 dark:bg-white/10" />
+        <div
+          aria-hidden
+          className="absolute inset-x-0 top-1/2 -translate-y-1/2 bg-gray-200 dark:bg-white/10"
+          style={{ height: "0.3px" }}
+        />
         <button
           type="button"
           onClick={handleFlip}
-          className="relative flex size-10 items-center justify-center rounded-full bg-gray-200 text-gray-500 transition-all hover:bg-gray-300 active:scale-95 dark:bg-neutral-700 dark:text-white/60 dark:hover:bg-neutral-600"
+          className="relative flex size-8 items-center justify-center rounded-lg bg-gray-200 text-gray-500 transition-all hover:bg-gray-300 active:scale-95 dark:bg-surface-canvas dark:text-white/60 dark:hover:bg-neutral-600"
         >
           {isQuoteLoading ? (
-            <div className="size-4 animate-spin rounded-full border-2 border-gray-400 border-t-transparent dark:border-white/40 dark:border-t-transparent" />
+            <div className="size-5 animate-spin rounded-full border-2 border-gray-400 border-t-transparent dark:border-white/40 dark:border-t-transparent" />
           ) : (
-            <ArrowUpDownIcon className="size-4" />
+            <ArrowDataTransferVerticalIcon className="size-5" strokeWidth={1.5} />
           )}
         </button>
       </div>
@@ -340,8 +353,8 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
       </div>
 
       {/* TO card */}
-      <div className={cardCls}>
-        <div className="flex items-center justify-between">
+      <div className={amountCardCls}>
+        <div className="flex items-center justify-between pb-4 pl-3 pr-2.5 pt-3">
           <BridgePicker
             title="Select 'to' token"
             items={toTokenItems}
@@ -374,10 +387,16 @@ export const BridgeRouteSelector: React.FC<BridgeRouteSelectorProps> = ({
             on {toNetworkName}
           </span>
         </div>
-        <div className="flex items-end justify-between">
+        <div
+          aria-hidden
+          className="w-full bg-gray-200 dark:bg-white/10"
+          style={{ height: "0.3px" }}
+        />
+        <div className="flex items-center justify-between px-3 pb-5 pt-4">
           <span
             className={classNames(
-              "text-3xl font-light",
+              amountInputCls,
+              "flex items-center",
               outputAmount
                 ? "text-gray-900 dark:text-white"
                 : "text-gray-300 dark:text-white/20",


### PR DESCRIPTION

### Description


- Increased icon sizes and adjusted stroke widths for better visual consistency across components.
- Enhanced styling for information display and card elements in BridgeRouteSelector to align with design specifications.
- Refactored layout and spacing for improved user experience and accessibility.


### References




### Testing

<img width="620" height="1103" alt="Screenshot 2026-07-14 at 10 01 58 am" src="https://github.com/user-attachments/assets/96a03fba-2f40-4e97-a0d2-d1a0b393e8a6" />


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined bridge form and route selector layouts for a cleaner, more consistent appearance.
  * Updated network icons, wallet indicators, spacing, borders, backgrounds, and amount fields.
  * Improved back, dropdown, and route-swap icon sizing and visual weight.
  * Enhanced the cross-network funds routing callout styling.
  * Updated loading and swap controls while preserving their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->