### PR TITLE
fix(currencies): sync availability from aggregator and remove MWK

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -1081,6 +1081,27 @@ export const fetchTokens = async (): Promise<APIToken[]> => {
 };
 
 /**
+ * Fetches fiat currency codes currently enabled by the aggregator.
+ * Currencies omitted from this response are unavailable in the active environment.
+ */
+export const fetchSupportedCurrencyCodes = async (): Promise<string[]> => {
+  const response = await axios.get(`${aggregatorOriginForV2()}/v2/currencies`);
+  const currencies = response.data?.data;
+
+  if (!Array.isArray(currencies)) {
+    throw new Error("Invalid currencies response from aggregator");
+  }
+
+  return currencies
+    .map((currency: unknown) => {
+      if (!currency || typeof currency !== "object") return "";
+      const code = (currency as { code?: unknown }).code;
+      return typeof code === "string" ? code.trim().toUpperCase() : "";
+    })
+    .filter(Boolean);
+};
+
+/**
  * Fetches saved recipients for a wallet address
  * @param {string} accessToken - The access token for authentication
  * @returns {Promise<RecipientDetailsWithId[]>} Array of saved recipients

--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -79,10 +79,6 @@ export const acceptedCurrencies = [
     label: "Tanzanian Shilling (TZS)",
   },
   {
-    name: "MWK",
-    label: "Malawian Kwacha (MWK)",
-  },
-  {
     name: "GHS",
     label: "Ghanaian Cedi (GHS)",
     disabled: true,

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -46,6 +46,7 @@ import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 import { useLoginWithScrollPin } from "../hooks/useLoginWithScrollPin";
+import { fetchSupportedCurrencyCodes } from "../api/aggregator";
 import { useCNGNRate } from "../hooks/useCNGNRate";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
@@ -150,6 +151,8 @@ export const TransactionForm = ({
   const [rateError, setRateError] = useState<string | null>(null);
   const [isLimitModalOpen, setIsLimitModalOpen] = useState(false);
   const [blockedTransactionAmount, setBlockedTransactionAmount] = useState(0);
+  const [supportedCurrencyCodes, setSupportedCurrencyCodes] =
+    useState<Set<string> | null>(null);
 
   const currencies = useMemo(
     () =>
@@ -157,14 +160,15 @@ export const TransactionForm = ({
         const countryCode = currencyToCountryCode(item.name);
         return {
           ...item,
+          disabled:
+            item.disabled ||
+            (supportedCurrencyCodes !== null &&
+              !supportedCurrencyCodes.has(item.name)),
           imageUrl: `https://flagcdn.com/h24/${countryCode}.webp`,
         };
       }),
-    [],
+    [supportedCurrencyCodes],
   );
-
-  // state for reordered currencies
-  const [orderedCurrencies, setOrderedCurrencies] = useState(currencies);
 
   const {
     handleSubmit,
@@ -183,6 +187,42 @@ export const TransactionForm = ({
     swapMode,
     receiveDestinationExplicitlySelected,
   } = watch();
+
+  const selectableCurrencies = useMemo(() => {
+    return currencies
+      .map((item) => ({
+        ...item,
+        disabled:
+          item.disabled ||
+          (swapMode === "onramp" && !isOnrampFiatCurrencyCode(item.name)) ||
+          (token?.toUpperCase() === "CNGN" && item.name !== "NGN"),
+      }))
+      .sort((a, b) => {
+        if (a.disabled === b.disabled) return 0;
+        return a.disabled ? 1 : -1;
+      });
+  }, [currencies, swapMode, token]);
+
+  // state for reordered currencies
+  const [orderedCurrencies, setOrderedCurrencies] =
+    useState<CurrencyOption[]>(selectableCurrencies);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    fetchSupportedCurrencyCodes()
+      .then((codes) => {
+        if (isMounted) setSupportedCurrencyCodes(new Set(codes));
+      })
+      .catch((error) => {
+        // Preserve static defaults if the availability request fails.
+        console.error("Failed to fetch supported currencies:", error);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   const onrampSupported = networkSupportsOnramp(selectedNetwork.chain);
 
@@ -327,7 +367,7 @@ export const TransactionForm = ({
       });
     }
     if (currency) {
-      const supported = currencies.find(
+      const supported = selectableCurrencies.find(
         (c: CurrencyOption) => c.name === currency && !c.disabled,
       );
 
@@ -553,39 +593,44 @@ export const TransactionForm = ({
         });
 
         if (swapMode === "onramp") {
-          currencies.forEach((c: CurrencyOption) => {
-            c.disabled = !isOnrampFiatCurrencyCode(c.name);
-          });
-          if (!isOnrampFiatCurrencyCode(currency)) {
-            formMethods.setValue("currency", "NGN", { shouldDirty: true });
+          const preferred =
+            selectableCurrencies.find(
+              (item) =>
+                !item.disabled && isOnrampFiatCurrencyCode(item.name),
+            )?.name ?? "";
+          if (currency !== preferred) {
+            formMethods.setValue("currency", preferred, { shouldDirty: true });
+          }
+          if (!preferred) {
+            formMethods.setValue("receiveDestinationExplicitlySelected", false, {
+              shouldDirty: true,
+            });
           }
         } else if (normalizedToken === "CNGN") {
-          // When cNGN is selected, only enable NGN
-          currencies.forEach((currency: CurrencyOption) => {
-            currency.disabled = currency.name !== "NGN";
-          });
-          // If the selected currency is not NGN, set it to NGN
-          if (currency !== "NGN") {
+          const ngnEnabled = selectableCurrencies.some(
+            (item) => item.name === "NGN" && !item.disabled,
+          );
+          if (ngnEnabled && currency !== "NGN") {
             formMethods.setValue("currency", "NGN", { shouldDirty: true });
+          } else if (!ngnEnabled && currency) {
+            formMethods.setValue("currency", "", { shouldDirty: true });
           }
-          formMethods.setValue("receiveDestinationExplicitlySelected", true, {
+          formMethods.setValue(
+            "receiveDestinationExplicitlySelected",
+            ngnEnabled,
+            { shouldDirty: true },
+          );
+        } else if (
+          currency &&
+          selectableCurrencies.some(
+            (item) => item.name === currency && item.disabled,
+          )
+        ) {
+          formMethods.setValue("currency", "", { shouldDirty: true });
+          formMethods.setValue("receiveDestinationExplicitlySelected", false, {
             shouldDirty: true,
           });
-        } else {
-          // Reset currencies to their default state from mocks
-          currencies.forEach((currency: CurrencyOption) => {
-            // Only GHS, BRL, and ARS are disabled by default
-            currency.disabled = ["GHS", "BRL", "ARS"].includes(
-              currency.name,
-            );
-          });
         }
-
-        // Sort currencies so enabled ones appear first
-        currencies.sort((a: CurrencyOption, b: CurrencyOption) => {
-          if (a.disabled === b.disabled) return 0;
-          return a.disabled ? 1 : -1;
-        });
       }
 
       registerFormFields();
@@ -594,7 +639,7 @@ export const TransactionForm = ({
       token,
       currency,
       formMethods,
-      currencies,
+      selectableCurrencies,
       selectedNetwork,
       cngnRate,
       cngnRateError,
@@ -608,19 +653,19 @@ export const TransactionForm = ({
   useEffect(() => {
     let isMounted = true;
 
-    reorderCurrenciesByLocation(currencies, formMethods)
+    reorderCurrenciesByLocation(selectableCurrencies, formMethods)
       .then((reordered) => {
         if (isMounted) setOrderedCurrencies(reordered);
       })
       .catch(() => {
-        if (isMounted) setOrderedCurrencies(currencies);
+        if (isMounted) setOrderedCurrencies(selectableCurrencies);
       });
 
     return () => {
       isMounted = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currencies]);
+  }, [selectableCurrencies]);
 
   const { isEnabled, buttonText, buttonAction } = useSwapButton({
     watch,
@@ -783,6 +828,10 @@ export const TransactionForm = ({
       hasToken &&
       hasCurrency &&
       hasBothAmounts;
+    const preferredOnrampCurrency =
+      currencies.find(
+        (item) => !item.disabled && isOnrampFiatCurrencyCode(item.name),
+      )?.name ?? "";
 
     setValue("receiveDestinationExplicitlySelected", isCompleteFlow, {
       shouldDirty: true,
@@ -800,8 +849,8 @@ export const TransactionForm = ({
       setFormattedReceivedAmount(formattedSentAmount);
 
       if (nextSwapMode === "onramp") {
-        if (!isOnrampFiatCurrencyCode(currency)) {
-          setValue("currency", "NGN", { shouldDirty: true });
+        if (!isOnrampFiatCurrencyCode(currency) || !preferredOnrampCurrency) {
+          setValue("currency", preferredOnrampCurrency, { shouldDirty: true });
         }
       }
     } else {
@@ -812,7 +861,7 @@ export const TransactionForm = ({
       setFormattedReceivedAmount("");
 
       if (nextSwapMode === "onramp") {
-        setValue("currency", "NGN", { shouldDirty: true });
+        setValue("currency", preferredOnrampCurrency, { shouldDirty: true });
         setValue("token", "", { shouldDirty: true });
         if (!walletAddress) {
           setValue("walletAddress", "", { shouldDirty: true });

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -593,18 +593,26 @@ export const TransactionForm = ({
         });
 
         if (swapMode === "onramp") {
-          const preferred =
-            selectableCurrencies.find(
-              (item) =>
-                !item.disabled && isOnrampFiatCurrencyCode(item.name),
-            )?.name ?? "";
-          if (currency !== preferred) {
+          const currentOnrampEnabled = selectableCurrencies.some(
+            (item) =>
+              item.name === currency &&
+              !item.disabled &&
+              isOnrampFiatCurrencyCode(item.name),
+          );
+          if (!currentOnrampEnabled) {
+            const preferred =
+              selectableCurrencies.find(
+                (item) =>
+                  !item.disabled && isOnrampFiatCurrencyCode(item.name),
+              )?.name ?? "";
             formMethods.setValue("currency", preferred, { shouldDirty: true });
-          }
-          if (!preferred) {
-            formMethods.setValue("receiveDestinationExplicitlySelected", false, {
-              shouldDirty: true,
-            });
+            if (!preferred) {
+              formMethods.setValue(
+                "receiveDestinationExplicitlySelected",
+                false,
+                { shouldDirty: true },
+              );
+            }
           }
         } else if (normalizedToken === "CNGN") {
           const ngnEnabled = selectableCurrencies.some(
@@ -652,6 +660,8 @@ export const TransactionForm = ({
   // Reorder currencies based on user location
   useEffect(() => {
     let isMounted = true;
+    // Reflect availability immediately; location reorder may resolve later.
+    setOrderedCurrencies(selectableCurrencies);
 
     reorderCurrenciesByLocation(selectableCurrencies, formMethods)
       .then((reordered) => {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -178,7 +178,6 @@ export const getCurrencySymbol = (currency: string): string => {
     USD: "$",
     GBP: "£",
     EUR: "€",
-    MWK: "MK",
     XOF: "CFA",
     XAF: "FCFA",
   };
@@ -204,7 +203,6 @@ export function getOfframpAccountIdentifierPlaceholder(
     NGN: "08XXXXXXXX",
     UGX: "07XXXXXXXX",
     TZS: "07XXXXXXXX",
-    MWK: "0XXXXXXXXX",
     GHS: "0XXXXXXXXX",
   };
   return (
@@ -218,7 +216,6 @@ const NOBLOCKS_FIAT_CURRENCY_CODES = new Set([
   "KES",
   "UGX",
   "TZS",
-  "MWK",
   "GHS",
   "BRL",
   "ARS",
@@ -2041,7 +2038,6 @@ export function mapCountryToCurrency(countryCode: string): string | null {
     AR: "ARS",
     US: "USD",
     GB: "GBP",
-    MW: "MWK",
     // add more as needed
   };
   return mapping[countryCode] || null;


### PR DESCRIPTION
### Description

Currencies that are not returned by the aggregator `GET /v2/currencies` endpoint are now treated as unavailable in Noblocks. The swap form loads the live currency list on mount and disables any static option that is missing from that response, so corridors turned off in production (previously e.g. MWK still selectable) cannot be chosen.

MWK is also removed entirely from Noblocks static currency configuration (accepted currencies, symbol map, fiat code set, and country→currency mapping).

If the currencies request fails, the form falls back to the existing static defaults so the UI still loads.

### References

- Closes #602

### Testing

1. Point the app at an aggregator environment where MWK (or another corridor) is omitted from `/v2/currencies`.
2. Open the Sell/Buy currency dropdown and confirm omitted currencies are disabled (lock icon) or, for MWK, no longer listed.
3. Confirm still-supported currencies (e.g. NGN, KES, UGX, TZS) remain selectable for off-ramp.
4. Optionally block `/v2/currencies` and confirm the form still loads with static defaults.

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed/fixed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fiat currency options are now synced with the aggregator at runtime, automatically disabling unsupported currencies.
  * Onramp flows default to the first available preferred fiat currency when switching directions.
  * Deep-link/default currency selection now validates against the currently selectable currencies.

* **Bug Fixes**
  * Removed Malawian Kwacha (MWK) support across currency utilities and mappings.
  * Improved behavior when the selected fiat currency is unavailable, including clearer handling for cNGN/NGN exclusivity rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->