### PR TITLE
feat: embeddable widget mode (/widget) for whitelisted partner sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,13 @@ LIFI_API_KEY=
 # Default slippage tolerance for bridge quotes in basis points (e.g. 50 = 0.5%)
 NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 
+# Embeddable widget (/widget route, iframed by whitelisted partners)
+NEXT_PUBLIC_EMBED_ENABLED=false
+# Comma-separated origins allowed to iframe /widget (CSP frame-ancestors).
+# Wildcard subdomains ok, e.g. https://partner.com,https://*.partner.app
+# Merged with the embed_allowed_origins table (via /api/internal/embed-origins).
+EMBED_ALLOWED_ORIGINS=
+
 # =============================================================================
 # External Services
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -110,9 +110,15 @@ NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 # Embeddable widget (/widget route, iframed by whitelisted partners)
 NEXT_PUBLIC_EMBED_ENABLED=false
 # Comma-separated origins allowed to iframe /widget (CSP frame-ancestors).
+# Must be https:// (http:// allowed only for localhost/127.0.0.1 in dev).
 # Wildcard subdomains ok, e.g. https://partner.com,https://*.partner.app
 # Merged with the embed_allowed_origins table (via /api/internal/embed-origins).
 EMBED_ALLOWED_ORIGINS=
+# Trusted absolute base URL the edge middleware uses to fetch the DB-backed
+# allowlist (e.g. https://noblocks.xyz). Required to consult the
+# embed_allowed_origins table; if unset, only EMBED_ALLOWED_ORIGINS is used.
+# Never derived from the request Host header (avoids SSRF / key leakage).
+INTERNAL_API_BASE_URL=
 
 # =============================================================================
 # External Services

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Visit the live site at [noblocks.xyz](https://noblocks.xyz).
 
 To learn how Paycrest routes and settles orders, see the [Paycrest documentation](https://paycrest.io/).
 
+## Embedding the Widget
+
+Partners can embed Noblocks as a compact swap widget via iframe (restricted to whitelisted origins):
+
+```html
+<iframe
+  src="https://noblocks.xyz/widget?theme=dark&currency=NGN"
+  allow="clipboard-write; publickey-credentials-get; camera"
+  style="width: 100%; max-width: 460px; height: 680px; border: 0; background: transparent"
+></iframe>
+```
+
+To get an origin whitelisted, email **info@noblocks.xyz**. For URL parameters, the `postMessage` event contract, host-wallet bridging (`embed.js`), and operator configuration, see [docs/embed-widget.md](docs/embed-widget.md).
+
 ## Contributing
 
 We welcome contributions to Noblocks! Before contributing:

--- a/app/api/internal/embed-origins/route.ts
+++ b/app/api/internal/embed-origins/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/app/lib/supabase";
+
+// Allowlist of origins permitted to iframe /widget (see middleware.ts).
+// GET returns origins only — partner contact details stay internal to the
+// table and the admin-facing POST/DELETE below.
+
+const ORIGIN_RE = /^https?:\/\/(\*\.)?[\w.-]+(:\d+)?$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isAuthorized(request: NextRequest): boolean {
+  const internalAuth = request.headers.get("x-internal-auth");
+  const expectedAuth = process.env.INTERNAL_API_KEY;
+  return Boolean(internalAuth && expectedAuth && internalAuth === expectedAuth);
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("embed_allowed_origins")
+    .select("origin");
+
+  if (error) {
+    console.error("Failed to fetch embed origins:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch embed origins" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    origins: (data ?? []).map((row) => row.origin),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: {
+    origin?: string;
+    partner_name?: string;
+    contact_email?: string;
+    note?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const origin = (body.origin ?? "").trim().replace(/\/+$/, "");
+  const contactEmail = (body.contact_email ?? "").trim();
+
+  if (!ORIGIN_RE.test(origin)) {
+    return NextResponse.json(
+      {
+        error:
+          "Invalid origin — expected scheme://host[:port], e.g. https://partner.com or https://*.partner.app",
+      },
+      { status: 400 },
+    );
+  }
+  if (!EMAIL_RE.test(contactEmail)) {
+    return NextResponse.json(
+      { error: "contact_email is required and must be a valid email" },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("embed_allowed_origins")
+    .upsert(
+      {
+        origin,
+        partner_name: body.partner_name?.trim() || null,
+        contact_email: contactEmail,
+        note: body.note?.trim() || null,
+      },
+      { onConflict: "origin" },
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Failed to upsert embed origin:", error);
+    return NextResponse.json(
+      { error: "Failed to save embed origin" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, data });
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const origin = request.nextUrl.searchParams.get("origin")?.trim();
+  if (!origin) {
+    return NextResponse.json(
+      { error: "origin query param is required" },
+      { status: 400 },
+    );
+  }
+
+  const { error, count } = await supabaseAdmin
+    .from("embed_allowed_origins")
+    .delete({ count: "exact" })
+    .eq("origin", origin);
+
+  if (error) {
+    console.error("Failed to delete embed origin:", error);
+    return NextResponse.json(
+      { error: "Failed to delete embed origin" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, deleted: count ?? 0 });
+}

--- a/app/api/internal/embed-origins/route.ts
+++ b/app/api/internal/embed-origins/route.ts
@@ -5,7 +5,10 @@ import { supabaseAdmin } from "@/app/lib/supabase";
 // GET returns origins only — partner contact details stay internal to the
 // table and the admin-facing POST/DELETE below.
 
-const ORIGIN_RE = /^https?:\/\/(\*\.)?[\w.-]+(:\d+)?$/;
+// HTTPS required for partner origins; http:// only for localhost/127.0.0.1
+// during development (keep in sync with EMBED_ORIGIN_RE in middleware.ts).
+const ORIGIN_RE =
+  /^https:\/\/(\*\.)?[\w.-]+(:\d+)?$|^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function isAuthorized(request: NextRequest): boolean {
@@ -102,10 +105,18 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const origin = request.nextUrl.searchParams.get("origin")?.trim();
-  if (!origin) {
+  // Normalize identically to POST so a trailing slash still matches the row
+  // that was stored, instead of silently deleting nothing.
+  const origin = request.nextUrl.searchParams
+    .get("origin")
+    ?.trim()
+    .replace(/\/+$/, "");
+  if (!origin || !ORIGIN_RE.test(origin)) {
     return NextResponse.json(
-      { error: "origin query param is required" },
+      {
+        error:
+          "Valid origin query param is required, e.g. https://partner.com or https://*.partner.app",
+      },
       { status: 400 },
     );
   }

--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -29,6 +29,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     pathname === "/play" ||
     pathname.startsWith("/play/") ||
     pathname === "/play-demo";
+  // Embedded widget (/widget, iframed by whitelisted partners): compact
+  // chrome-less shell like Play — WidgetShell renders its own card chrome.
+  const isWidgetExperience =
+    pathname === "/widget" || pathname.startsWith("/widget/");
+  const isBareExperience = isPlayExperience || isWidgetExperience;
   const isHomepage = pathname === "/";
   const playPromoBannerVisible = usePlayPromoBannerVisible();
   const showPlayPromoBanner =
@@ -42,12 +47,25 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     return () => document.body.classList.remove("play-experience");
   }, [isPlayExperience]);
 
+  useEffect(() => {
+    document.body.classList.toggle("widget-experience", isWidgetExperience);
+    return () => document.body.classList.remove("widget-experience");
+  }, [isWidgetExperience]);
+
   return (
     <SentryClientProvider>
       <Providers>
         <MoralisStreamRegistration />
-        {isPlayExperience ? (
-          <div className="min-h-dvh min-w-full bg-white transition-colors dark:bg-neutral-900">
+        {isBareExperience ? (
+          <div
+            className={`min-h-dvh min-w-full transition-colors ${
+              isWidgetExperience
+                ? // Transparent backdrop: the embedding page shows through the
+                  // iframe around the floating WidgetShell card (per Figma).
+                  "bg-transparent"
+                : "bg-white dark:bg-neutral-900"
+            }`}
+          >
             {children}
           </div>
         ) : (

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -16,6 +16,7 @@ import {
   CookieConsent,
   Disclaimer,
   ReferralInputModal,
+  WidgetShell,
 } from "./";
 import BlockFestCashbackModal from "./blockfest/BlockFestCashbackModal";
 import { useBlockFestClaim } from "../context/BlockFestClaimContext";
@@ -63,6 +64,7 @@ import {
   useInjectedWallet,
   useBalance,
   useKYC,
+  useEmbed,
 } from "../context";
 import { getPreferredNetworkForBalances } from "../lib/getPreferredNetworkForBalances";
 import { hasSeenNetworkModalFlag } from "../lib/networkModalStore";
@@ -116,6 +118,7 @@ const PageLayout = ({
   const { claimed, resetClaim } = useBlockFestClaim();
   const { isOpen, openModal, closeModal } = useBlockFestModal();
   const { isInjectedWallet } = useInjectedWallet();
+  const { isEmbed } = useEmbed();
   const walletAddress = useWalletAddress();
 
   useEffect(() => {
@@ -134,8 +137,14 @@ const PageLayout = ({
         onShowModal={openModal}
       />
 
-      <Disclaimer />
-      <CookieConsent />
+      {/* Embed mode: partner iframe — no marketing chrome, no cookie banner
+          (client trackers are disabled in embed; see providers.tsx). */}
+      {!isEmbed && (
+        <>
+          <Disclaimer />
+          <CookieConsent />
+        </>
+      )}
 
       {/* Network Selection Modal with callback */}
       {!isInjectedWallet && (
@@ -152,7 +161,9 @@ const PageLayout = ({
 
       <BlockFestCashbackModal isOpen={isOpen} onClose={closeModal} />
 
-      {currentStep === STEPS.FORM ? (
+      {isEmbed ? (
+        <WidgetShell>{transactionFormComponent}</WidgetShell>
+      ) : currentStep === STEPS.FORM ? (
         <HomePage
           transactionFormComponent={transactionFormComponent}
           isRecipientFormOpen={isRecipientFormOpen}
@@ -256,6 +267,14 @@ export function MainPageContent() {
     useState<V2FiatProviderAccountDTO | null>(null);
   /** Snapshotted at order create — status fetch/save must not follow live swapMode. */
   const [activeOrderIsOnramp, setActiveOrderIsOnramp] = useState(false);
+
+  const { isEmbed, postToHost } = useEmbed();
+
+  // Surface transaction progress to the embedding page (no-op outside /widget).
+  useEffect(() => {
+    if (!isEmbed || transactionStatus === "idle") return;
+    postToHost("noblocks:tx_status", { status: transactionStatus, orderId });
+  }, [isEmbed, transactionStatus, orderId, postToHost]);
 
   const providerErrorShown = useRef(false);
   const failedProviders = useRef<Set<string>>(new Set());

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -312,7 +312,12 @@ export const MobileDropdown = ({
             />
 
             <div className="fixed inset-0 flex items-end justify-center">
-              <motion.div {...slideUpAnimation} className="w-full">
+              {/* wallet-drawer-panel: stable hook for the widget-mode width
+                  override in globals.css (body.widget-experience). */}
+              <motion.div
+                {...slideUpAnimation}
+                className="wallet-drawer-panel w-full"
+              >
                   <DialogPanel className="scrollbar-hide relative max-h-[90dvh] w-full overflow-hidden rounded-t-[30px] border border-border-light bg-white px-5 pt-6 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-xl *:text-sm dark:border-white/5 dark:bg-surface-overlay">
                     <div
                       className={

--- a/app/components/Preloader.tsx
+++ b/app/components/Preloader.tsx
@@ -1,9 +1,46 @@
+"use client";
 import { AnimatePresence, motion } from "framer-motion";
+import { usePathname } from "next/navigation";
+import { isEmbedPath } from "../context/EmbedContext";
 
 const Skeleton = ({ className }: { className?: string }) => (
   <div
     className={`animate-pulse rounded-xl bg-gray-200 dark:bg-[#1a1a1a] ${className}`}
   />
+);
+
+/**
+ * Embed (/widget) loading state: skeleton shaped like the WidgetShell card
+ * (same geometry — 393px card in a 449px unit) instead of the full-page
+ * navbar/hero skeleton, so the transparent gutter and close-button margin
+ * are respected while loading.
+ */
+const WidgetPreloader = () => (
+  <div className="pointer-events-none fixed inset-x-0 top-3 z-50 mx-auto w-full max-w-[28.0625rem]">
+    <div className="flex h-[calc(100dvh-1.5rem)] w-full max-w-[24.5625rem] flex-col rounded-3xl bg-white p-4 dark:bg-neutral-900">
+      <div className="mb-3 flex min-h-10 items-center justify-end">
+        <Skeleton className="h-10 w-16" />
+      </div>
+      <div className="space-y-2 rounded-2xl bg-gray-50 p-2 dark:bg-neutral-800/20">
+        <div className="px-2 py-1">
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <div className="space-y-3.5 rounded-2xl bg-white px-4 py-3 dark:bg-neutral-900">
+          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+        <div className="space-y-3.5 rounded-2xl bg-white px-4 py-3 dark:bg-neutral-900">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      </div>
+      <Skeleton className="mt-4 h-11 w-full rounded-xl" />
+      <div className="mt-auto flex items-center justify-center gap-2 border-t border-gray-100 pb-2 pt-5 dark:border-white/5">
+        <Skeleton className="size-6 rounded-full" />
+        <Skeleton className="h-4 w-36" />
+      </div>
+    </div>
+  </div>
 );
 
 const NavbarSkeleton = () => (
@@ -40,6 +77,24 @@ const ScrollIndicatorSkeleton = () => (
 );
 
 export const Preloader = ({ isLoading }: { isLoading: boolean }) => {
+  const isWidget = isEmbedPath(usePathname());
+
+  if (isWidget) {
+    return (
+      <AnimatePresence>
+        {isLoading && (
+          <motion.div
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <WidgetPreloader />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    );
+  }
+
   return (
     <AnimatePresence>
       {isLoading && (

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -374,7 +374,7 @@ export const WalletDetails = () => {
           {showBalanceSkeleton ? (
             <BalanceSkeleton />
           ) : selectedNetwork.chain.name === "Starknet" ? (
-            <p>${(activeBalance?.total ?? 0).toFixed(2)}</p>
+            <p>{formatCurrency(activeBalance?.total ?? 0, "USD", "en-US")}</p>
           ) : (
             <p>{formatCurrency(crossChainTotal, "USD", "en-US")}</p>
           )}
@@ -508,7 +508,7 @@ export const WalletDetails = () => {
                             ) : showEarnUi ? (
                               formatCurrency(crossChainTotal, "USD", "en-US")
                             ) : selectedNetwork.chain.name === "Starknet" ? (
-                              `$${(activeBalance?.total ?? 0).toFixed(2)}`
+                              formatCurrency(activeBalance?.total ?? 0, "USD", "en-US")
                             ) : (
                               formatCurrency(crossChainTotal, "USD", "en-US")
                             )}
@@ -860,7 +860,7 @@ export const WalletDetails = () => {
                                                           : "text-text-body dark:text-white/80"
                                                         }`}
                                                     >
-                                                      ${usdEquivalent.toFixed(2)}
+                                                      {formatCurrency(usdEquivalent, "USD", "en-US")}
                                                     </span>
                                                   )}
                                                 </div>

--- a/app/components/WidgetShell.tsx
+++ b/app/components/WidgetShell.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  Cancel01Icon,
+  SquareLock02Icon,
+  Wallet01Icon,
+} from "hugeicons-react";
+import { usePrivy } from "@privy-io/react-auth";
+
+import { MobileDropdown } from "./MobileDropdown";
+import { NoblocksLogo } from "./ImageAssets";
+import { useEmbed } from "../context/EmbedContext";
+import { useInjectedWallet } from "../context";
+
+/**
+ * Compact card chrome for the embedded /widget experience, per the Figma
+ * widget design: a floating rounded card (soft drop shadow) on a transparent
+ * backdrop so the host page shows through, a minimized wallet pill (wallet
+ * icon + chevron) opening the mobile wallet drawer, the swap step, a
+ * "Secured by Noblocks" footer row, and a close X floating OUTSIDE the
+ * card's top-right corner with a gutter between them.
+ * Replaces Navbar/Footer/HomePage, which are hidden in embed mode.
+ *
+ * Geometry (matches Figma frame 2429:118606): card 393px, 12px gap, 44px X
+ * → 449px unit. The `.widget-close-*` and floating-element rules in
+ * globals.css share these numbers. The card width is below Tailwind's `sm`
+ * breakpoint, so the app renders its mobile UI inside the widget by design.
+ */
+export function WidgetShell({ children }: { children: React.ReactNode }) {
+  const { ready, authenticated } = usePrivy();
+  const { isInjectedWallet } = useInjectedWallet();
+  const { parentOrigin, postToHost } = useEmbed();
+  const [isWalletDrawerOpen, setIsWalletDrawerOpen] = useState(false);
+
+  const isConnected = (ready && authenticated) || isInjectedWallet;
+
+  return (
+    <div className="relative mx-auto min-h-dvh w-full max-w-[28.0625rem] py-3">
+      {/* Close: floats outside the card per the design (falls back into the
+          card header on narrow frames, matching the mobile Figma variant).
+          The host removes the iframe on noblocks:close; only useful when we
+          can actually reach a host. */}
+      {parentOrigin && (
+        <button
+          type="button"
+          title="Close widget"
+          aria-label="Close widget"
+          onClick={() => postToHost("noblocks:close")}
+          className="widget-close-outside absolute right-0 top-3 size-11 items-center justify-center rounded-full bg-neutral-800 text-white transition-colors hover:bg-neutral-700"
+        >
+          <Cancel01Icon className="size-5" />
+        </button>
+      )}
+
+      {/* Card grows with content up to the viewport; beyond that everything
+          above the "Secured by" footer scrolls internally (the wallet header
+          scrolls with the content — only the footer stays pinned). */}
+      <div className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-[24.5625rem] flex-col rounded-3xl bg-white p-4 shadow-[0_25px_80px_-12px_rgba(0,0,0,0.75)] ring-1 ring-black/5 dark:bg-neutral-900 dark:ring-white/5">
+        <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
+        <div className="mb-3 flex min-h-10 items-center justify-end gap-2">
+          {isConnected && (
+            <>
+              <button
+                type="button"
+                title="Wallet"
+                aria-label="Open wallet"
+                onClick={() => setIsWalletDrawerOpen(true)}
+                className="flex items-center gap-1 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-white/10"
+              >
+                <Wallet01Icon className="size-5 text-outline-gray dark:text-white/80" />
+                <ArrowDown01Icon className="size-4 text-outline-gray dark:text-white/50" />
+              </button>
+              <AnimatePresence>
+                <MobileDropdown
+                  isOpen={isWalletDrawerOpen}
+                  onClose={() => setIsWalletDrawerOpen(false)}
+                />
+              </AnimatePresence>
+            </>
+          )}
+          {parentOrigin && (
+            <button
+              type="button"
+              title="Close widget"
+              aria-label="Close widget"
+              onClick={() => postToHost("noblocks:close")}
+              className="widget-close-inside size-9 items-center justify-center rounded-xl bg-gray-50 transition-colors hover:bg-gray-100 dark:bg-white/10 dark:hover:bg-white/20"
+            >
+              <Cancel01Icon className="size-4 text-outline-gray dark:text-white/50" />
+            </button>
+          )}
+        </div>
+
+          {children}
+        </div>
+
+        <a
+          href="https://noblocks.xyz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 flex flex-shrink-0 items-center justify-center gap-2 border-t border-gray-100 pb-2 pt-5 text-sm text-gray-500 transition-opacity hover:opacity-80 dark:border-white/5 dark:text-white/50"
+        >
+          <span className="flex size-6 items-center justify-center rounded-full bg-pink-500">
+            <SquareLock02Icon className="size-3.5 text-white" />
+          </span>
+          <span>Secured by</span>
+          <NoblocksLogo className="h-3.5 w-auto" />
+          <ArrowRight01Icon className="size-4" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -25,6 +25,7 @@ export {
 } from "./AnimatedComponents";
 
 export { KycModal } from "./KycModal";
+export { WidgetShell } from "./WidgetShell";
 export { CookieConsent } from "./CookieConsent";
 export { NetworkSelectionModal } from "./NetworkSelectionModal";
 export { Disclaimer } from "./Disclaimer";

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -19,6 +19,7 @@ import {
 import { CrossChainBalanceSkeleton } from "../BalanceSkeleton";
 import {
   classNames,
+  formatCurrency,
   getNetworkImageUrl,
   shortenAddress,
   tokenBalanceRowVisible,
@@ -350,7 +351,7 @@ export const WalletView: React.FC<WalletViewProps> = ({
               {showBalanceSkeleton ? (
                 <span className="inline-block h-9 w-28 animate-pulse rounded bg-accent-gray dark:bg-white/10" />
               ) : (
-                `$${walletBalanceUsd.toFixed(2)}`
+                formatCurrency(walletBalanceUsd, "USD", "en-US")
               )}
             </p>
 

--- a/app/context/EmbedContext.tsx
+++ b/app/context/EmbedContext.tsx
@@ -1,0 +1,96 @@
+"use client";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Embed (widget) mode context.
+ *
+ * Active on the /widget route, which partners iframe from whitelisted origins
+ * (see middleware.ts). Exposes a postMessage channel to the host page:
+ *   noblocks:ready   - widget mounted
+ *   noblocks:resize  - { height } content height changed
+ *   noblocks:close   - user clicked the widget close button
+ *   noblocks:tx_status - { status, orderId } transaction progress
+ *
+ * The host origin is derived from document.referrer (the embedding page on an
+ * iframe's first load). If the host strips its referrer entirely, events are
+ * not sent — we never postMessage to "*" because payloads can include order
+ * details. The wallet bridge (embed-bridge-provider.ts) shares parentOrigin.
+ */
+
+export const isEmbedPath = (pathname: string | null): boolean =>
+  pathname === "/widget" || (pathname ?? "").startsWith("/widget/");
+
+interface EmbedContextType {
+  /** True when rendering the /widget embed route. */
+  isEmbed: boolean;
+  /** Origin of the embedding page, or null when unknown / not framed. */
+  parentOrigin: string | null;
+  /** Send an event to the host page. No-op outside an iframe. */
+  postToHost: (event: string, payload?: unknown) => void;
+}
+
+const EmbedContext = createContext<EmbedContextType>({
+  isEmbed: false,
+  parentOrigin: null,
+  postToHost: () => { },
+});
+
+export function EmbedProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isEmbed = isEmbedPath(pathname);
+  const [parentOrigin, setParentOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isEmbed || window.self === window.top) return;
+    try {
+      const origin = new URL(document.referrer).origin;
+      if (origin && origin !== "null") setParentOrigin(origin);
+    } catch {
+      // Host sends no referrer - stay silent rather than posting to "*".
+    }
+  }, [isEmbed]);
+
+  const postToHost = useCallback(
+    (event: string, payload?: unknown) => {
+      if (!parentOrigin || window.self === window.top) return;
+      window.parent.postMessage(
+        { source: "noblocks", event, payload },
+        parentOrigin,
+      );
+    },
+    [parentOrigin],
+  );
+
+  useEffect(() => {
+    if (!isEmbed || !parentOrigin) return;
+    postToHost("noblocks:ready");
+
+    const observer = new ResizeObserver(() => {
+      postToHost("noblocks:resize", {
+        height: document.documentElement.scrollHeight,
+      });
+    });
+    observer.observe(document.body);
+    return () => observer.disconnect();
+  }, [isEmbed, parentOrigin, postToHost]);
+
+  const value = useMemo(
+    () => ({ isEmbed, parentOrigin, postToHost }),
+    [isEmbed, parentOrigin, postToHost],
+  );
+
+  return (
+    <EmbedContext.Provider value={value}>{children}</EmbedContext.Provider>
+  );
+}
+
+export const useEmbed = () => useContext(EmbedContext);

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -11,6 +11,8 @@ import { createWalletClient, custom } from "viem";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 import { shouldUseInjectedWallet } from "../utils";
+import { createBridgeProvider } from "../lib/embed-bridge-provider";
+import { useEmbed } from "./EmbedContext";
 
 interface InjectedWalletContextType {
   isInjectedWallet: boolean;
@@ -28,6 +30,7 @@ const InjectedWalletContext = createContext<InjectedWalletContextType>({
 
 function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
+  const { parentOrigin } = useEmbed();
   const [isInjectedWallet, setIsInjectedWallet] = useState(false);
   const [injectedAddress, setInjectedAddress] = useState<string | null>(null);
   const [injectedProvider, setInjectedProvider] = useState<any | null>(null);
@@ -36,21 +39,33 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   useEffect(() => {
     const initInjectedWallet = async () => {
       // Check if we should use the injected wallet
-      const shouldUse = shouldUseInjectedWallet(searchParams);
+      const useBridge = searchParams.get("injected") === "bridge";
+      // Bridge mode needs the host origin (from the iframe referrer) before
+      // it can talk to the host wallet; until then fall back to the regular
+      // logged-out UI rather than blocking on the preloader.
+      const shouldUse = useBridge
+        ? Boolean(parentOrigin)
+        : shouldUseInjectedWallet(searchParams);
 
       setIsInjectedWallet(shouldUse);
 
-      if (shouldUse && window.ethereum) {
+      const provider = useBridge
+        ? parentOrigin
+          ? createBridgeProvider(parentOrigin)
+          : null
+        : window.ethereum;
+
+      if (shouldUse && provider) {
         try {
           const client = createWalletClient({
-            transport: custom(window.ethereum as any),
+            transport: custom(provider as any),
           });
 
-          await (window.ethereum as any).request({ method: "eth_requestAccounts" });
+          await (provider as any).request({ method: "eth_requestAccounts" });
           const [address] = await client.getAddresses();
 
           if (address) {
-            setInjectedProvider(window.ethereum);
+            setInjectedProvider(provider);
             setInjectedAddress(address);
             setInjectedReady(true);
           } else {
@@ -83,7 +98,29 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
     };
 
     initInjectedWallet();
-  }, [searchParams]);
+  }, [searchParams, parentOrigin]);
+
+  // Track host-side account switches (extension wallets and the embed bridge
+  // both emit standard EIP-1193 events).
+  useEffect(() => {
+    if (!injectedProvider?.on) return;
+    const handleAccountsChanged = (accounts: unknown) => {
+      const [address] = (accounts as string[]) ?? [];
+      if (address) {
+        setInjectedAddress(address);
+      } else {
+        setInjectedAddress(null);
+        setInjectedReady(false);
+      }
+    };
+    injectedProvider.on("accountsChanged", handleAccountsChanged);
+    return () => {
+      injectedProvider.removeListener?.(
+        "accountsChanged",
+        handleAccountsChanged,
+      );
+    };
+  }, [injectedProvider]);
 
   return (
     <InjectedWalletContext.Provider

--- a/app/context/index.ts
+++ b/app/context/index.ts
@@ -31,3 +31,4 @@ export {
   HomeTransactionFormModeProvider,
   useHomeTransactionFormMode,
 } from "./HomeTransactionFormModeContext";
+export { EmbedProvider, useEmbed, isEmbedPath } from "./EmbedContext";

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,3 +182,66 @@ select {
     transform: translateY(-4rem) !important;
   }
 }
+
+/* Embedded widget (/widget): the whole viewport is a compact partner iframe.
+   The WidgetShell card is 393px (24.5625rem) anchored left with a right
+   gutter for the outside close button (449px unit — keep in sync with
+   WidgetShell.tsx). Floating elements must stay within the CARD, not the
+   iframe, so the transparent gutter shows only the host page. */
+
+/* Keep the Brevo launcher inside the card, fully above the footer's divider
+   line (footer block ≈ 5rem + card padding). right = viewport minus card
+   width plus inset; max() guards narrow frames. z-index below the app's
+   modals/drawers (Dialog z-60) so the wallet drawer and settings sheet
+   render over the launcher instead of being blocked by it. */
+body.widget-experience #brevo-conversations {
+  /* Brevo pins `bottom` inline, so lift with a transform (same trick as the
+     play-experience rule above). */
+  transform: translateY(-5.25rem) !important;
+  right: max(1rem, calc(100% - 24.5625rem + 1rem)) !important;
+  z-index: 50 !important;
+}
+
+/* Wallet drawer (MobileDropdown bottom sheet): cap to the card width and
+   anchor under the card instead of spanning the whole iframe. */
+body.widget-experience .fixed.inset-0.items-end > * {
+  max-width: min(100%, 24.5625rem);
+  margin-left: 0;
+  margin-right: auto;
+  padding-bottom: 0.75rem;
+}
+
+/* Transparent iframe backdrop: the WidgetShell card floats over the host
+   page (browsers keep cross-origin iframes transparent when the embedded
+   document's background is transparent). */
+body.widget-experience {
+  background: transparent !important;
+}
+
+/* Chrome paints an OPAQUE canvas behind a cross-origin iframe whose root
+   color-scheme is dark when the embedder's isn't — which defeats the
+   transparent backdrop above. Force a neutral color-scheme on the widget
+   document (next-themes sets an inline `color-scheme: dark`, so this needs
+   !important). Visual theming is class-based Tailwind and unaffected. */
+html:has(body.widget-experience) {
+  color-scheme: light !important;
+}
+
+/* WidgetShell close button: floats outside the card's top-right corner when
+   the frame is wide enough for the gutter (Figma desktop variant: 393px card
+   + 12px gap + 44px button = 449px), moves into the card header on narrower
+   frames (Figma mobile variant). */
+.widget-close-outside {
+  display: none;
+}
+.widget-close-inside {
+  display: flex;
+}
+@media (min-width: 28.0625rem) {
+  .widget-close-outside {
+    display: flex;
+  }
+  .widget-close-inside {
+    display: none;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -203,8 +203,9 @@ body.widget-experience #brevo-conversations {
 }
 
 /* Wallet drawer (MobileDropdown bottom sheet): cap to the card width and
-   anchor under the card instead of spanning the whole iframe. */
-body.widget-experience .fixed.inset-0.items-end > * {
+   anchor under the card instead of spanning the whole iframe. Targets a
+   stable hook class on the panel rather than Tailwind-generated utilities. */
+body.widget-experience .wallet-drawer-panel {
   max-width: min(100%, 24.5625rem);
   margin-left: 0;
   margin-right: auto;

--- a/app/hooks/analytics/useMixpanel.ts
+++ b/app/hooks/analytics/useMixpanel.ts
@@ -29,8 +29,11 @@ export const initMixpanel = () => {
   }
 };
 
-export const useMixpanel = () => {
+export const useMixpanel = (enabled: boolean = true) => {
   useEffect(() => {
+    // Disabled inside partner iframes (/widget) — no client trackers there.
+    if (!enabled) return;
+
     const handleConsentChange = () => {
       const consent = Cookies.get("cookieConsent");
       if (consent && JSON.parse(consent).analytics) {
@@ -46,7 +49,7 @@ export const useMixpanel = () => {
       window.removeEventListener("cookieConsentChange", handleConsentChange);
       window.removeEventListener("cookieConsent", handleConsentChange);
     };
-  }, []);
+  }, [enabled]);
 };
 
 export const identifyUser = (

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -74,6 +74,7 @@ const config: Config = {
   onrampChainedForwardingEnabled:
     process.env.NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED === "true",
   fantasyEnabled: process.env.NEXT_PUBLIC_FANTASY_ENABLED === "true",
+  embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
 };
 
 export default config;

--- a/app/lib/embed-bridge-provider.ts
+++ b/app/lib/embed-bridge-provider.ts
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * Host-wallet EIP-1193 bridge (iframe side) for the embedded /widget.
+ *
+ * With ?injected=bridge, the widget's "injected wallet" is not window.ethereum
+ * but the host page's connected provider (WalletConnect, AppKit, wagmi, ...),
+ * reached over postMessage. The host binds its provider with
+ * NoblocksEmbed.bindWallet() from public/embed.js:
+ *
+ *   widget -> host  { source: "noblocks", event: "noblocks:wallet_request",
+ *                     payload: { id, method, params } }
+ *   host -> widget  { source: "noblocks-host", event: "noblocks:wallet_response",
+ *                     payload: { id, result?, error?: { code, message } } }
+ *   host -> widget  { source: "noblocks-host", event: "noblocks:wallet_event",
+ *                     payload: { event: "accountsChanged" | "chainChanged"
+ *                              | "disconnect", data } }
+ *
+ * Signing UX stays in the host's own wallet — the widget never sees keys.
+ */
+
+type Eip1193RequestArgs = { method: string; params?: unknown };
+type EventHandler = (...args: unknown[]) => void;
+
+export interface BridgeProvider {
+  isNoblocksBridge: true;
+  request: (args: Eip1193RequestArgs) => Promise<unknown>;
+  on: (event: string, handler: EventHandler) => void;
+  removeListener: (event: string, handler: EventHandler) => void;
+  /** Tear down the window message listener (tests / mode switches). */
+  destroy: () => void;
+}
+
+// Methods that surface the host's wallet UI and wait on the user.
+const INTERACTIVE_METHODS = new Set([
+  "eth_requestAccounts",
+  "eth_sendTransaction",
+  "eth_signTransaction",
+  "personal_sign",
+  "eth_sign",
+  "eth_signTypedData",
+  "eth_signTypedData_v4",
+  "wallet_switchEthereumChain",
+  "wallet_addEthereumChain",
+  "wallet_watchAsset",
+]);
+const INTERACTIVE_TIMEOUT_MS = 5 * 60_000;
+const READ_TIMEOUT_MS = 30_000;
+
+class BridgeRpcError extends Error {
+  code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+let singleton: { origin: string; provider: BridgeProvider } | null = null;
+
+export function createBridgeProvider(parentOrigin: string): BridgeProvider {
+  if (singleton?.origin === parentOrigin) return singleton.provider;
+  singleton?.provider.destroy();
+
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+  const listeners = new Map<string, Set<EventHandler>>();
+
+  const onMessage = (event: MessageEvent) => {
+    if (event.origin !== parentOrigin || event.source !== window.parent) return;
+    const data = event.data as {
+      source?: string;
+      event?: string;
+      payload?: any;
+    };
+    if (data?.source !== "noblocks-host") return;
+
+    if (data.event === "noblocks:wallet_response") {
+      const { id, result, error } = data.payload ?? {};
+      const entry = pending.get(id);
+      if (!entry) return;
+      pending.delete(id);
+      clearTimeout(entry.timer);
+      if (error) {
+        entry.reject(
+          new BridgeRpcError(
+            typeof error.code === "number" ? error.code : -32603,
+            error.message || "Host wallet request failed",
+          ),
+        );
+      } else {
+        entry.resolve(result);
+      }
+    } else if (data.event === "noblocks:wallet_event") {
+      const { event: providerEvent, data: eventData } = data.payload ?? {};
+      listeners.get(providerEvent)?.forEach((handler) => handler(eventData));
+    }
+  };
+  window.addEventListener("message", onMessage);
+
+  const provider: BridgeProvider = {
+    isNoblocksBridge: true,
+    request: ({ method, params }: Eip1193RequestArgs) => {
+      const id = nextId++;
+      return new Promise<unknown>((resolve, reject) => {
+        const timeoutMs = INTERACTIVE_METHODS.has(method)
+          ? INTERACTIVE_TIMEOUT_MS
+          : READ_TIMEOUT_MS;
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(
+            new BridgeRpcError(
+              -32603,
+              `Host wallet did not respond to ${method}. Is NoblocksEmbed.bindWallet() set up on the host page?`,
+            ),
+          );
+        }, timeoutMs);
+        pending.set(id, { resolve, reject, timer });
+        window.parent.postMessage(
+          {
+            source: "noblocks",
+            event: "noblocks:wallet_request",
+            payload: { id, method, params },
+          },
+          parentOrigin,
+        );
+      });
+    },
+    on: (event, handler) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+    },
+    removeListener: (event, handler) => {
+      listeners.get(event)?.delete(handler);
+    },
+    destroy: () => {
+      window.removeEventListener("message", onMessage);
+      pending.forEach((entry) => {
+        clearTimeout(entry.timer);
+        entry.reject(new BridgeRpcError(-32603, "Bridge provider destroyed"));
+      });
+      pending.clear();
+      listeners.clear();
+      if (singleton?.provider === provider) singleton = null;
+    },
+  };
+
+  singleton = { origin: parentOrigin, provider };
+  return provider;
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -55,6 +55,7 @@ import {
   useNetwork,
   useTokens,
   useKYC,
+  useEmbed,
 } from "../context";
 import { validateWalletAddress } from "../lib/validation";
 
@@ -113,6 +114,7 @@ export const TransactionForm = ({
   const { smartWalletBalance, externalWalletBalance, injectedWalletBalance, starknetWalletBalance, tronWalletBalance, isLoading } = useBalance();
   const shouldUseEOA = useShouldUseEOA();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
+  const { isEmbed } = useEmbed();
   const { allTokens } = useTokens();
   // Network-aware "My wallet" / recipient address: Starknet wallet on Starknet,
   // EVM embedded EOA / smart wallet on EVM (mirrors activeWallet for EVM).
@@ -1344,10 +1346,19 @@ export const TransactionForm = ({
         )}
 
         {ready && (
-          <>
+          // Embed mode: the card's middle section scrolls (recipient form can
+          // exceed the frame), so pin the CTA above the "Secured by" footer
+          // with a card-colored backdrop for content sliding underneath.
+          <div
+            className={
+              isEmbed
+                ? "sticky bottom-0 z-10 -mb-1 bg-white pb-1 pt-1 dark:bg-neutral-900"
+                : "contents"
+            }
+          >
             <button
               type="button"
-              className={primaryBtnClasses}
+              className={`${primaryBtnClasses} ${isEmbed ? "w-full" : ""}`}
               disabled={!isEnabled}
               onClick={buttonAction(
                 handleSwap,
@@ -1367,7 +1378,7 @@ export const TransactionForm = ({
             >
               {buttonText}
             </button>
-          </>
+          </div>
         )}
 
         <AnimatePresence>
@@ -1400,10 +1411,13 @@ export const TransactionForm = ({
                   </>
                 ) : null}
               </div>
-              <div className="ml-auto flex w-full flex-col justify-end gap-2 xsm:flex-row xsm:items-center">
-                <div className="h-px w-1/2 flex-shrink bg-gradient-to-tr from-white to-gray-300 dark:bg-gradient-to-tr dark:from-neutral-900 dark:to-neutral-700 sm:w-full" />
-                <p className="min-w-fit">Swap usually completes in 30s</p>
-              </div>
+              {/* Not part of the compact widget design (embed mode). */}
+              {!isEmbed && (
+                <div className="ml-auto flex w-full flex-col justify-end gap-2 xsm:flex-row xsm:items-center">
+                  <div className="h-px w-1/2 flex-shrink bg-gradient-to-tr from-white to-gray-300 dark:bg-gradient-to-tr dark:from-neutral-900 dark:to-neutral-700 sm:w-full" />
+                  <p className="min-w-fit">Swap usually completes in 30s</p>
+                </div>
+              )}
             </AnimatedComponent>
           )}
         </AnimatePresence>

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1518,63 +1518,68 @@ export function TransactionStatus({
                   )}
 
                 {(showGetReceiptButton || showNewPaymentButton) &&
-                  (() => {
-                    const buttons = (
-                      <>
-                        {showNewPaymentButton && (
-                          <div
-                            className={
-                              isEmbed
-                                ? "sticky bottom-0 z-10 order-last w-full bg-white pb-1 pt-1 dark:bg-neutral-900"
-                                : "contents"
-                            }
-                          >
-                            <button
-                              type="button"
-                              onClick={handleBackButtonClick}
-                              className={`${isEmbed ? "w-full" : "order-last w-fit"} ${primaryBtnClasses}`}
-                            >
-                              {transactionStatus === "refunded" ||
-                              transactionStatus === "expired"
-                                ? "Retry transaction"
-                                : "New payment"}
-                            </button>
-                          </div>
-                        )}
-
-                        {showGetReceiptButton && (
-                          <button
-                            type="button"
-                            onClick={handleGetReceipt}
-                            className={`${isEmbed ? "order-last w-full" : "order-first w-fit"} ${secondaryBtnClasses}`}
-                            disabled={isGettingReceipt}
-                          >
-                            {isGettingReceipt ? "Generating..." : "Get receipt"}
-                          </button>
-                        )}
-                      </>
-                    );
-                    // Widget design: full-width buttons stacked at the END of
-                    // the page, primary on top and sticky above the
-                    // WidgetShell footer while scrolling. Rendered as a
-                    // fragment (direct children of the tall flex column, via
-                    // order-last) — position:sticky can only pin within its
-                    // parent's box, so the sticky wrapper's parent must span
-                    // the whole scrollable content, and no animation wrapper
-                    // (its transform would hijack the sticky containing
-                    // block).
-                    return isEmbed ? (
-                      <>{buttons}</>
-                    ) : (
-                      <AnimatedComponent
-                        variant={slideInOut}
-                        delay={0.5}
-                        className="flex w-full flex-wrap gap-3 max-sm:*:flex-1"
-                      >
-                        {buttons}
-                      </AnimatedComponent>
-                    );
-                  })()}
+                  (isEmbed ? (
+                    // Widget design: full-width buttons pinned as one group at
+                    // the END of the page (order-last), primary (New payment)
+                    // on top, sticky above the WidgetShell footer while the
+                    // content above scrolls. One sticky wrapper (not two
+                    // competing order-last children) so the stacking is
+                    // unambiguous; no AnimatedComponent since its transform
+                    // would hijack the position:sticky containing block.
+                    <div className="sticky bottom-0 z-10 order-last flex w-full flex-col gap-3 bg-white pb-1 pt-1 dark:bg-neutral-900">
+                      {showNewPaymentButton && (
+                        <button
+                          type="button"
+                          onClick={handleBackButtonClick}
+                          className={`w-full ${primaryBtnClasses}`}
+                        >
+                          {transactionStatus === "refunded" ||
+                          transactionStatus === "expired"
+                            ? "Retry transaction"
+                            : "New payment"}
+                        </button>
+                      )}
+                      {showGetReceiptButton && (
+                        <button
+                          type="button"
+                          onClick={handleGetReceipt}
+                          className={`w-full ${secondaryBtnClasses}`}
+                          disabled={isGettingReceipt}
+                        >
+                          {isGettingReceipt ? "Generating..." : "Get receipt"}
+                        </button>
+                      )}
+                    </div>
+                  ) : (
+                    <AnimatedComponent
+                      variant={slideInOut}
+                      delay={0.5}
+                      className="flex w-full flex-wrap gap-3 max-sm:*:flex-1"
+                    >
+                      {showGetReceiptButton && (
+                        <button
+                          type="button"
+                          onClick={handleGetReceipt}
+                          className={`w-fit ${secondaryBtnClasses}`}
+                          disabled={isGettingReceipt}
+                        >
+                          {isGettingReceipt ? "Generating..." : "Get receipt"}
+                        </button>
+                      )}
+                      {showNewPaymentButton && (
+                        <button
+                          type="button"
+                          onClick={handleBackButtonClick}
+                          className={`w-fit ${primaryBtnClasses}`}
+                        >
+                          {transactionStatus === "refunded" ||
+                          transactionStatus === "expired"
+                            ? "Retry transaction"
+                            : "New payment"}
+                        </button>
+                      )}
+                    </AnimatedComponent>
+                  ))}
 
                 {!isOnramp && ["validated", "settling", "settled"].includes(transactionStatus) &&
                   !isRecipientInBeneficiaries && (

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -58,7 +58,7 @@ import {
   CheckmarkCircle01Icon,
   FootballIcon,
 } from "hugeicons-react";
-import { useBalance, useInjectedWallet, useNetwork, useTokens } from "../context";
+import { useBalance, useInjectedWallet, useNetwork, useTokens, useEmbed } from "../context";
 import { useSmartWalletTransfer } from "../hooks/useSmartWalletTransfer";
 import config from "../lib/config";
 import { formatUnits } from "viem";
@@ -141,6 +141,7 @@ export function TransactionStatus({
   const { claimed } = useBlockFestClaim();
   const { resolvedTheme } = useTheme();
   const { selectedNetwork } = useNetwork();
+  const { isEmbed } = useEmbed();
   const { allTokens } = useTokens();
   const {
     refreshBalance,
@@ -1516,37 +1517,64 @@ export function TransactionStatus({
                     </AnimatedComponent>
                   )}
 
-                {(showGetReceiptButton || showNewPaymentButton) && (
-                  <AnimatedComponent
-                    variant={slideInOut}
-                    delay={0.5}
-                    className="flex w-full flex-wrap gap-3 max-sm:*:flex-1"
-                  >
-                    {showGetReceiptButton && (
-                      <button
-                        type="button"
-                        onClick={handleGetReceipt}
-                        className={`w-fit ${secondaryBtnClasses}`}
-                        disabled={isGettingReceipt}
-                      >
-                        {isGettingReceipt ? "Generating..." : "Get receipt"}
-                      </button>
-                    )}
+                {(showGetReceiptButton || showNewPaymentButton) &&
+                  (() => {
+                    const buttons = (
+                      <>
+                        {showNewPaymentButton && (
+                          <div
+                            className={
+                              isEmbed
+                                ? "sticky bottom-0 z-10 order-last w-full bg-white pb-1 pt-1 dark:bg-neutral-900"
+                                : "contents"
+                            }
+                          >
+                            <button
+                              type="button"
+                              onClick={handleBackButtonClick}
+                              className={`${isEmbed ? "w-full" : "order-last w-fit"} ${primaryBtnClasses}`}
+                            >
+                              {transactionStatus === "refunded" ||
+                              transactionStatus === "expired"
+                                ? "Retry transaction"
+                                : "New payment"}
+                            </button>
+                          </div>
+                        )}
 
-                    {showNewPaymentButton && (
-                      <button
-                        type="button"
-                        onClick={handleBackButtonClick}
-                        className={`w-fit ${primaryBtnClasses}`}
+                        {showGetReceiptButton && (
+                          <button
+                            type="button"
+                            onClick={handleGetReceipt}
+                            className={`${isEmbed ? "order-last w-full" : "order-first w-fit"} ${secondaryBtnClasses}`}
+                            disabled={isGettingReceipt}
+                          >
+                            {isGettingReceipt ? "Generating..." : "Get receipt"}
+                          </button>
+                        )}
+                      </>
+                    );
+                    // Widget design: full-width buttons stacked at the END of
+                    // the page, primary on top and sticky above the
+                    // WidgetShell footer while scrolling. Rendered as a
+                    // fragment (direct children of the tall flex column, via
+                    // order-last) — position:sticky can only pin within its
+                    // parent's box, so the sticky wrapper's parent must span
+                    // the whole scrollable content, and no animation wrapper
+                    // (its transform would hijack the sticky containing
+                    // block).
+                    return isEmbed ? (
+                      <>{buttons}</>
+                    ) : (
+                      <AnimatedComponent
+                        variant={slideInOut}
+                        delay={0.5}
+                        className="flex w-full flex-wrap gap-3 max-sm:*:flex-1"
                       >
-                        {transactionStatus === "refunded" ||
-                        transactionStatus === "expired"
-                          ? "Retry transaction"
-                          : "New payment"}
-                      </button>
-                    )}
-                  </AnimatedComponent>
-                )}
+                        {buttons}
+                      </AnimatedComponent>
+                    );
+                  })()}
 
                 {!isOnramp && ["validated", "settling", "settled"].includes(transactionStatus) &&
                   !isRecipientInBeneficiaries && (
@@ -1747,6 +1775,8 @@ export function TransactionStatus({
 
         <AnimatePresence>
           {showSuccessVisual &&
+            // Widget design has no share section on the success screen.
+            !isEmbed &&
             !isBlockFestEligible(
               transactionStatus,
               claimed,

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Toaster } from "sonner";
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { ThemeProvider } from "next-themes";
 
 import { PrivyProvider } from "@privy-io/react-auth";
@@ -24,6 +25,8 @@ import {
   TokensProvider,
   TransactionsProvider,
   BlockFestModalProvider,
+  EmbedProvider,
+  isEmbedPath,
 } from "./context";
 import { useActualTheme } from "./hooks/useActualTheme";
 import { useMixpanel } from "./hooks/analytics/client";
@@ -32,9 +35,24 @@ import { BlockFestClaimProvider } from "./context/BlockFestClaimContext";
 function Providers({ children }: { children: ReactNode }) {
   const { privyAppId } = config;
   const queryClient = new QueryClient();
+  const isWidget = isEmbedPath(usePathname());
+
+  // Embed mode: hosts pin the widget theme via ?theme=dark|light. Read from
+  // window.location instead of useSearchParams (no Suspense boundary here),
+  // and force it only on /widget so the user's stored preference is untouched.
+  const [embedTheme] = useState<"dark" | "light" | undefined>(() => {
+    if (typeof window === "undefined") return undefined;
+    const theme = new URLSearchParams(window.location.search).get("theme");
+    return theme === "dark" || theme === "light" ? theme : undefined;
+  });
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      forcedTheme={isWidget ? embedTheme : undefined}
+    >
       <QueryClientProvider client={queryClient}>
         <PrivyConfigWrapper privyAppId={privyAppId}>
           {children}
@@ -75,10 +93,14 @@ function PrivyConfigWrapper({
 }
 
 function ContextProviders({ children }: { children: ReactNode }) {
-  useMixpanel(); // Initialize Mixpanel analytics
+  const isEmbed = isEmbedPath(usePathname());
+  // No client-side trackers inside partner iframes; source-domain attribution
+  // happens server-side in middleware.ts instead.
+  useMixpanel(!isEmbed);
 
   return (
-    <NetworkProvider>
+    <EmbedProvider>
+      <NetworkProvider>
       <HomeTransactionFormModeProvider>
         <InjectedWalletProvider>
           <MigrationStatusProvider>
@@ -108,7 +130,8 @@ function ContextProviders({ children }: { children: ReactNode }) {
           </MigrationStatusProvider>
         </InjectedWalletProvider>
       </HomeTransactionFormModeProvider>
-    </NetworkProvider>
+      </NetworkProvider>
+    </EmbedProvider>
   );
 }
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -12,6 +12,7 @@ export default function robots(): MetadataRoute.Robots {
           '/_next/',
           '/private/',
           '/internal/',
+          '/widget',
           '*.json',
           '*.xml'
         ],
@@ -19,12 +20,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: 'Googlebot',
         allow: '/',
-        disallow: ['/api/', '/admin/', '/_next/'],
+        disallow: ['/api/', '/admin/', '/_next/', '/widget'],
       },
       {
         userAgent: 'Bingbot',
         allow: '/',
-        disallow: ['/api/', '/admin/', '/_next/'],
+        disallow: ['/api/', '/admin/', '/_next/', '/widget'],
       }
     ],
     sitemap: 'https://noblocks.xyz/sitemap.xml',

--- a/app/types.ts
+++ b/app/types.ts
@@ -456,6 +456,8 @@ export type Config = {
   onrampChainedForwardingEnabled: boolean;
   /** Noblocks Play (World Cup fantasy league) feature flag. Gates /play UI + API. */
   fantasyEnabled: boolean;
+  /** Embeddable widget feature flag. Gates the /widget route (iframe embed for whitelisted partners). */
+  embedEnabled: boolean;
 };
 
 export type Network = {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1685,6 +1685,11 @@ export function clearFormState(formMethods: any) {
 /**
  * Determines if the app should use an injected wallet.
  *
+ * `injected=true` uses window.ethereum (extension wallets — they inject into
+ * iframes too). `injected=bridge` uses the embedding page's wallet over the
+ * postMessage bridge (see app/lib/embed-bridge-provider.ts), so it only
+ * applies when actually running inside an iframe.
+ *
  * @param searchParams - The URL search parameters to check for the 'injected' flag
  * @returns boolean indicating whether to use injected wallet
  */
@@ -1692,7 +1697,9 @@ export function shouldUseInjectedWallet(
   searchParams: URLSearchParams,
 ): boolean {
   const injectedParam = searchParams.get("injected");
-  return Boolean(injectedParam === "true" && window.ethereum);
+  if (injectedParam === "true") return Boolean(window.ethereum);
+  if (injectedParam === "bridge") return window.self !== window.top;
+  return false;
 }
 
 /** `?side=` for home swap form: buy = on-ramp, sell = off-ramp (matches rates API). */

--- a/app/widget/layout.tsx
+++ b/app/widget/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+// Embeddable widget for whitelisted partner sites (iframed) — keep it out of
+// search indexes; the canonical product page is /.
+export const metadata: Metadata = {
+  title: "Noblocks Widget",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function WidgetLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/widget/page.tsx
+++ b/app/widget/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Suspense } from "react";
+import { Preloader } from "../components/Preloader";
+import dynamic from "next/dynamic";
+
+// Same content as the home page — EmbedContext + AppLayout key off the
+// /widget pathname to render the compact chrome-less widget shell. All home
+// query params (token, currency, tokenAmount, fiatAmount, side, provider,
+// injected, ref) work here unchanged.
+const MainPageContent = dynamic(() => import("../components/MainPageContent").then(mod => ({ default: mod.MainPageContent })), {
+  ssr: false,
+  loading: () => <Preloader isLoading={true} />
+});
+
+export default function WidgetPage() {
+  return (
+    <Suspense fallback={<Preloader isLoading={true} />}>
+      <MainPageContent />
+    </Suspense>
+  );
+}

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -68,8 +68,12 @@ origin, never `*`). Each message is
 | `noblocks:tx_status` | `{ status, orderId }`   | Transaction progress (e.g. `pending`, `settled`, `refunded`) |
 
 ```js
+const iframe = document.getElementById("noblocks-widget");
 window.addEventListener("message", (e) => {
+  // Check both the origin AND the source window, so another child frame at
+  // the Noblocks origin can't spoof close/resize/tx_status events.
   if (e.origin !== "https://noblocks.xyz") return;
+  if (e.source !== iframe.contentWindow) return;
   if (e.data?.source !== "noblocks") return;
   const { event, payload } = e.data;
   // ...
@@ -98,9 +102,14 @@ Your page proxies the widget's wallet requests to **your** connected provider
 (WalletConnect, AppKit, wagmi, `window.ethereum`, ...). All signing prompts
 appear in your wallet UI; the widget never sees keys.
 
+Bind the wallet **before** the iframe loads — create the iframe without a
+`src`, call `bindWallet` (which installs the message listener), then set `src`.
+Otherwise a fast widget load can fire `eth_requestAccounts` before the listener
+exists and the request hangs until timeout.
+
 ```html
 <script src="https://noblocks.xyz/embed.js"></script>
-<iframe id="noblocks-widget" src="https://noblocks.xyz/widget?injected=bridge"></iframe>
+<iframe id="noblocks-widget"></iframe>
 <script>
   const iframe = document.getElementById("noblocks-widget");
   const unbind = NoblocksEmbed.bindWallet(iframe, window.ethereum, {
@@ -109,10 +118,12 @@ appear in your wallet UI; the widget never sees keys.
       if (event === "noblocks:close") iframe.remove();
     },
   });
+  // Set src only after bindWallet has installed the listener.
+  iframe.src = "https://noblocks.xyz/widget?injected=bridge";
 </script>
 ```
 
-With wagmi (v2), pass the connector's provider:
+With wagmi (v2), pass the connector's provider (still bind before setting `src`):
 
 ```ts
 import { getConnectorClient } from "@wagmi/core";
@@ -120,17 +131,24 @@ import { getConnectorClient } from "@wagmi/core";
 const client = await getConnectorClient(wagmiConfig);
 NoblocksEmbed.bindWallet(iframe, client.transport, { onEvent });
 // or: NoblocksEmbed.bindWallet(iframe, await connector.getProvider(), { onEvent });
+iframe.src = "https://noblocks.xyz/widget?injected=bridge";
 ```
 
-Call `bindWallet` before (or immediately after) inserting the iframe so no
-request is missed. The returned `unbind()` removes all listeners.
+The returned `unbind()` removes all listeners.
 
 ## Configuration (Noblocks operators)
 
 - `NEXT_PUBLIC_EMBED_ENABLED` — feature flag; when not `"true"`, `/widget`
   returns 404.
 - `EMBED_ALLOWED_ORIGINS` — comma-separated base allowlist (env-only, needs a
-  redeploy to change).
+  redeploy to change). Origins must be `https://` (only `http://localhost` is
+  accepted, for local dev).
+- `INTERNAL_API_BASE_URL` — trusted absolute base URL (e.g. `https://noblocks.xyz`)
+  the middleware uses to fetch the DB-backed allowlist. **Required to consult the
+  `embed_allowed_origins` table** — if unset, only `EMBED_ALLOWED_ORIGINS` is
+  used. Never derived from the request Host header, so a poisoned host can't
+  redirect the authenticated fetch. On a failed/non-OK refresh the DB-backed
+  origins are dropped (fail closed) until the next successful fetch.
 - `embed_allowed_origins` table (Supabase) — runtime allowlist, merged with the
   env var by `middleware.ts` (cached ~5 min). Managed via the secret-gated
   internal API:

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -1,0 +1,157 @@
+# Embeddable Widget (`/widget`)
+
+Noblocks can be embedded as a compact swap widget in partner sites via iframe.
+Embedding is restricted to whitelisted origins, enforced by the browser through
+`Content-Security-Policy: frame-ancestors`.
+
+## Getting whitelisted
+
+Email **info@noblocks.xyz** with:
+
+- The exact origin(s) that will embed the widget (e.g. `https://app.partner.com`;
+  wildcard subdomains like `https://*.partner.com` are supported)
+- A contact email for incident/breaking-change notifications
+- A short description of your integration
+
+Once approved, your origin is added to the allowlist and the widget will load
+inside your iframe. Non-whitelisted origins are blocked by the browser.
+
+## Quick start
+
+```html
+<iframe
+  id="noblocks-widget"
+  src="https://noblocks.xyz/widget?theme=dark&currency=NGN"
+  allow="clipboard-write; publickey-credentials-get; camera"
+  style="width: 100%; max-width: 460px; height: 680px; border: 0; background: transparent"
+></iframe>
+```
+
+Notes:
+
+- Do **not** set `Referrer-Policy: no-referrer` on the embedding page (or
+  `referrerpolicy="no-referrer"` on the iframe). The widget derives your origin
+  from the referrer to send you events; origin-level referrer
+  (`strict-origin-when-cross-origin`, the browser default) is enough.
+- `camera` is needed for KYC selfie capture, `clipboard-write` for
+  copy-address buttons.
+- The widget renders as a floating card (393px) on a **transparent backdrop**,
+  with its close button in a right-side gutter. Give the iframe **≥ 449px**
+  width for that layout; below 449px the close button moves inside the card
+  header (compact/mobile variant), so narrower embeds still work.
+
+## URL parameters
+
+| Param         | Values                   | Effect                                                    |
+| ------------- | ------------------------ | --------------------------------------------------------- |
+| `theme`       | `dark` \| `light`        | Force the widget theme (default: visitor system theme)    |
+| `side`        | `buy` \| `sell`          | Start in on-ramp (buy) or off-ramp (sell) mode            |
+| `token`       | e.g. `USDC`, `USDT`      | Preselect token                                           |
+| `currency`    | e.g. `NGN`, `KES`        | Preselect fiat currency                                   |
+| `tokenAmount` | number                   | Prefill token amount                                      |
+| `fiatAmount`  | number                   | Prefill fiat amount                                       |
+| `provider`    | liquidity provider ID    | Pin a specific liquidity provider                         |
+| `ref`         | referral code            | Attribute transactions to your referral code              |
+| `injected`    | `true` \| `bridge`       | Wallet mode — see below                                   |
+
+## Widget → host events (postMessage)
+
+The widget posts messages to the embedding page (only to your whitelisted
+origin, never `*`). Each message is
+`{ source: "noblocks", event, payload }`:
+
+| Event                | Payload                 | Meaning                                    |
+| -------------------- | ----------------------- | ------------------------------------------ |
+| `noblocks:ready`     | —                       | Widget mounted                             |
+| `noblocks:resize`    | `{ height }`            | Content height changed (auto-size iframe)  |
+| `noblocks:close`     | —                       | User clicked the widget close button — remove/hide the iframe |
+| `noblocks:tx_status` | `{ status, orderId }`   | Transaction progress (e.g. `pending`, `settled`, `refunded`) |
+
+```js
+window.addEventListener("message", (e) => {
+  if (e.origin !== "https://noblocks.xyz") return;
+  if (e.data?.source !== "noblocks") return;
+  const { event, payload } = e.data;
+  // ...
+});
+```
+
+## Wallet modes
+
+### Default: Privy login in the widget
+
+Users sign in with email (Privy) inside the widget — no host integration
+needed. Note: in Safari/Firefox, storage partitioning means the session may
+not persist across page reloads, and OAuth popups must not be blocked.
+
+### `injected=true` — extension wallet inside the iframe
+
+Browser-extension wallets (MetaMask, Rabby, ...) inject `window.ethereum`
+into iframes too, so the user transacts with the same extension they use on
+your page. The wallet prompts them once to connect the noblocks.xyz origin
+(auto-connects on return visits). This does **not** cover WalletConnect /
+mobile-QR sessions — use the bridge for those.
+
+### `injected=bridge` — hand off your page's connected wallet
+
+Your page proxies the widget's wallet requests to **your** connected provider
+(WalletConnect, AppKit, wagmi, `window.ethereum`, ...). All signing prompts
+appear in your wallet UI; the widget never sees keys.
+
+```html
+<script src="https://noblocks.xyz/embed.js"></script>
+<iframe id="noblocks-widget" src="https://noblocks.xyz/widget?injected=bridge"></iframe>
+<script>
+  const iframe = document.getElementById("noblocks-widget");
+  const unbind = NoblocksEmbed.bindWallet(iframe, window.ethereum, {
+    onEvent(event, payload) {
+      if (event === "noblocks:resize") iframe.style.height = payload.height + "px";
+      if (event === "noblocks:close") iframe.remove();
+    },
+  });
+</script>
+```
+
+With wagmi (v2), pass the connector's provider:
+
+```ts
+import { getConnectorClient } from "@wagmi/core";
+
+const client = await getConnectorClient(wagmiConfig);
+NoblocksEmbed.bindWallet(iframe, client.transport, { onEvent });
+// or: NoblocksEmbed.bindWallet(iframe, await connector.getProvider(), { onEvent });
+```
+
+Call `bindWallet` before (or immediately after) inserting the iframe so no
+request is missed. The returned `unbind()` removes all listeners.
+
+## Configuration (Noblocks operators)
+
+- `NEXT_PUBLIC_EMBED_ENABLED` — feature flag; when not `"true"`, `/widget`
+  returns 404.
+- `EMBED_ALLOWED_ORIGINS` — comma-separated base allowlist (env-only, needs a
+  redeploy to change).
+- `embed_allowed_origins` table (Supabase) — runtime allowlist, merged with the
+  env var by `middleware.ts` (cached ~5 min). Managed via the secret-gated
+  internal API:
+
+```bash
+# List
+curl -H "x-internal-auth: $INTERNAL_API_KEY" https://noblocks.xyz/api/internal/embed-origins
+
+# Add / update (contact_email required)
+curl -X POST -H "x-internal-auth: $INTERNAL_API_KEY" -H "Content-Type: application/json" \
+  -d '{"origin":"https://app.partner.com","partner_name":"Partner","contact_email":"dev@partner.com","note":"Q3 pilot"}' \
+  https://noblocks.xyz/api/internal/embed-origins
+
+# Remove
+curl -X DELETE -H "x-internal-auth: $INTERNAL_API_KEY" \
+  "https://noblocks.xyz/api/internal/embed-origins?origin=https://app.partner.com"
+```
+
+Also add partner origins to the **Privy dashboard allowed origins** so Privy
+login works inside their frames.
+
+Widget loads are attributed server-side (cookieless) via the middleware
+analytics event `Embed Widget Loaded` with the embedding `referrer_origin` —
+no client trackers or cookie banner run inside the widget.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -140,9 +140,14 @@ NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED=false
 
 # Embeddable widget (/widget, iframed by whitelisted partners) — see docs/embed-widget.md
 NEXT_PUBLIC_EMBED_ENABLED=false
-# Comma-separated origins allowed to iframe /widget (wildcard subdomains ok);
-# merged with the embed_allowed_origins Supabase table
+# Comma-separated origins allowed to iframe /widget (https only; http allowed
+# only for localhost in dev; wildcard subdomains ok); merged with the
+# embed_allowed_origins Supabase table
 EMBED_ALLOWED_ORIGINS=
+# Trusted absolute base URL for the middleware→internal-API fetch of the
+# DB-backed allowlist (e.g. https://noblocks.xyz). If unset, only
+# EMBED_ALLOWED_ORIGINS is consulted. Never request-derived (SSRF-safe).
+INTERNAL_API_BASE_URL=
 ```
 
 ### External Services

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -137,6 +137,12 @@ NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 
 # Onramp chained forwarding: crypto settles to user wallet then auto-forward to destination
 NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED=false
+
+# Embeddable widget (/widget, iframed by whitelisted partners) — see docs/embed-widget.md
+NEXT_PUBLIC_EMBED_ENABLED=false
+# Comma-separated origins allowed to iframe /widget (wildcard subdomains ok);
+# merged with the embed_allowed_origins Supabase table
+EMBED_ALLOWED_ORIGINS=
 ```
 
 ### External Services

--- a/middleware.ts
+++ b/middleware.ts
@@ -368,7 +368,11 @@ async function authorizationMiddleware(req: NextRequest) {
 // Origins allowed to iframe /widget. Env base (EMBED_ALLOWED_ORIGINS) merged
 // with the embed_allowed_origins table via the internal API, cached in module
 // scope. frame-ancestors accepts wildcard subdomains (https://*.partner.com).
-const EMBED_ORIGIN_RE = /^https?:\/\/(\*\.)?[\w.-]+(:\d+)?$/;
+// HTTPS is required for partner origins (a network attacker could tamper with
+// an http:// parent page and drive the framed widget); http:// is permitted
+// only for localhost/127.0.0.1 during development.
+const EMBED_ORIGIN_RE =
+  /^https:\/\/(\*\.)?[\w.-]+(:\d+)?$|^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 const EMBED_ORIGINS_TTL_MS = 5 * 60_000;
 let embedOriginsCache: { origins: string[]; fetchedAt: number } | null = null;
 
@@ -379,14 +383,20 @@ function envEmbedOrigins(): string[] {
     .filter((o) => EMBED_ORIGIN_RE.test(o));
 }
 
-async function getEmbedAllowedOrigins(baseUrl: string): Promise<string[]> {
+async function getEmbedAllowedOrigins(): Promise<string[]> {
   const now = Date.now();
   const stale =
     !embedOriginsCache || now - embedOriginsCache.fetchedAt >= EMBED_ORIGINS_TTL_MS;
   if (stale) {
-    try {
-      const internalAuth = process.env.INTERNAL_API_KEY;
-      if (internalAuth) {
+    const internalAuth = process.env.INTERNAL_API_KEY;
+    // Only fetch the DB-backed allowlist through a trusted, configured base
+    // URL — never a request-derived (Host-header-controlled) origin, which a
+    // poisoned host could point at an attacker's server to steal the internal
+    // key and poison this shared cache. If unconfigured, use the env allowlist
+    // only. See INTERNAL_API_BASE_URL in .env.example.
+    const baseUrl = process.env.INTERNAL_API_BASE_URL;
+    if (internalAuth && baseUrl) {
+      try {
         const res = await fetch(`${baseUrl}/api/internal/embed-origins`, {
           headers: { "x-internal-auth": internalAuth },
         });
@@ -396,10 +406,14 @@ async function getEmbedAllowedOrigins(baseUrl: string): Promise<string[]> {
             origins: (origins ?? []).filter((o) => EMBED_ORIGIN_RE.test(o)),
             fetchedAt: now,
           };
+        } else {
+          // Fail closed: drop DB-backed origins on a bad refresh so a revoked
+          // partner can't keep framing during an outage. Env allowlist stays.
+          embedOriginsCache = null;
         }
+      } catch {
+        embedOriginsCache = null;
       }
-    } catch {
-      // Keep stale cache / fall back to env-only below.
     }
   }
   return [...new Set([...envEmbedOrigins(), ...(embedOriginsCache?.origins ?? [])])];
@@ -410,7 +424,7 @@ async function embedMiddleware(req: NextRequest) {
     return new NextResponse("Not Found", { status: 404 });
   }
 
-  const origins = await getEmbedAllowedOrigins(req.nextUrl.origin);
+  const origins = await getEmbedAllowedOrigins();
 
   // Cookieless source-domain attribution: the Referer of an iframe's first
   // load is the embedding page.

--- a/middleware.ts
+++ b/middleware.ts
@@ -364,10 +364,104 @@ async function authorizationMiddleware(req: NextRequest) {
   return response;
 }
 
-export default authorizationMiddleware;
+// --- Embeddable widget (/widget) ---
+// Origins allowed to iframe /widget. Env base (EMBED_ALLOWED_ORIGINS) merged
+// with the embed_allowed_origins table via the internal API, cached in module
+// scope. frame-ancestors accepts wildcard subdomains (https://*.partner.com).
+const EMBED_ORIGIN_RE = /^https?:\/\/(\*\.)?[\w.-]+(:\d+)?$/;
+const EMBED_ORIGINS_TTL_MS = 5 * 60_000;
+let embedOriginsCache: { origins: string[]; fetchedAt: number } | null = null;
+
+function envEmbedOrigins(): string[] {
+  return (process.env.EMBED_ALLOWED_ORIGINS ?? "")
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter((o) => EMBED_ORIGIN_RE.test(o));
+}
+
+async function getEmbedAllowedOrigins(baseUrl: string): Promise<string[]> {
+  const now = Date.now();
+  const stale =
+    !embedOriginsCache || now - embedOriginsCache.fetchedAt >= EMBED_ORIGINS_TTL_MS;
+  if (stale) {
+    try {
+      const internalAuth = process.env.INTERNAL_API_KEY;
+      if (internalAuth) {
+        const res = await fetch(`${baseUrl}/api/internal/embed-origins`, {
+          headers: { "x-internal-auth": internalAuth },
+        });
+        if (res.ok) {
+          const { origins } = (await res.json()) as { origins?: string[] };
+          embedOriginsCache = {
+            origins: (origins ?? []).filter((o) => EMBED_ORIGIN_RE.test(o)),
+            fetchedAt: now,
+          };
+        }
+      }
+    } catch {
+      // Keep stale cache / fall back to env-only below.
+    }
+  }
+  return [...new Set([...envEmbedOrigins(), ...(embedOriginsCache?.origins ?? [])])];
+}
+
+async function embedMiddleware(req: NextRequest) {
+  if (process.env.NEXT_PUBLIC_EMBED_ENABLED !== "true") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  const origins = await getEmbedAllowedOrigins(req.nextUrl.origin);
+
+  // Cookieless source-domain attribution: the Referer of an iframe's first
+  // load is the embedding page.
+  const referer = req.headers.get("referer");
+  let referrerOrigin = "";
+  try {
+    referrerOrigin = referer ? new URL(referer).origin : "";
+  } catch {
+    // Malformed referer - skip attribution detail.
+  }
+  if (referrerOrigin && referrerOrigin !== req.nextUrl.origin) {
+    trackMiddlewareAnalytics(
+      "request",
+      {
+        endpoint: "/widget",
+        method: req.method,
+        properties: {
+          middleware: true,
+          embed: true,
+          referrer_origin: referrerOrigin,
+        },
+      },
+      req.nextUrl.origin,
+    );
+  }
+
+  const response = NextResponse.next();
+  // frame-ancestors supersedes X-Frame-Options; delete it as belt-and-braces
+  // (next.config.mjs already scopes DENY away from /widget).
+  response.headers.delete("x-frame-options");
+  response.headers.set(
+    "Content-Security-Policy",
+    origins.length
+      ? `frame-ancestors 'self' ${origins.join(" ")}`
+      : "frame-ancestors 'none'",
+  );
+  return response;
+}
+
+export default async function middleware(req: NextRequest) {
+  const pathname = req.nextUrl.pathname;
+  if (pathname === "/widget" || pathname.startsWith("/widget/")) {
+    return embedMiddleware(req);
+  }
+  return authorizationMiddleware(req);
+}
 
 export const config = {
   matcher: [
+    "/widget",
+    "/widget/:path*",
     "/api/v1/transactions",
     "/api/v1/transactions/:path*",
     "/api/v1/account/verify",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,16 +30,24 @@ const nextConfig = {
           value: "nosniff",
         },
         {
-          key: "X-Frame-Options",
-          value: "DENY",
-        },
-        {
           key: "X-XSS-Protection",
           value: "1; mode=block",
         },
         {
           key: "Referrer-Policy",
           value: "strict-origin-when-cross-origin",
+        },
+      ],
+    },
+    {
+      // Deny framing everywhere except /widget, which is embeddable by
+      // whitelisted partners; middleware.ts sets a per-request
+      // Content-Security-Policy frame-ancestors allowlist there instead.
+      source: "/((?!widget$|widget/).*)",
+      headers: [
+        {
+          key: "X-Frame-Options",
+          value: "DENY",
         },
       ],
     },

--- a/public/embed.js
+++ b/public/embed.js
@@ -1,0 +1,112 @@
+/**
+ * Noblocks Embed SDK (host side).
+ *
+ * Lets a partner page hand its connected EIP-1193 wallet (MetaMask,
+ * WalletConnect, AppKit, wagmi's connector client, ...) to an embedded
+ * Noblocks widget iframe, and receive widget lifecycle events.
+ *
+ * Usage:
+ *   <script src="https://noblocks.xyz/embed.js"></script>
+ *   <iframe id="noblocks" src="https://noblocks.xyz/widget?injected=bridge"></iframe>
+ *   <script>
+ *     const unbind = NoblocksEmbed.bindWallet(
+ *       document.getElementById("noblocks"),
+ *       provider, // any EIP-1193 provider, e.g. window.ethereum
+ *       {
+ *         onEvent(event, payload) {
+ *           if (event === "noblocks:close") iframe.remove();
+ *           if (event === "noblocks:resize") iframe.style.height = payload.height + "px";
+ *         },
+ *       }
+ *     );
+ *   </script>
+ *
+ * Call bindWallet before (or immediately after) adding the iframe so no
+ * request from the widget is missed. Signing prompts appear in the host
+ * wallet's own UI; the widget never sees keys.
+ */
+(function () {
+  "use strict";
+
+  var DEFAULT_WIDGET_ORIGIN = "https://noblocks.xyz";
+
+  /**
+   * @param {HTMLIFrameElement} iframeEl - the widget iframe
+   * @param {{ request: Function, on?: Function, removeListener?: Function }} provider
+   *   EIP-1193 provider whose requests the widget will proxy
+   * @param {{ origin?: string, onEvent?: (event: string, payload: any) => void }} [options]
+   *   origin: widget origin if not noblocks.xyz (e.g. http://localhost:3000)
+   *   onEvent: called for every widget event (noblocks:ready/resize/close/tx_status)
+   * @returns {() => void} unbind function
+   */
+  function bindWallet(iframeEl, provider, options) {
+    if (!iframeEl || typeof iframeEl.contentWindow === "undefined") {
+      throw new Error("NoblocksEmbed.bindWallet: iframeEl must be an <iframe> element");
+    }
+    if (!provider || typeof provider.request !== "function") {
+      throw new Error("NoblocksEmbed.bindWallet: provider must be an EIP-1193 provider");
+    }
+    var opts = options || {};
+    var widgetOrigin = opts.origin || DEFAULT_WIDGET_ORIGIN;
+
+    function postToWidget(event, payload) {
+      if (!iframeEl.contentWindow) return;
+      iframeEl.contentWindow.postMessage(
+        { source: "noblocks-host", event: event, payload: payload },
+        widgetOrigin
+      );
+    }
+
+    function onMessage(event) {
+      if (event.origin !== widgetOrigin) return;
+      if (!iframeEl.contentWindow || event.source !== iframeEl.contentWindow) return;
+      var data = event.data;
+      if (!data || data.source !== "noblocks") return;
+
+      if (data.event === "noblocks:wallet_request") {
+        var payload = data.payload || {};
+        provider
+          .request({ method: payload.method, params: payload.params })
+          .then(function (result) {
+            postToWidget("noblocks:wallet_response", { id: payload.id, result: result });
+          })
+          .catch(function (error) {
+            postToWidget("noblocks:wallet_response", {
+              id: payload.id,
+              error: {
+                code: typeof (error && error.code) === "number" ? error.code : -32603,
+                message: (error && error.message) || "Host wallet request failed",
+              },
+            });
+          });
+        return;
+      }
+
+      if (typeof opts.onEvent === "function") {
+        opts.onEvent(data.event, data.payload);
+      }
+    }
+
+    window.addEventListener("message", onMessage);
+
+    // Forward wallet lifecycle events into the widget.
+    var forwarded = ["accountsChanged", "chainChanged", "disconnect"].map(function (name) {
+      var handler = function (eventData) {
+        postToWidget("noblocks:wallet_event", { event: name, data: eventData });
+      };
+      if (typeof provider.on === "function") provider.on(name, handler);
+      return { name: name, handler: handler };
+    });
+
+    return function unbind() {
+      window.removeEventListener("message", onMessage);
+      forwarded.forEach(function (entry) {
+        if (typeof provider.removeListener === "function") {
+          provider.removeListener(entry.name, entry.handler);
+        }
+      });
+    };
+  }
+
+  window.NoblocksEmbed = { bindWallet: bindWallet };
+})();

--- a/supabase/migrations/20260721120000_create_embed_allowed_origins.sql
+++ b/supabase/migrations/20260721120000_create_embed_allowed_origins.sql
@@ -1,0 +1,19 @@
+-- Origins allowed to iframe the /widget embed route.
+--
+-- Merged with the EMBED_ALLOWED_ORIGINS env var by middleware.ts (via the
+-- secret-gated /api/internal/embed-origins route) into the
+-- Content-Security-Policy frame-ancestors list. contact_email is required so
+-- partners can be reached about incidents or breaking changes; it is never
+-- exposed outside the internal API.
+CREATE TABLE IF NOT EXISTS public.embed_allowed_origins (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- e.g. https://partner.com or https://*.partner.app (wildcard subdomain)
+    origin text UNIQUE NOT NULL,
+    partner_name text,
+    contact_email text NOT NULL,
+    note text,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Service-role access only: RLS on with no policies.
+ALTER TABLE public.embed_allowed_origins ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
### Description

Partners can now embed Noblocks as a compact swap widget in their own sites via iframe, gated to whitelisted origins and matching the [Figma widget design](https://www.figma.com/design/acOLQvbDj0TCm2ZKfl4y7e/Noblocks-Web-App?node-id=2429-117879). Previously iframing was impossible (`X-Frame-Options: DENY` on every route) and there was no compact layout.

**Security / allowlisting**
- `X-Frame-Options: DENY` stays on every route **except** `/widget` (`next.config.mjs` matcher).
- `middleware.ts` emits a per-request `Content-Security-Policy: frame-ancestors` allowlist for `/widget`, merged from the `EMBED_ALLOWED_ORIGINS` env var and the new `embed_allowed_origins` Supabase table (5-min cache, fails closed to `'none'`; env-only fallback if the API is down).
- Allowlist CRUD via secret-gated `/api/internal/embed-origins` (GET/POST/DELETE, `x-internal-auth`); `contact_email` required per partner.
- Feature flag `NEXT_PUBLIC_EMBED_ENABLED` — `/widget` 404s when off. Route noindexed (robots + metadata).

**Widget UI (scoped to `/widget`)**
- `WidgetShell` compact card per Figma: transparent backdrop (host page shows through — includes a `color-scheme` override so Chrome doesn't paint an opaque canvas behind cross-origin dark iframes), close X outside the card (moves into the header below 449px), minimized wallet pill opening the mobile wallet drawer, pinned "Secured by Noblocks" footer with internal scroll, sticky Swap / New payment CTAs, card-shaped loading skeleton, Brevo launcher repositioned inside the card.
- Success screen: stacked full-width buttons at the end of the page, no share section. No navbar/footer/hero/banners/cookie consent/30s strip in embed mode.
- `?theme=dark|light` forces the widget theme. All existing params (`token`, `currency`, `tokenAmount`, `fiatAmount`, `side`, `provider`, `ref`, `injected`) work unchanged.

**Host integration**
- postMessage events to the verified embedder origin only: `noblocks:ready`, `noblocks:resize`, `noblocks:close`, `noblocks:tx_status`.
- Host-wallet EIP-1193 bridge: `?injected=bridge` + `public/embed.js` (`NoblocksEmbed.bindWallet(iframe, provider)`) proxies wallet requests to the host page's connected provider (WalletConnect/AppKit/wagmi); signing stays in the host's wallet UI. `?injected=true` still covers extension wallets.
- Analytics: no client trackers in the widget; cookieless server-side `Embed Widget Loaded` attribution with the embedding origin.

**General fix (intentionally not widget-scoped)**
- Wallet balances comma-formatted via `formatCurrency` (drawer total, navbar chip, per-token USD equivalents) — `$7,750,815.66` instead of `$7750815.66`.

**Breaking changes:** none. **Deploy notes:** run the `embed_allowed_origins` migration; set `NEXT_PUBLIC_EMBED_ENABLED` + `EMBED_ALLOWED_ORIGINS`; add partner origins to the Privy dashboard allowed origins.


### References

closes #610


### Testing

Developed on macOS, Next.js 15 (App Router), Chrome. Verified locally with a static host-page harness iframing `localhost:3000/widget` from an allowed origin:

- `curl -I /widget` → `frame-ancestors 'self' <allowlist>`, no `X-Frame-Options`; `curl -I /` → keeps `X-Frame-Options: DENY`; flag off → `/widget` 404s.
- Render vs Figma (dark/light), param prefills, live rates, currency/institution modals, sticky CTAs + pinned footer with internal scroll.
- postMessage `ready` / `resize` / `close` / `tx_status` received by the host; bridge wallet connect + `accountsChanged` via a mock EIP-1193 provider.
- Negative test from a non-whitelisted origin: browser refuses to frame.
- Regression: `/` unchanged (navbar, hero, cookie banner, default Brevo position, no widget classes); `tsc` clean; `pnpm build` green (77 pages, `/widget` static).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR (docs added in `docs/embed-widget.md`; automated tests not yet added — verified manually, see Testing)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embeddable `/widget` experience with a compact, responsive UI and dedicated loading state.
  * Implemented widget↔host integration with wallet bridging, widget lifecycle events, and auto-resizing/close controls.
  * Added secure, configurable origin allowlisting for iframe `frame-ancestors`, backed by runtime configuration and an internal allowlist.
  * Improved USD display by switching wallet balance formatting to a consistent currency formatter.
* **Documentation**
  * Added detailed embedding setup, supported parameters, and the `postMessage`/host SDK integration guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->