### PR TITLE
feat: pack offramp createOrder rates at ×100000

### DIFF
--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from "next/navigation";
 import {
   calculateDuration,
   calculateSenderFee,
+  packRate,
   classNames,
   formatCurrency,
   formatNumberWithCommas,
@@ -310,7 +311,7 @@ export const TransactionPreview = ({
     const params = {
       token: tokenAddress,
       amount: parseUnits(amountSent.toString(), tokenDecimals ?? 18),
-      rate: BigInt(Math.round(rate * 100)),
+      rate: packRate(rate),
       senderFeeRecipient: getAddress(senderFeeRecipientAddress),
       senderFee: senderFeeInTokenUnits,
       refundAddress: activeWallet?.address as `0x${string}`,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -2265,6 +2265,28 @@ export const getBlockFestTimeRemaining = (): number => {
 };
 
 /**
+ * On-chain quote-rate multiplier for Gateway createOrder `_rate`.
+ * Matches aggregator RateScale target (×100000) so sub-par local corridors
+ * (e.g. CNGN 0.998) encode distinctly from par 1.0.
+ */
+export const RATE_SCALE = 100000;
+
+/**
+ * Packs a human quote rate for on-chain createOrder (`round(rate × RATE_SCALE)`).
+ */
+export function packRate(rate: number): bigint {
+  return BigInt(Math.round(rate * RATE_SCALE));
+}
+
+/**
+ * Local-corridor quotes sit near 1 (e.g. CNGN/NGN 0.998–1.0); FX quotes are much larger.
+ * Used for sender-fee eligibility — must not depend on legacy ×100 packing.
+ */
+function isLocalTransferRate(rate: number): boolean {
+  return Number.isFinite(rate) && rate > 0 && rate < 10;
+}
+
+/**
  * Calculates the sender fee and returns the fee amount and recipient address
  * @param amount - The transaction amount in human-readable token units
  * @param rate - The exchange rate (e.g., 1.0 for local transfers, other values for FX)
@@ -2279,8 +2301,7 @@ export function calculateSenderFee(
   rate: number,
   tokenDecimals: number = 18,
 ): { feeAmount: number; feeAmountInBaseUnits: bigint; feeRecipient: string } {
-  const calculatedRate = Math.round(rate * 100);
-  const isLocalTransfer = calculatedRate === 100;
+  const isLocalTransfer = isLocalTransferRate(rate);
   const decimalsMultiplier = BigInt(10 ** tokenDecimals);
   const maxFeeCapInBaseUnits =
     BigInt(Math.floor(localTransferFeeCap)) * decimalsMultiplier;


### PR DESCRIPTION
### Description

Noblocks offramp packed gateway `createOrder` rates with `Math.round(rate * 100)`. Sub-par local-corridor quotes such as CNGN/NGN `0.998` therefore encoded as `100` — the same as par `1.0` — so the aggregator could not distinguish the real quote from the on-chain packed value.

This PR packs at ×100000 via `packRate()`, matching the aggregator's dual-scale / `RATE_SCALE=100000` target. It also detects local transfers with `isLocalTransferRate` (`0 < rate < 10`) so sender fees still apply when the quote is `0.998` instead of relying on legacy ×100 packing equaling `100`.

**Impacts**
- Offramp `createOrder` on-chain `_rate` uses ×100000 packing (e.g. `0.998` → `99800`)
- Local-corridor sender fee still applies for rates near 1
- Onramp unchanged (orders go through the sender API; client does not pack rate)

**Breaking changes:** none for APIs. Requires aggregator dual-decode (and preferred write scale) to interpret new packs correctly in production.

**Alternatives considered:** keep ×100 and rely only on aggregator orphan collision handling — rejected; clients should send precise packs once the aggregator supports ×100000.

### References

- closes #604
- Related aggregator dual-scale / fiat payout work: paycrest/aggregator#948, paycrest/aggregator#949

### Testing

- Manual: CNGN → NGN offramp with quote `0.998`; confirm Basescan/Gateway `OrderCreated` rate is `99800` (not `100`)
- Manual: confirm local sender fee still shown/applied for that quote
- Manual: FX offramp (e.g. USDC/NGN) still packs `rate × 100000` and does not apply local fee
- Onramp smoke: confirm path still uses payment-order API (no client `packRate`)

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-chain transaction rate serialization for more accurate order processing.
  * Updated local transfer detection and fee calculations to better handle supported quote rates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->