### PR TITLE
feat: Implement order validation and payment confirmation modal

### DIFF
--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -915,6 +915,50 @@ export async function updateTransactionStatus({
 }
 
 /**
+ * Confirms the user received funds for a stuck order (proxies to aggregator validate).
+ */
+export async function validateOrder({
+  orderId,
+  accessToken,
+  walletAddress,
+}: {
+  orderId: string;
+  accessToken: string;
+  walletAddress: string;
+}): Promise<{
+  success: boolean;
+  data?: { message?: string; validatedAt?: string };
+  error?: string;
+}> {
+  try {
+    const response = await axios.post(
+      `/api/v1/orders/${orderId}/validate`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "x-wallet-address": walletAddress.toLowerCase(),
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message =
+        (error.response?.data as { error?: string })?.error ||
+        error.message ||
+        "Failed to validate order";
+      return { success: false, error: message };
+    }
+    console.error("Validate order error:", error);
+    return {
+      success: false,
+      error: "Failed to validate order. Please try again.",
+    };
+  }
+}
+
+/**
  * Updates the details of a transaction including status, hash, and time spent
  * @param {Object} params - The parameters object
  * @param {string} params.transactionId - The ID of the transaction to update

--- a/app/api/v1/orders/[id]/validate/route.ts
+++ b/app/api/v1/orders/[id]/validate/route.ts
@@ -1,0 +1,240 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import config, { DEFAULT_PRIVY_CONFIG } from "@/app/lib/config";
+import { verifyJWT } from "@/app/lib/jwt";
+import { supabaseAdmin } from "@/app/lib/supabase";
+
+// Route handler for POST - validate order (user confirmed payment received)
+export const POST = withRateLimit(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string }> },
+  ) => {
+    const startTime = Date.now();
+    let orderId: string | null = null;
+
+    try {
+      const authHeader = request.headers.get("Authorization");
+      const token = authHeader?.replace(/^Bearer\s+/i, "");
+
+      if (!token) {
+        trackApiError(
+          request,
+          "/api/v1/orders/validate",
+          "POST",
+          new Error("Missing auth token"),
+          401,
+        );
+        return NextResponse.json(
+          { success: false, error: "Unauthorized" },
+          { status: 401 },
+        );
+      }
+
+      let authenticatedUserId: string;
+      try {
+        const jwtResult = await verifyJWT(token, DEFAULT_PRIVY_CONFIG);
+        authenticatedUserId = jwtResult.payload.sub ?? "";
+
+        if (!authenticatedUserId) {
+          trackApiError(
+            request,
+            "/api/v1/orders/validate",
+            "POST",
+            new Error("Invalid token"),
+            401,
+          );
+          return NextResponse.json(
+            { success: false, error: "Unauthorized" },
+            { status: 401 },
+          );
+        }
+      } catch (jwtError) {
+        trackApiError(
+          request,
+          "/api/v1/orders/validate",
+          "POST",
+          jwtError as Error,
+          401,
+        );
+        return NextResponse.json(
+          { success: false, error: "Invalid or expired token" },
+          { status: 401 },
+        );
+      }
+
+      const walletAddress = request.headers
+        .get("x-wallet-address")
+        ?.toLowerCase();
+
+      if (!walletAddress) {
+        trackApiError(
+          request,
+          "/api/v1/orders/validate",
+          "POST",
+          new Error("Missing wallet address"),
+          401,
+        );
+        return NextResponse.json(
+          { success: false, error: "Unauthorized" },
+          { status: 401 },
+        );
+      }
+
+      const params = await context.params;
+      orderId = params.id;
+      if (!orderId) {
+        trackApiError(
+          request,
+          "/api/v1/orders/validate",
+          "POST",
+          new Error("Order ID is required"),
+          400,
+        );
+        return NextResponse.json(
+          { success: false, error: "Order ID is required" },
+          { status: 400 },
+        );
+      }
+
+      const fullPath = `/api/v1/orders/${orderId}/validate`;
+
+      // Verify the order belongs to the authenticated wallet before using sender API key
+      const { data: ownedTransaction, error: ownershipError } =
+        await supabaseAdmin
+          .from("transactions")
+          .select("id")
+          .eq("order_id", orderId)
+          .eq("wallet_address", walletAddress)
+          .maybeSingle();
+
+      if (ownershipError || !ownedTransaction) {
+        trackApiError(
+          request,
+          fullPath,
+          "POST",
+          new Error("Order not found or unauthorized"),
+          403,
+        );
+        return NextResponse.json(
+          { success: false, error: "Order not found or unauthorized" },
+          { status: 403 },
+        );
+      }
+
+      trackApiRequest(request, fullPath, "POST", {
+        wallet_address: walletAddress,
+        order_id: orderId,
+      });
+
+      const aggregatorUrl = config.aggregatorUrl?.trim();
+      const apiKeyId =
+        config.aggregatorSenderApiKeyId?.trim() ||
+        config.aggregatorSenderApiKey?.trim();
+      if (!aggregatorUrl || !apiKeyId) {
+        trackApiError(
+          request,
+          fullPath,
+          "POST",
+          new Error("Order validate service is not configured"),
+          503,
+        );
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "Order validate service is not configured. Please try again later.",
+          },
+          { status: 503 },
+        );
+      }
+
+      const url = `${aggregatorUrl}/sender/orders/${orderId}/validate`;
+      const FETCH_TIMEOUT_MS = 30_000;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      let res: Response;
+      try {
+        res = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "API-Key": apiKeyId,
+          },
+          body: JSON.stringify({}),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeoutId);
+      }
+
+      const data = await res.json().catch(() => ({}));
+      const rawMessage =
+        typeof data?.message === "string"
+          ? data.message
+          : (data?.Message as string) ?? "";
+
+      if (!res.ok) {
+        const status =
+          res.status >= 400 && res.status < 600 ? res.status : 502;
+        const errorMessage =
+          rawMessage.trim() || "Failed to validate order";
+        trackApiError(
+          request,
+          fullPath,
+          "POST",
+          new Error(errorMessage),
+          status,
+          { response_time_ms: Date.now() - startTime },
+        );
+        return NextResponse.json(
+          { success: false, error: errorMessage },
+          { status },
+        );
+      }
+
+      const responseTime = Date.now() - startTime;
+      trackApiResponse(fullPath, "POST", 200, responseTime, {
+        wallet_address: walletAddress,
+        order_id: orderId,
+      });
+
+      const successMessage =
+        rawMessage.trim() || "Order validated successfully";
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          message: successMessage,
+          validatedAt: new Date().toISOString(),
+        },
+      });
+    } catch (error) {
+      console.error("Validate order error:", error);
+      const responseTime = Date.now() - startTime;
+      const fullPath = orderId
+        ? `/api/v1/orders/${orderId}/validate`
+        : "/api/v1/orders/validate";
+      const isTimeout =
+        error instanceof Error && error.name === "AbortError";
+      const status = isTimeout ? 504 : 500;
+      trackApiError(request, fullPath, "POST", error as Error, status, {
+        response_time_ms: responseTime,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: isTimeout
+            ? "Validation request timed out. Please try again."
+            : "Failed to validate order. Please try again.",
+        },
+        { status },
+      );
+    }
+  },
+);

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -72,6 +72,11 @@ import {
 } from "../lib/pendingReferralCode";
 import { isReferralEnabled } from "../utils";
 import { useWalletAddress } from "../hooks/useWalletAddress";
+import { networks } from "../mocks";
+import {
+  readStuckPaymentSession,
+  clearStuckPaymentSession,
+} from "../lib/stuckPaymentSession";
 
 /**
  * PageLayout component renders the main page structure including modals,
@@ -261,6 +266,7 @@ export function MainPageContent() {
   const failedProviders = useRef<Set<string>>(new Set());
   const autoSelectedNetworkSessionRef = useRef<string | null>(null);
   const noProviderEventGuard = useRef<Set<string>>(new Set());
+  const restoredStuckSessionRef = useRef(false);
 
   const [isUserVerified, setIsUserVerified] = useState(false);
   const [rateError, setRateError] = useState<string | null>(null);
@@ -476,11 +482,73 @@ export function MainPageContent() {
   }, [walletAddress]);
 
   useEffect(function setPageLoadingState() {
-    setOrderId("");
-    setOnrampPaymentAccount(null);
-    setActiveOrderIsOnramp(false);
+    // Keep stuck-order fields intact when a session will be restored on auth ready.
+    if (!readStuckPaymentSession()) {
+      setOrderId("");
+      setOnrampPaymentAccount(null);
+      setActiveOrderIsOnramp(false);
+    }
     setIsPageLoading(false);
   }, []);
+
+  useEffect(
+    function restoreStuckPaymentSessionOnLoad() {
+      if (restoredStuckSessionRef.current) return;
+      if (!ready) return;
+      if (!authenticated && !isInjectedWallet) return;
+
+      const session = readStuckPaymentSession();
+      if (!session) return;
+
+      restoredStuckSessionRef.current = true;
+
+      const restoredForm: FormData = {
+        network: session.network || selectedNetwork.chain.name,
+        token: session.form.token,
+        currency: session.form.currency,
+        institution: session.form.institution,
+        accountIdentifier: session.form.accountIdentifier,
+        recipientName: session.form.recipientName,
+        accountType: session.form.accountType || "bank",
+        walletAddress: session.form.walletAddress || "",
+        memo: session.form.memo || "",
+        amountSent: session.form.amountSent,
+        amountReceived: session.form.amountReceived,
+        swapMode: session.form.swapMode || (session.isOnramp ? "onramp" : "offramp"),
+        isSwapped: session.isOnramp,
+        receiveDestinationExplicitlySelected: true,
+      };
+
+      formMethods.reset({
+        ...formMethods.getValues(),
+        ...restoredForm,
+      });
+      setFormValues(restoredForm);
+      setOrderId(session.orderId);
+      setCreatedAt(session.createdAt);
+      setTransactionStatus(session.transactionStatus);
+      setActiveOrderIsOnramp(session.isOnramp);
+
+      if (session.transactionId) {
+        try {
+          localStorage.setItem("currentTransactionId", session.transactionId);
+        } catch {
+          // ignore
+        }
+      }
+
+      if (session.network) {
+        const match = networks.find((n) => n.chain.name === session.network);
+        if (match) {
+          setSelectedNetwork(match);
+        }
+      }
+
+      setCurrentStep(STEPS.STATUS);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ready, authenticated, isInjectedWallet],
+  );
 
   useEffect(
     function resetOnLogout() {
@@ -490,6 +558,8 @@ export function MainPageContent() {
         setFormValues({} as FormData);
         setOnrampPaymentAccount(null);
         setActiveOrderIsOnramp(false);
+        clearStuckPaymentSession();
+        restoredStuckSessionRef.current = false;
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/components/PaymentConfirmationModal.tsx
+++ b/app/components/PaymentConfirmationModal.tsx
@@ -9,8 +9,12 @@ import { primaryBtnClasses } from "./Styles";
 
 interface PaymentConfirmationModalProps {
   isOpen: boolean;
+  /** Close without action (X / backdrop). */
   onClose: () => void;
+  /** User confirmed funds received. */
   onConfirm: () => void | Promise<void>;
+  /** User has not received funds — triggers reindex / status retry. */
+  onDecline: () => void | Promise<void>;
   tokenAmount: string | number;
   token: string;
   /** Destination wallet where funds are going. */
@@ -27,21 +31,25 @@ export const PaymentConfirmationModal = ({
   isOpen,
   onClose,
   onConfirm,
+  onDecline,
   tokenAmount,
   token,
   recipientAddress,
   explorerLink,
 }: PaymentConfirmationModalProps) => {
   const [confirming, setConfirming] = useState(false);
+  const [declining, setDeclining] = useState(false);
+  const busy = confirming || declining;
 
   useEffect(() => {
     if (!isOpen) {
       setConfirming(false);
+      setDeclining(false);
     }
   }, [isOpen]);
 
   const handleConfirm = useCallback(async () => {
-    if (confirming) return;
+    if (busy) return;
     setConfirming(true);
     try {
       await Promise.resolve(onConfirm());
@@ -50,7 +58,19 @@ export const PaymentConfirmationModal = ({
     } finally {
       setConfirming(false);
     }
-  }, [confirming, onConfirm]);
+  }, [busy, onConfirm]);
+
+  const handleDecline = useCallback(async () => {
+    if (busy) return;
+    setDeclining(true);
+    try {
+      await Promise.resolve(onDecline());
+    } catch {
+      // Parent shows toast; keep modal open so user can retry.
+    } finally {
+      setDeclining(false);
+    }
+  }, [busy, onDecline]);
 
   const tokenLogo = token?.toLowerCase() || "usdc";
 
@@ -60,7 +80,7 @@ export const PaymentConfirmationModal = ({
         <Dialog
           open={isOpen}
           onClose={() => {
-            if (!confirming) onClose();
+            if (!busy) onClose();
           }}
           className="relative z-[70]"
         >
@@ -94,7 +114,7 @@ export const PaymentConfirmationModal = ({
                     <button
                       type="button"
                       onClick={onClose}
-                      disabled={confirming}
+                      disabled={busy}
                       className="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-gray-100 hover:text-text-body disabled:opacity-50 dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
                       aria-label="Close"
                     >
@@ -167,19 +187,19 @@ export const PaymentConfirmationModal = ({
                   <div className="flex gap-3">
                     <button
                       type="button"
-                      onClick={onClose}
-                      disabled={confirming}
+                      onClick={handleDecline}
+                      disabled={busy}
                       className={classNames(
                         primaryBtnClasses,
                         "!min-h-12 !min-w-0 !flex-none !rounded-2xl border-none px-8 text-sm leading-6 shadow-none",
                       )}
                     >
-                      No, I haven&apos;t
+                      {declining ? "Checking…" : "No, I haven't"}
                     </button>
                     <button
                       type="button"
                       onClick={handleConfirm}
-                      disabled={confirming}
+                      disabled={busy}
                       className="flex min-h-12 min-w-0 flex-1 items-center justify-center rounded-2xl border-none bg-gray-100 px-5 text-sm font-medium leading-6 text-neutral-900 shadow-none transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed hover:bg-gray-200 dark:bg-white/10 dark:text-white dark:hover:bg-white/[0.14] dark:focus-visible:ring-offset-neutral-900"
                     >
                       {confirming ? "Confirming…" : "Yes, Payment Received"}

--- a/app/components/PaymentConfirmationModal.tsx
+++ b/app/components/PaymentConfirmationModal.tsx
@@ -2,15 +2,13 @@
 import { useState, useCallback, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Dialog, DialogPanel } from "@headlessui/react";
-import { Cancel01Icon, Loading03Icon } from "hugeicons-react";
+import { Loading03Icon } from "hugeicons-react";
 import Image from "next/image";
 import { classNames } from "../utils";
 import { primaryBtnClasses } from "./Styles";
 
 interface PaymentConfirmationModalProps {
   isOpen: boolean;
-  /** Close without action (X / backdrop). */
-  onClose: () => void;
   /** User confirmed funds received. */
   onConfirm: () => void | Promise<void>;
   /** User has not received funds — triggers reindex / status retry. */
@@ -29,7 +27,6 @@ function truncateAddress(address: string) {
 
 export const PaymentConfirmationModal = ({
   isOpen,
-  onClose,
   onConfirm,
   onDecline,
   tokenAmount,
@@ -54,7 +51,7 @@ export const PaymentConfirmationModal = ({
     try {
       await Promise.resolve(onConfirm());
     } catch {
-      // Parent shows toast; keep modal open so user can retry.
+      // Keep modal open on failure; parent handles state silently.
     } finally {
       setConfirming(false);
     }
@@ -65,8 +62,6 @@ export const PaymentConfirmationModal = ({
     setDeclining(true);
     try {
       await Promise.resolve(onDecline());
-    } catch {
-      // Parent shows toast; keep modal open so user can retry.
     } finally {
       setDeclining(false);
     }
@@ -79,9 +74,7 @@ export const PaymentConfirmationModal = ({
       {isOpen && (
         <Dialog
           open={isOpen}
-          onClose={() => {
-            if (!busy) onClose();
-          }}
+          onClose={() => {}}
           className="relative z-[70]"
         >
           <motion.div
@@ -106,20 +99,11 @@ export const PaymentConfirmationModal = ({
             >
               <DialogPanel className="relative mx-auto w-full sm:max-w-[27.3125rem]">
                 <div className="w-full space-y-5 rounded-t-[30px] border border-border-light bg-white p-6 dark:border-white/10 dark:bg-surface-overlay sm:rounded-3xl">
-                  <div className="flex items-center justify-between">
+                  <div className="flex items-center">
                     <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-100 px-3 py-1 text-xs font-normal text-amber-600 dark:bg-white/10 dark:text-[#E8C84A]">
                       <Loading03Icon className="size-3.5 animate-spin" />
                       Pending
                     </span>
-                    <button
-                      type="button"
-                      onClick={onClose}
-                      disabled={busy}
-                      className="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-gray-100 hover:text-text-body disabled:opacity-50 dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
-                      aria-label="Close"
-                    >
-                      <Cancel01Icon className="size-5" />
-                    </button>
                   </div>
 
                   <h2 className="text-[26px] font-medium leading-7 text-text-body dark:text-white/80">
@@ -194,7 +178,7 @@ export const PaymentConfirmationModal = ({
                         "!min-h-12 !min-w-0 !flex-none !rounded-2xl border-none px-8 text-sm leading-6 shadow-none",
                       )}
                     >
-                      {declining ? "Checking…" : "No, I haven't"}
+                      No, I haven&apos;t
                     </button>
                     <button
                       type="button"

--- a/app/components/PaymentConfirmationModal.tsx
+++ b/app/components/PaymentConfirmationModal.tsx
@@ -1,0 +1,196 @@
+"use client";
+import { useState, useCallback, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { Cancel01Icon, Loading03Icon } from "hugeicons-react";
+import Image from "next/image";
+import { classNames } from "../utils";
+import { primaryBtnClasses } from "./Styles";
+
+interface PaymentConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  tokenAmount: string | number;
+  token: string;
+  /** Destination wallet where funds are going. */
+  recipientAddress?: string;
+  explorerLink?: string;
+}
+
+function truncateAddress(address: string) {
+  if (address.length <= 14) return address;
+  return `${address.slice(0, 6)}...${address.slice(-5)}`;
+}
+
+export const PaymentConfirmationModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  tokenAmount,
+  token,
+  recipientAddress,
+  explorerLink,
+}: PaymentConfirmationModalProps) => {
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirming(false);
+    }
+  }, [isOpen]);
+
+  const handleConfirm = useCallback(async () => {
+    if (confirming) return;
+    setConfirming(true);
+    try {
+      await Promise.resolve(onConfirm());
+    } catch {
+      // Parent shows toast; keep modal open so user can retry.
+    } finally {
+      setConfirming(false);
+    }
+  }, [confirming, onConfirm]);
+
+  const tokenLogo = token?.toLowerCase() || "usdc";
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <Dialog
+          open={isOpen}
+          onClose={() => {
+            if (!confirming) onClose();
+          }}
+          className="relative z-[70]"
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="fixed inset-0 bg-black/30 backdrop-blur-sm"
+          />
+
+          <div className="fixed inset-0 flex w-screen items-end sm:items-center sm:justify-center sm:p-4">
+            <motion.div
+              initial={{ y: "100%", opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: "100%", opacity: 0 }}
+              transition={{
+                type: "spring",
+                stiffness: 300,
+                damping: 30,
+              }}
+              className="w-full"
+            >
+              <DialogPanel className="relative mx-auto w-full sm:max-w-[27.3125rem]">
+                <div className="w-full space-y-5 rounded-t-[30px] border border-border-light bg-white p-6 dark:border-white/10 dark:bg-surface-overlay sm:rounded-3xl">
+                  <div className="flex items-center justify-between">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-100 px-3 py-1 text-xs font-normal text-amber-600 dark:bg-white/10 dark:text-[#E8C84A]">
+                      <Loading03Icon className="size-3.5 animate-spin" />
+                      Pending
+                    </span>
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      disabled={confirming}
+                      className="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-gray-100 hover:text-text-body disabled:opacity-50 dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
+                      aria-label="Close"
+                    >
+                      <Cancel01Icon className="size-5" />
+                    </button>
+                  </div>
+
+                  <h2 className="text-[26px] font-medium leading-7 text-text-body dark:text-white/80">
+                    Have you received
+                    <br />
+                    this payment?
+                  </h2>
+
+                  <div className="flex items-center rounded-full border border-border-light py-1.5 pl-1.5 pr-4 dark:border-white/10">
+                    <div className="flex items-center gap-2 rounded-full bg-gray-200/70 px-3 py-1.5 dark:bg-white/5">
+                      <Image
+                        src={`/logos/${tokenLogo}-logo.svg`}
+                        alt={`${token} logo`}
+                        width={16}
+                        height={16}
+                      />
+                      <span className="whitespace-nowrap text-sm font-medium text-text-body dark:text-white">
+                        {tokenAmount} {token}
+                      </span>
+                    </div>
+
+                    <span
+                      aria-hidden
+                      className="mx-4 flex-1 truncate text-center font-medium text-xs tracking-[0.35em] text-gray-300 dark:text-white/20"
+                    >
+                      -·······
+                    </span>
+
+                    {recipientAddress ? (
+                      <div className="flex items-center gap-3">
+                        <span className="whitespace-nowrap font-mono text-sm text-text-secondary dark:text-white/50">
+                          {truncateAddress(recipientAddress)}
+                        </span>
+                        {explorerLink && (
+                          <a
+                            href={explorerLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="whitespace-nowrap text-sm font-medium text-lavender-500 dark:text-lavender-400"
+                          >
+                            View
+                          </a>
+                        )}
+                      </div>
+                    ) : (
+                      explorerLink && (
+                        <a
+                          href={explorerLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="whitespace-nowrap text-sm font-medium text-lavender-500 dark:text-lavender-400"
+                        >
+                          View
+                        </a>
+                      )
+                    )}
+                  </div>
+
+                  <p className="text-sm font-normal leading-5 text-text-secondary dark:text-white/50">
+                    We noticed this transaction is taking longer than usual to
+                    update. Please let us know if you have received your funds
+                    so we can finalize your status.
+                  </p>
+
+                  <div className="flex gap-3">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      disabled={confirming}
+                      className={classNames(
+                        primaryBtnClasses,
+                        "!min-h-12 !min-w-0 !flex-none !rounded-2xl border-none px-8 text-sm leading-6 shadow-none",
+                      )}
+                    >
+                      No, I haven&apos;t
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleConfirm}
+                      disabled={confirming}
+                      className="flex min-h-12 min-w-0 flex-1 items-center justify-center rounded-2xl border-none bg-gray-100 px-5 text-sm font-medium leading-6 text-neutral-900 shadow-none transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed hover:bg-gray-200 dark:bg-white/10 dark:text-white dark:hover:bg-white/[0.14] dark:focus-visible:ring-offset-neutral-900"
+                    >
+                      {confirming ? "Confirming…" : "Yes, Payment Received"}
+                    </button>
+                  </div>
+                </div>
+              </DialogPanel>
+            </motion.div>
+          </div>
+        </Dialog>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/app/components/PaymentConfirmationModal.tsx
+++ b/app/components/PaymentConfirmationModal.tsx
@@ -51,7 +51,7 @@ export const PaymentConfirmationModal = ({
     try {
       await Promise.resolve(onConfirm());
     } catch {
-      // Keep modal open on failure; parent handles state silently.
+      // Keep modal open on failure; parent surfaces errors via toast.
     } finally {
       setConfirming(false);
     }

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -44,6 +44,7 @@ export { SearchInput } from "./recipient/SearchInput";
 export { RecipientListItem } from "./recipient/RecipientListItem";
 export { SavedBeneficiariesModal } from "./recipient/SavedBeneficiariesModal";
 export { TransactionHelperText } from "./TransactionHelperText";
+export { PaymentConfirmationModal } from "./PaymentConfirmationModal";
 export {
   inputClasses,
   primaryBtnClasses,

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -24,6 +24,7 @@ export const STARKNET_PAYMASTER_MODE = "sponsored";
 
 const config: Config = {
   aggregatorUrl: process.env.NEXT_PUBLIC_AGGREGATOR_URL || "",
+  aggregatorSenderApiKeyId: process.env.AGGREGATOR_SENDER_API_KEY_ID || "",
   privyAppId: process.env.NEXT_PUBLIC_PRIVY_APP_ID || "",
   rpcUrlKey: process.env.NEXT_PUBLIC_RPC_URL_KEY || "",
   mixpanelToken: process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || "",

--- a/app/lib/reindex.ts
+++ b/app/lib/reindex.ts
@@ -1,6 +1,43 @@
 import { reindexTransaction } from "../api/aggregator";
 import { normalizeNetworkForRateFetch } from "../utils";
 import { networks } from "../mocks";
+import type { OrderDetailsData } from "../types";
+
+export type ReindexTarget = {
+  txHash: string;
+  network: string;
+};
+
+/** Resolve tx hash + network for GET /reindex/:network/:tx_hash_or_address. */
+export function resolveReindexTarget(
+  orderDetails: OrderDetailsData | undefined,
+  fallbackNetwork: string,
+  createdHash?: string,
+  sessionTxHash?: string,
+): ReindexTarget | null {
+  const network = orderDetails?.network || fallbackNetwork;
+  if (!network) return null;
+
+  let txHash = createdHash || orderDetails?.txHash || "";
+
+  if (!txHash && orderDetails?.txReceipts?.length) {
+    const pendingReceipt = orderDetails.txReceipts.find(
+      (receipt) => receipt.status === "pending" && receipt.txHash,
+    );
+    txHash =
+      pendingReceipt?.txHash ||
+      orderDetails.txReceipts.find((receipt) => receipt.txHash)?.txHash ||
+      orderDetails.txReceipts[0]?.txHash ||
+      "";
+  }
+
+  if (!txHash && sessionTxHash) {
+    txHash = sessionTxHash;
+  }
+
+  if (!txHash) return null;
+  return { txHash, network };
+}
 
 /**
  * Helper function for exponential backoff delay

--- a/app/lib/session-cleanup.ts
+++ b/app/lib/session-cleanup.ts
@@ -8,6 +8,7 @@ export function clearUserSessionData(userId?: string, walletAddress?: string) {
     "currentTransactionId",
     "lastFundingAttempt",
     "fundingCallbackId",
+    "noblocks_stuck_payment_session",
   ];
 
   if (walletAddress) {
@@ -29,5 +30,21 @@ export function clearUserSessionData(userId?: string, walletAddress?: string) {
     } catch {
       // Ignore storage errors (e.g. private browsing)
     }
+  }
+
+  // Clear per-order stuck timer keys (prefix match).
+  try {
+    const toDelete: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k?.startsWith("stuck_fulfilling_since_")) {
+        toDelete.push(k);
+      }
+    }
+    for (const k of toDelete) {
+      localStorage.removeItem(k);
+    }
+  } catch {
+    // ignore
   }
 }

--- a/app/lib/stuckPaymentSession.ts
+++ b/app/lib/stuckPaymentSession.ts
@@ -1,0 +1,102 @@
+import type { TransactionStatusType } from "../types";
+
+const SESSION_KEY = "noblocks_stuck_payment_session";
+
+export type StuckPaymentFormSnapshot = {
+  amountSent: number;
+  amountReceived: number;
+  token: string;
+  currency: string;
+  institution: string;
+  recipientName: string;
+  accountIdentifier: string;
+  accountType?: "bank" | "mobile_money";
+  walletAddress?: string;
+  memo?: string;
+  swapMode?: "onramp" | "offramp";
+};
+
+export type StuckPaymentSession = {
+  orderId: string;
+  transactionId?: string;
+  createdAt: string;
+  transactionStatus: Extract<
+    TransactionStatusType,
+    "fulfilling" | "fulfilled"
+  >;
+  isOnramp: boolean;
+  network?: string;
+  txHash?: string;
+  form: StuckPaymentFormSnapshot;
+  savedAt: number;
+};
+
+function isStuckStatus(
+  status: string,
+): status is StuckPaymentSession["transactionStatus"] {
+  return status === "fulfilling" || status === "fulfilled";
+}
+
+export function readStuckPaymentSession(): StuckPaymentSession | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StuckPaymentSession;
+    if (
+      !parsed?.orderId ||
+      !parsed?.createdAt ||
+      !isStuckStatus(parsed.transactionStatus) ||
+      !parsed?.form
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStuckPaymentSession(
+  session: Omit<StuckPaymentSession, "savedAt">,
+): void {
+  if (typeof window === "undefined") return;
+  if (!isStuckStatus(session.transactionStatus)) return;
+  try {
+    const payload: StuckPaymentSession = {
+      ...session,
+      savedAt: Date.now(),
+    };
+    localStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore quota / private browsing
+  }
+}
+
+export function clearStuckPaymentSession(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Clears per-order stuck timer keys used by the confirmation delay. */
+export function clearStuckFulfillingSince(orderId?: string | null): void {
+  if (typeof window === "undefined" || !orderId) return;
+  try {
+    localStorage.removeItem(`stuck_fulfilling_since_${orderId}`);
+  } catch {
+    // ignore
+  }
+}
+
+export function resetStuckFulfillingSince(orderId: string): void {
+  if (typeof window === "undefined" || !orderId) return;
+  try {
+    localStorage.setItem(`stuck_fulfilling_since_${orderId}`, String(Date.now()));
+  } catch {
+    // ignore
+  }
+}

--- a/app/lib/stuckPaymentSession.ts
+++ b/app/lib/stuckPaymentSession.ts
@@ -2,6 +2,9 @@ import type { TransactionStatusType } from "../types";
 
 const SESSION_KEY = "noblocks_stuck_payment_session";
 
+/** Abandoned stuck sessions stop restoring into the status step after this age. */
+const MAX_SESSION_AGE_MS = 6 * 60 * 60 * 1000;
+
 export type StuckPaymentFormSnapshot = {
   amountSent: number;
   amountReceived: number;
@@ -47,7 +50,9 @@ export function readStuckPaymentSession(): StuckPaymentSession | null {
       !parsed?.orderId ||
       !parsed?.createdAt ||
       !isStuckStatus(parsed.transactionStatus) ||
-      !parsed?.form
+      !parsed?.form ||
+      !Number.isFinite(parsed.savedAt) ||
+      Date.now() - parsed.savedAt > MAX_SESSION_AGE_MS
     ) {
       return null;
     }

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1067,6 +1067,11 @@ export function TransactionStatus({
       clearStuckFulfillingSince(orderId);
     } catch (error) {
       console.error("Error confirming payment:", error);
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Could not confirm payment. Please try again.";
+      toast.error(message);
       throw error;
     }
   };

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Image from "next/image";
 import { useTheme } from "next-themes";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { AnimatePresence } from "framer-motion";
 import { ImSpinner } from "react-icons/im";
 import { Checkbox } from "@headlessui/react";
@@ -46,6 +46,12 @@ import {
   deleteSavedRecipient,
 } from "../api/aggregator";
 import { reindexSingleTransaction } from "../lib/reindex";
+import {
+  writeStuckPaymentSession,
+  clearStuckPaymentSession,
+  clearStuckFulfillingSince,
+  resetStuckFulfillingSince,
+} from "../lib/stuckPaymentSession";
 import {
   STEPS,
   type OrderDetailsData,
@@ -172,6 +178,7 @@ export function TransactionStatus({
   const [isSavingRecipient, setIsSavingRecipient] = useState(false);
   const [showSaveSuccess, setShowSaveSuccess] = useState(false);
   const [showPaymentConfirmation, setShowPaymentConfirmation] = useState(false);
+  const [paymentConfirmationEpoch, setPaymentConfirmationEpoch] = useState(0);
   const paymentConfirmationTimerRef = useRef<NodeJS.Timeout | null>(null);
   const stuckInFulfillingSinceRef = useRef<number | null>(null);
   const lastStuckOrderIdRef = useRef<string | null>(null);
@@ -860,6 +867,7 @@ export function TransactionStatus({
         setShowPaymentConfirmation(false);
         stuckInFulfillingSinceRef.current = null;
         lastStuckOrderIdRef.current = null;
+        clearStuckPaymentSession();
         const key = getStuckStorageKey();
         if (key && typeof window !== "undefined") {
           try {
@@ -878,6 +886,39 @@ export function TransactionStatus({
       if (orderId !== lastStuckOrderIdRef.current) {
         stuckInFulfillingSinceRef.current = null;
         lastStuckOrderIdRef.current = orderId ?? null;
+      }
+
+      // Persist enough context to restore this stuck order after a full page refresh.
+      if (orderId) {
+        writeStuckPaymentSession({
+          orderId,
+          transactionId:
+            typeof window !== "undefined"
+              ? localStorage.getItem("currentTransactionId") || undefined
+              : undefined,
+          createdAt,
+          transactionStatus: transactionStatus as "fulfilling" | "fulfilled",
+          isOnramp,
+          network: orderDetails?.network || selectedNetwork.chain.name,
+          txHash: createdHash || orderDetails?.txHash || undefined,
+          form: {
+            amountSent: Number(amount) || 0,
+            amountReceived: Number(amountReceivedCrypto) || 0,
+            token: String(token || ""),
+            currency: String(currency || ""),
+            institution: String(institution || ""),
+            recipientName: String(recipientName || ""),
+            accountIdentifier: String(accountIdentifier || ""),
+            accountType:
+              (formMethods.watch("accountType") as
+                | "bank"
+                | "mobile_money"
+                | undefined) || "bank",
+            walletAddress: String(recipientWalletAddress || ""),
+            memo: String(formMethods.watch("memo") || ""),
+            swapMode: isOnramp ? "onramp" : "offramp",
+          },
+        });
       }
 
       const now = Date.now();
@@ -925,7 +966,8 @@ export function TransactionStatus({
         }
       };
     },
-    [transactionStatus, orderId],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [transactionStatus, orderId, createdAt, isOnramp, createdHash, orderDetails, paymentConfirmationEpoch],
   );
 
   const handlePaymentConfirmed = async () => {
@@ -975,13 +1017,8 @@ export function TransactionStatus({
 
       setTransactionStatus("settled");
       setShowPaymentConfirmation(false);
-      if (orderId && typeof window !== "undefined") {
-        try {
-          localStorage.removeItem(`stuck_fulfilling_since_${orderId}`);
-        } catch {
-          // ignore
-        }
-      }
+      clearStuckPaymentSession();
+      clearStuckFulfillingSince(orderId);
     } catch (error) {
       console.error("Error confirming payment:", error);
       const msg = error instanceof Error ? error.message : "";
@@ -997,6 +1034,46 @@ export function TransactionStatus({
       throw error;
     }
   };
+
+  /** "No, I haven't" — reindex via GET /reindex/:network/:tx_hash and keep polling. */
+  const handlePaymentNotReceived = useCallback(async () => {
+    const txHash =
+      createdHash ||
+      orderDetails?.txHash ||
+      orderDetails?.txReceipts?.find((r) => r.txHash)?.txHash ||
+      orderDetails?.txReceipts?.[0]?.txHash ||
+      "";
+    const network = orderDetails?.network || selectedNetwork.chain.name;
+
+    if (!txHash || !network) {
+      toast.error(
+        "Unable to re-check this transaction yet. Please wait a moment and try again.",
+      );
+      throw new Error("Missing tx hash or network for reindex");
+    }
+
+    try {
+      await reindexSingleTransaction(txHash, network);
+      toast.success("We're re-checking your payment status.");
+    } catch (error) {
+      console.error("Error reindexing after payment not received:", error);
+      toast.error("Could not re-check payment status. Please try again.");
+      throw error;
+    } finally {
+      // Dismiss prompt and restart the 120s stuck timer so it can reappear if still stuck.
+      setShowPaymentConfirmation(false);
+      stuckInFulfillingSinceRef.current = Date.now();
+      if (orderId) {
+        resetStuckFulfillingSince(orderId);
+      }
+      setPaymentConfirmationEpoch((n) => n + 1);
+    }
+  }, [
+    createdHash,
+    orderDetails,
+    selectedNetwork.chain.name,
+    orderId,
+  ]);
 
   /**
    * Tracks transaction events for analytics
@@ -1649,6 +1726,7 @@ export function TransactionStatus({
           isOpen={showPaymentConfirmation}
           onClose={() => setShowPaymentConfirmation(false)}
           onConfirm={handlePaymentConfirmed}
+          onDecline={handlePaymentNotReceived}
           tokenAmount={String(amount)}
           token={String(token)}
           recipientAddress={

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -45,12 +45,16 @@ import {
   saveRecipient,
   deleteSavedRecipient,
 } from "../api/aggregator";
-import { reindexSingleTransaction } from "../lib/reindex";
+import {
+  reindexSingleTransaction,
+  resolveReindexTarget,
+} from "../lib/reindex";
 import {
   writeStuckPaymentSession,
   clearStuckPaymentSession,
   clearStuckFulfillingSince,
   resetStuckFulfillingSince,
+  readStuckPaymentSession,
 } from "../lib/stuckPaymentSession";
 import {
   STEPS,
@@ -182,6 +186,7 @@ export function TransactionStatus({
   const paymentConfirmationTimerRef = useRef<NodeJS.Timeout | null>(null);
   const stuckInFulfillingSinceRef = useRef<number | null>(null);
   const lastStuckOrderIdRef = useRef<string | null>(null);
+  const lastAutoStuckReindexKeyRef = useRef<string | null>(null);
   const [hasReindexed, setHasReindexed] = useState(false);
   // Noblocks Play banner — dismissed state persists via localStorage.
   const [isFantasyBannerDismissed, setIsFantasyBannerDismissed] =
@@ -211,6 +216,7 @@ export function TransactionStatus({
     lastPersistedOrderStatusRef.current = null;
     lastFulfillPersistKeyRef.current = null;
     setProcessingStartedAt("");
+    lastAutoStuckReindexKeyRef.current = null;
   }, [orderId]);
 
   useEffect(
@@ -236,6 +242,16 @@ export function TransactionStatus({
   const institution = watch("institution") || "";
   const recipientWalletAddress = String(watch("walletAddress") || "");
   const amountReceivedCrypto = Number(watch("amountReceived")) || 0;
+
+  const getReindexTarget = useCallback(() => {
+    const sessionTxHash = readStuckPaymentSession()?.txHash;
+    return resolveReindexTarget(
+      orderDetails,
+      selectedNetwork.chain.name,
+      createdHash,
+      sessionTxHash,
+    );
+  }, [orderDetails, selectedNetwork.chain.name, createdHash]);
 
   /**
    * Leg 2: once an onramp settles into the user's Noblocks wallet, forward the funds to the user's
@@ -787,6 +803,13 @@ export function TransactionStatus({
           }
 
           if (status === "fulfilled") {
+            const hashFromOrder =
+              responseData.txHash ||
+              responseData.txReceipts?.find((r) => r.txHash)?.txHash ||
+              responseData.txReceipts?.[0]?.txHash;
+            if (hashFromOrder) {
+              setCreatedHash(hashFromOrder);
+            }
             setRocketStatus("fulfilled");
             return;
           }
@@ -890,6 +913,7 @@ export function TransactionStatus({
 
       // Persist enough context to restore this stuck order after a full page refresh.
       if (orderId) {
+        const reindexTarget = getReindexTarget();
         writeStuckPaymentSession({
           orderId,
           transactionId:
@@ -899,8 +923,8 @@ export function TransactionStatus({
           createdAt,
           transactionStatus: transactionStatus as "fulfilling" | "fulfilled",
           isOnramp,
-          network: orderDetails?.network || selectedNetwork.chain.name,
-          txHash: createdHash || orderDetails?.txHash || undefined,
+          network: reindexTarget?.network || orderDetails?.network || selectedNetwork.chain.name,
+          txHash: reindexTarget?.txHash,
           form: {
             amountSent: Number(amount) || 0,
             amountReceived: Number(amountReceivedCrypto) || 0,
@@ -967,19 +991,46 @@ export function TransactionStatus({
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [transactionStatus, orderId, createdAt, isOnramp, createdHash, orderDetails, paymentConfirmationEpoch],
+    [transactionStatus, orderId, createdAt, isOnramp, createdHash, orderDetails, paymentConfirmationEpoch, getReindexTarget],
+  );
+
+  /**
+   * Off-ramp: when the stuck-payment prompt opens (120s+ in fulfilling/fulfilled),
+   * automatically reindex once per prompt cycle so the aggregator re-checks chain/PSP state.
+   */
+  useEffect(
+    function autoReindexStuckOfframpOrder() {
+      if (!showPaymentConfirmation || isOnramp) return;
+
+      const target = getReindexTarget();
+      if (!target) return;
+
+      const attemptKey = `${paymentConfirmationEpoch}:${target.txHash}:${target.network}`;
+      if (lastAutoStuckReindexKeyRef.current === attemptKey) return;
+      lastAutoStuckReindexKeyRef.current = attemptKey;
+
+      void reindexSingleTransaction(target.txHash, target.network).catch(
+        (error) => {
+          console.error("Auto reindex for stuck off-ramp order failed:", error);
+        },
+      );
+    },
+    [
+      showPaymentConfirmation,
+      isOnramp,
+      paymentConfirmationEpoch,
+      getReindexTarget,
+    ],
   );
 
   const handlePaymentConfirmed = async () => {
     const accessToken = await getAccessToken();
     if (!accessToken || !orderId) {
-      toast.error("Unable to confirm payment. Please try again.");
       throw new Error("Missing access token or order ID");
     }
 
     const walletAddress = embeddedWallet?.address || "";
     if (!walletAddress) {
-      toast.error("Wallet not connected. Please reconnect and try again.");
       throw new Error("Missing wallet address");
     }
 
@@ -991,10 +1042,6 @@ export function TransactionStatus({
       });
 
       if (!validateResult.success) {
-        toast.error(
-          validateResult.error ||
-            "Could not validate order. Please try again or contact support.",
-        );
         throw new Error(validateResult.error || "Validation failed");
       }
 
@@ -1011,7 +1058,6 @@ export function TransactionStatus({
       });
 
       if (!updateResult?.success) {
-        toast.error("Could not update transaction status. Please try again.");
         throw new Error("Transaction update failed");
       }
 
@@ -1021,59 +1067,29 @@ export function TransactionStatus({
       clearStuckFulfillingSince(orderId);
     } catch (error) {
       console.error("Error confirming payment:", error);
-      const msg = error instanceof Error ? error.message : "";
-      const alreadyToasted =
-        msg === "Missing access token or order ID" ||
-        msg === "Missing wallet address" ||
-        msg === "Transaction not found" ||
-        msg === "Validation failed" ||
-        msg === "Transaction update failed";
-      if (!alreadyToasted) {
-        toast.error("Failed to confirm payment. Please try again.");
-      }
       throw error;
     }
   };
 
-  /** "No, I haven't" — reindex via GET /reindex/:network/:tx_hash and keep polling. */
+  /** "No, I haven't" — dismiss, restart 120s timer, reindex in background. */
   const handlePaymentNotReceived = useCallback(async () => {
-    const txHash =
-      createdHash ||
-      orderDetails?.txHash ||
-      orderDetails?.txReceipts?.find((r) => r.txHash)?.txHash ||
-      orderDetails?.txReceipts?.[0]?.txHash ||
-      "";
-    const network = orderDetails?.network || selectedNetwork.chain.name;
-
-    if (!txHash || !network) {
-      toast.error(
-        "Unable to re-check this transaction yet. Please wait a moment and try again.",
-      );
-      throw new Error("Missing tx hash or network for reindex");
+    setShowPaymentConfirmation(false);
+    stuckInFulfillingSinceRef.current = Date.now();
+    if (orderId) {
+      resetStuckFulfillingSince(orderId);
     }
+    setPaymentConfirmationEpoch((n) => n + 1);
+
+    const target = getReindexTarget();
+    if (!target) return;
 
     try {
-      await reindexSingleTransaction(txHash, network);
+      await reindexSingleTransaction(target.txHash, target.network);
       toast.success("We're re-checking your payment status.");
     } catch (error) {
       console.error("Error reindexing after payment not received:", error);
-      toast.error("Could not re-check payment status. Please try again.");
-      throw error;
-    } finally {
-      // Dismiss prompt and restart the 120s stuck timer so it can reappear if still stuck.
-      setShowPaymentConfirmation(false);
-      stuckInFulfillingSinceRef.current = Date.now();
-      if (orderId) {
-        resetStuckFulfillingSince(orderId);
-      }
-      setPaymentConfirmationEpoch((n) => n + 1);
     }
-  }, [
-    createdHash,
-    orderDetails,
-    selectedNetwork.chain.name,
-    orderId,
-  ]);
+  }, [getReindexTarget, orderId]);
 
   /**
    * Tracks transaction events for analytics
@@ -1160,35 +1176,26 @@ export function TransactionStatus({
       if (
         transactionStatus !== "pending" ||
         hasReindexed ||
-        !orderDetails ||
-        !orderDetails.network
+        !orderDetails
       ) {
         return;
       }
 
-      // Get txHash from orderDetails.txHash or from txReceipts
-      let txHash = orderDetails.txHash;
-      if (
-        !txHash &&
-        orderDetails.txReceipts &&
-        orderDetails.txReceipts.length > 0
-      ) {
-        // Try to find a pending receipt first, otherwise use the first one
-        const pendingReceipt = orderDetails.txReceipts.find(
-          (receipt) => receipt.status === "pending",
-        );
-        txHash = pendingReceipt?.txHash || orderDetails.txReceipts[0]?.txHash;
-      }
-
-      // If we still don't have a txHash, we can't reindex
-      if (!txHash) {
+      const target = resolveReindexTarget(
+        orderDetails,
+        selectedNetwork.chain.name,
+        createdHash,
+      );
+      if (!target) {
         return;
       }
+
+      const { txHash, network } = target;
 
       // Reindex transaction to sync with blockchain state
       const callReindex = async (): Promise<void> => {
         try {
-          await reindexSingleTransaction(txHash, orderDetails.network);
+          await reindexSingleTransaction(txHash, network);
           setHasReindexed(true);
         } catch (error) {
           console.error("Error reindexing transaction:", error);
@@ -1222,7 +1229,7 @@ export function TransactionStatus({
         }
       };
     },
-    [transactionStatus, hasReindexed, orderDetails, createdAt],
+    [transactionStatus, hasReindexed, orderDetails, createdAt, createdHash, selectedNetwork.chain.name],
   );
 
   /**
@@ -1724,7 +1731,6 @@ export function TransactionStatus({
 
         <PaymentConfirmationModal
           isOpen={showPaymentConfirmation}
-          onClose={() => setShowPaymentConfirmation(false)}
           onConfirm={handlePaymentConfirmed}
           onDecline={handlePaymentNotReceived}
           tokenAmount={String(amount)}

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -40,6 +40,7 @@ import {
   resolveOnrampOrderStatusFromV2Response,
   updateTransactionDetails,
   unwrapV2SenderOrderEnvelope,
+  validateOrder,
   fetchSavedRecipients,
   saveRecipient,
   deleteSavedRecipient,
@@ -75,6 +76,7 @@ import {
 import { readForwardBalanceWei } from "../lib/onrampForwarding/readForwardBalanceWei";
 import type { Token } from "../types";
 import { usePrivy } from "@privy-io/react-auth";
+import { PaymentConfirmationModal } from "../components/PaymentConfirmationModal";
 import { TransactionHelperText } from "../components/TransactionHelperText";
 import { useConfetti } from "../hooks/useConfetti";
 import { BlockFestCashbackComponent } from "../components/blockfest";
@@ -169,6 +171,10 @@ export function TransactionStatus({
   const [hasShownConfetti, setHasShownConfetti] = useState(false);
   const [isSavingRecipient, setIsSavingRecipient] = useState(false);
   const [showSaveSuccess, setShowSaveSuccess] = useState(false);
+  const [showPaymentConfirmation, setShowPaymentConfirmation] = useState(false);
+  const paymentConfirmationTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const stuckInFulfillingSinceRef = useRef<number | null>(null);
+  const lastStuckOrderIdRef = useRef<string | null>(null);
   const [hasReindexed, setHasReindexed] = useState(false);
   // Noblocks Play banner — dismissed state persists via localStorage.
   const [isFantasyBannerDismissed, setIsFantasyBannerDismissed] =
@@ -840,6 +846,158 @@ export function TransactionStatus({
     [orderId, transactionStatus],
   );
 
+  useEffect(
+    function showPaymentConfirmationAfterDelay() {
+      const STUCK_STORAGE_KEY_PREFIX = "stuck_fulfilling_since_";
+      const getStuckStorageKey = () =>
+        orderId ? `${STUCK_STORAGE_KEY_PREFIX}${orderId}` : null;
+
+      const isStuckState = ["fulfilling", "fulfilled"].includes(
+        transactionStatus,
+      );
+
+      if (!isStuckState) {
+        setShowPaymentConfirmation(false);
+        stuckInFulfillingSinceRef.current = null;
+        lastStuckOrderIdRef.current = null;
+        const key = getStuckStorageKey();
+        if (key && typeof window !== "undefined") {
+          try {
+            localStorage.removeItem(key);
+          } catch {
+            // ignore
+          }
+        }
+        if (paymentConfirmationTimerRef.current) {
+          clearTimeout(paymentConfirmationTimerRef.current);
+          paymentConfirmationTimerRef.current = null;
+        }
+        return;
+      }
+
+      if (orderId !== lastStuckOrderIdRef.current) {
+        stuckInFulfillingSinceRef.current = null;
+        lastStuckOrderIdRef.current = orderId ?? null;
+      }
+
+      const now = Date.now();
+      if (stuckInFulfillingSinceRef.current === null) {
+        const key = getStuckStorageKey();
+        if (key && typeof window !== "undefined") {
+          try {
+            const stored = localStorage.getItem(key);
+            const parsed = stored ? parseInt(stored, 10) : NaN;
+            if (Number.isFinite(parsed) && parsed <= now) {
+              stuckInFulfillingSinceRef.current = parsed;
+            }
+          } catch {
+            // ignore
+          }
+        }
+        if (stuckInFulfillingSinceRef.current === null) {
+          stuckInFulfillingSinceRef.current = now;
+          const keyToWrite = getStuckStorageKey();
+          if (keyToWrite && typeof window !== "undefined") {
+            try {
+              localStorage.setItem(keyToWrite, String(now));
+            } catch {
+              // ignore
+            }
+          }
+        }
+      }
+      const stuckSince = stuckInFulfillingSinceRef.current;
+      const elapsed = now - stuckSince;
+      const delayMs = 120_000;
+
+      if (elapsed >= delayMs) {
+        setShowPaymentConfirmation(true);
+      } else {
+        paymentConfirmationTimerRef.current = setTimeout(() => {
+          setShowPaymentConfirmation(true);
+        }, delayMs - elapsed);
+      }
+
+      return () => {
+        if (paymentConfirmationTimerRef.current) {
+          clearTimeout(paymentConfirmationTimerRef.current);
+          paymentConfirmationTimerRef.current = null;
+        }
+      };
+    },
+    [transactionStatus, orderId],
+  );
+
+  const handlePaymentConfirmed = async () => {
+    const accessToken = await getAccessToken();
+    if (!accessToken || !orderId) {
+      toast.error("Unable to confirm payment. Please try again.");
+      throw new Error("Missing access token or order ID");
+    }
+
+    const walletAddress = embeddedWallet?.address || "";
+    if (!walletAddress) {
+      toast.error("Wallet not connected. Please reconnect and try again.");
+      throw new Error("Missing wallet address");
+    }
+
+    try {
+      const validateResult = await validateOrder({
+        orderId,
+        accessToken,
+        walletAddress,
+      });
+
+      if (!validateResult.success) {
+        toast.error(
+          validateResult.error ||
+            "Could not validate order. Please try again or contact support.",
+        );
+        throw new Error(validateResult.error || "Validation failed");
+      }
+
+      const transactionId = localStorage.getItem("currentTransactionId");
+      if (!transactionId) throw new Error("Transaction not found");
+
+      const updateResult = await updateTransactionDetails({
+        transactionId,
+        status: "settled",
+        txHash: createdHash || orderDetails?.txHash,
+        timeSpent: calculateDuration(createdAt, new Date().toISOString()),
+        accessToken,
+        walletAddress,
+      });
+
+      if (!updateResult?.success) {
+        toast.error("Could not update transaction status. Please try again.");
+        throw new Error("Transaction update failed");
+      }
+
+      setTransactionStatus("settled");
+      setShowPaymentConfirmation(false);
+      if (orderId && typeof window !== "undefined") {
+        try {
+          localStorage.removeItem(`stuck_fulfilling_since_${orderId}`);
+        } catch {
+          // ignore
+        }
+      }
+    } catch (error) {
+      console.error("Error confirming payment:", error);
+      const msg = error instanceof Error ? error.message : "";
+      const alreadyToasted =
+        msg === "Missing access token or order ID" ||
+        msg === "Missing wallet address" ||
+        msg === "Transaction not found" ||
+        msg === "Validation failed" ||
+        msg === "Transaction update failed";
+      if (!alreadyToasted) {
+        toast.error("Failed to confirm payment. Please try again.");
+      }
+      throw error;
+    }
+  };
+
   /**
    * Tracks transaction events for analytics
    * Only tracks once per transaction when status is final
@@ -1485,6 +1643,25 @@ export function TransactionStatus({
                   fails."
           showAfterMs={60000}
           className="w-full space-y-4"
+        />
+
+        <PaymentConfirmationModal
+          isOpen={showPaymentConfirmation}
+          onClose={() => setShowPaymentConfirmation(false)}
+          onConfirm={handlePaymentConfirmed}
+          tokenAmount={String(amount)}
+          token={String(token)}
+          recipientAddress={
+            recipientWalletAddress || String(accountIdentifier || "")
+          }
+          explorerLink={
+            (createdHash || orderDetails?.txHash) && orderDetails?.network
+              ? getExplorerLink(
+                  orderDetails.network,
+                  (createdHash || orderDetails?.txHash) ?? "",
+                )
+              : undefined
+          }
         />
 
         <AnimatePresence>

--- a/app/types.ts
+++ b/app/types.ts
@@ -414,6 +414,8 @@ export type KYCStatusResponse = {
 
 export type Config = {
   aggregatorUrl: string;
+  /** Server-only sender API key UUID for order validate proxy. */
+  aggregatorSenderApiKeyId: string;
   privyAppId: string;
   rpcUrlKey: string;
   mixpanelToken: string;


### PR DESCRIPTION
### Description

This PR adds a **stuck-transaction prompt** so users can manually confirm receipt when a swap stays in **Fulfilling** or **Fulfilled** for more than 2 minutes. It reduces support load and lets users settle the transaction without waiting for the provider to update.

**Background:** Swaps can remain in "fulfilling" or "fulfilled" for longer than expected. The user may have already received funds. This flow asks "Have you received this payment?" and, on confirmation, validates the order on the aggregator and marks the Noblocks transaction as settled.

**Changes:**

- **Stuck detection:** Modal appears only when the transaction has been in **fulfilling** or **fulfilled** for **120 seconds** (time in that state, not since transaction creation).
- **Persistence:** "Stuck since" is stored in `localStorage` keyed by `orderId`, so the 120s count survives refresh and navigating away. On open/refresh, if already stuck ≥120s, the prompt can show immediately.
- **Confirm (Yes):** User taps **Yes, Payment Received** → Noblocks calls `POST /api/v1/orders/:id/validate` (proxy to aggregator sender API) → aggregator validates order → Noblocks updates transaction to settled/completed and dismisses the prompt. Stuck timestamp is cleared from `localStorage`. **No, I haven't** dismisses without validating.
- **UI:** Redesigned `PaymentConfirmationModal` to match Figma (Pending badge, amount + destination address + View, Yes/No actions).
- **Config:** Uses `config.aggregatorUrl` and `config.aggregatorSenderApiKeyId` from `@/app/lib/config` for the validate route (falls back to `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` when the server-only key is unset).
- **Scope:** Prompt only for **fulfilling** and **fulfilled** (not refunding), per product spec.

**New/updated surface:**

- **Noblocks:** `POST /api/v1/orders/[id]/validate` (rate-limited, requires `x-wallet-address`), `validateOrder()` in `aggregator.ts`, `TransactionStatus` 120s + localStorage logic and `handlePaymentConfirmed`, redesigned `PaymentConfirmationModal`.
- **Config:** `aggregatorSenderApiKeyId` added to `Config` and `config.ts`; env `AGGREGATOR_SENDER_API_KEY_ID` (UUID) preferred for validate.
- **No breaking changes.** Existing flows unchanged when the prompt is not shown or not used.

### References

- Closes #354
- Design: [Figma – Stuck transaction / Payment confirmation](https://www.figma.com/design/acOLQvbDj0TCm2ZKfl4y7e/Noblocks-Web-App?node-id=1047-85180&t=FjifFQu6YbRsaQht-0)
- Aggregator: `POST /v1/sender/orders/:id/validate` (sender API), `ValidateOrder` in `aggregator/controllers/sender/sender.go`

<img width="776" height="656" alt="Screenshot 2026-07-20 180001" src="https://github.com/user-attachments/assets/0aac6aad-2301-4fde-a8ad-edb6de4efec5" />


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a payment confirmation modal for on-ramp/off-ramp transactions that remain pending beyond a delay.
  * Added “stuck payment” session persistence so the confirmation flow can resume after refresh and re-authentication.

* **Improvements**
  * Improved backend order validation by adding a dedicated, rate-limited validation endpoint with clearer success/failure handling.
  * Enhanced transaction polling and reindex targeting to better determine the correct transaction hash/network for retries.

* **Chores**
  * Improved session cleanup to remove stuck-payment related local storage data on logout/reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->