### PR TITLE
fix(widget): sticky wallet header; host owns iframe dismiss

### DIFF
--- a/app/components/WidgetShell.tsx
+++ b/app/components/WidgetShell.tsx
@@ -4,7 +4,6 @@ import { AnimatePresence } from "framer-motion";
 import {
   ArrowDown01Icon,
   ArrowRight01Icon,
-  Cancel01Icon,
   SquareLock02Icon,
   Wallet01Icon,
 } from "hugeicons-react";
@@ -12,7 +11,6 @@ import { usePrivy } from "@privy-io/react-auth";
 
 import { MobileDropdown } from "./MobileDropdown";
 import { NoblocksLogo } from "./ImageAssets";
-import { useEmbed } from "../context/EmbedContext";
 import { useInjectedWallet } from "../context";
 
 /**
@@ -20,9 +18,10 @@ import { useInjectedWallet } from "../context";
  * card that FILLS the entire iframe viewport — no margins, no shadow; the
  * partner sizes/rounds/floats the widget by styling the iframe element
  * itself, and the rounded corners show against the transparent backdrop.
- * Inside: a minimized wallet pill (wallet icon + chevron) opening the mobile
- * wallet drawer, a close X in the card header (iframe-embedded only), the
- * swap step, and a "Secured by Noblocks" footer row.
+ * Inside: a sticky wallet pill (wallet icon + chevron) opening the mobile
+ * wallet drawer, the swap step, and a "Secured by Noblocks" footer row.
+ * Dismissing the iframe is owned by the host page (backdrop, host close
+ * control, etc.) — the widget does not render a close button.
  * Replaces Navbar/Footer/HomePage, which are hidden in embed mode.
  *
  * The recommended iframe width (~393-420px, per Figma frame 2429:118606) is
@@ -32,7 +31,6 @@ import { useInjectedWallet } from "../context";
 export function WidgetShell({ children }: { children: React.ReactNode }) {
   const { ready, authenticated } = usePrivy();
   const { isInjectedWallet } = useInjectedWallet();
-  const { parentOrigin, postToHost } = useEmbed();
   const [isWalletDrawerOpen, setIsWalletDrawerOpen] = useState(false);
 
   const isConnected = (ready && authenticated) || isInjectedWallet;
@@ -42,45 +40,31 @@ export function WidgetShell({ children }: { children: React.ReactNode }) {
       {/* Fixed full-viewport height: short steps (e.g. the pending/status
           screen) keep the footer pinned to the bottom edge instead of the
           card shrinking to fit; tall content scrolls internally above the
-          footer (the wallet header scrolls with the content). */}
+          footer. The wallet header sits outside the scroll region so it
+          stays visible while the form scrolls. */}
       <div className="flex h-dvh w-full flex-col rounded-3xl bg-white p-4 dark:bg-neutral-900">
-        <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
-        <div className="mb-3 flex min-h-10 items-center justify-end gap-2">
-          {isConnected && (
-            <>
-              <button
-                type="button"
-                title="Wallet"
-                aria-label="Open wallet"
-                onClick={() => setIsWalletDrawerOpen(true)}
-                className="flex items-center gap-1 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-white/10"
-              >
-                <Wallet01Icon className="size-5 text-outline-gray dark:text-white/80" />
-                <ArrowDown01Icon className="size-4 text-outline-gray dark:text-white/50" />
-              </button>
-              <AnimatePresence>
-                <MobileDropdown
-                  isOpen={isWalletDrawerOpen}
-                  onClose={() => setIsWalletDrawerOpen(false)}
-                />
-              </AnimatePresence>
-            </>
-          )}
-          {/* The host removes the iframe on noblocks:close; only useful when
-              we can actually reach a host. */}
-          {parentOrigin && (
+        {isConnected && (
+          <div className="mb-3 flex min-h-10 flex-shrink-0 items-center justify-end gap-2">
             <button
               type="button"
-              title="Close widget"
-              aria-label="Close widget"
-              onClick={() => postToHost("noblocks:close")}
-              className="flex size-9 items-center justify-center rounded-xl bg-gray-50 transition-colors hover:bg-gray-100 dark:bg-white/10 dark:hover:bg-white/20"
+              title="Wallet"
+              aria-label="Open wallet"
+              onClick={() => setIsWalletDrawerOpen(true)}
+              className="flex items-center gap-1 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-white/10"
             >
-              <Cancel01Icon className="size-4 text-outline-gray dark:text-white/50" />
+              <Wallet01Icon className="size-5 text-outline-gray dark:text-white/80" />
+              <ArrowDown01Icon className="size-4 text-outline-gray dark:text-white/50" />
             </button>
-          )}
-        </div>
+            <AnimatePresence>
+              <MobileDropdown
+                isOpen={isWalletDrawerOpen}
+                onClose={() => setIsWalletDrawerOpen(false)}
+              />
+            </AnimatePresence>
+          </div>
+        )}
 
+        <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
           {children}
         </div>
 

--- a/app/context/EmbedContext.tsx
+++ b/app/context/EmbedContext.tsx
@@ -17,8 +17,10 @@ import { usePathname } from "next/navigation";
  * (see middleware.ts). Exposes a postMessage channel to the host page:
  *   noblocks:ready   - widget mounted
  *   noblocks:resize  - { height } content height changed
- *   noblocks:close   - user clicked the widget close button
  *   noblocks:tx_status - { status, orderId } transaction progress
+ *
+ * Closing / dismissing the iframe is owned by the host page — the widget
+ * does not emit a close event.
  *
  * The host origin is derived from document.referrer (the embedding page on an
  * iframe's first load). If the host strips its referrer entirely, events are

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -46,9 +46,12 @@ Notes:
 - Recommended width **360–420px**. The widget renders its mobile UI below
   ~640px wide (a comfortable compact layout); above that it would switch to
   the desktop layout, so keep it narrow. Height is flexible — size it to fit
-  the flow (≈600–680px works well); the footer pins to the bottom edge.
-- The close button sits in the card header (shown only when the widget can
-  reach a host — see `noblocks:close` below).
+  the flow (≈600–680px works well); the footer pins to the bottom edge, and
+  the wallet control stays visible while the form scrolls.
+- **Dismissing the widget is your responsibility.** Provide whatever close
+  affordance fits your UX (modal backdrop click, host close button, drawer
+  handle, etc.) and remove or hide the iframe from your page. The widget
+  itself does not render a close control.
 - Do **not** set `Referrer-Policy: no-referrer` on the embedding page (or
   `referrerpolicy="no-referrer"` on the iframe). The widget derives your origin
   from the referrer to send you events; origin-level referrer
@@ -76,18 +79,17 @@ The widget posts messages to the embedding page (only to your whitelisted
 origin, never `*`). Each message is
 `{ source: "noblocks", event, payload }`:
 
-| Event                | Payload                 | Meaning                                    |
-| -------------------- | ----------------------- | ------------------------------------------ |
-| `noblocks:ready`     | —                       | Widget mounted                             |
-| `noblocks:resize`    | `{ height }`            | Content height changed (auto-size iframe)  |
-| `noblocks:close`     | —                       | User clicked the widget close button — remove/hide the iframe |
+| Event                | Payload                 | Meaning                                   |
+| -------------------- | ----------------------- | ----------------------------------------- |
+| `noblocks:ready`     | —                       | Widget mounted                            |
+| `noblocks:resize`    | `{ height }`            | Content height changed (auto-size iframe) |
 | `noblocks:tx_status` | `{ status, orderId }`   | Transaction progress (e.g. `pending`, `settled`, `refunded`) |
 
 ```js
 const iframe = document.getElementById("noblocks-widget");
 window.addEventListener("message", (e) => {
   // Check both the origin AND the source window, so another child frame at
-  // the Noblocks origin can't spoof close/resize/tx_status events.
+  // the Noblocks origin can't spoof resize/tx_status events.
   if (e.origin !== "https://noblocks.xyz") return;
   if (e.source !== iframe.contentWindow) return;
   if (e.data?.source !== "noblocks") return;
@@ -136,7 +138,6 @@ exists and the request hangs until timeout.
   const unbind = NoblocksEmbed.bindWallet(iframe, window.ethereum, {
     onEvent(event, payload) {
       if (event === "noblocks:resize") iframe.style.height = payload.height + "px";
-      if (event === "noblocks:close") iframe.remove();
     },
   });
   // Set src only after bindWallet has installed the listener.

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -46,7 +46,7 @@ Notes:
 - Recommended width **360–420px**. The widget renders its mobile UI below
   ~640px wide (a comfortable compact layout); above that it would switch to
   the desktop layout, so keep it narrow. Height is flexible — size it to fit
-  the flow (≈600–680px works well); the footer pins to the bottom edge, and
+  the flow (≈670–750px works well); the footer pins to the bottom edge, and
   the wallet control stays visible while the form scrolls.
 - **Dismissing the widget is your responsibility.** Provide whatever close
   affordance fits your UX (modal backdrop click, host close button, drawer

--- a/public/embed.js
+++ b/public/embed.js
@@ -14,7 +14,6 @@
  *       provider, // any EIP-1193 provider, e.g. window.ethereum
  *       {
  *         onEvent(event, payload) {
- *           if (event === "noblocks:close") iframe.remove();
  *           if (event === "noblocks:resize") iframe.style.height = payload.height + "px";
  *         },
  *       }
@@ -23,7 +22,8 @@
  *
  * Call bindWallet before (or immediately after) adding the iframe so no
  * request from the widget is missed. Signing prompts appear in the host
- * wallet's own UI; the widget never sees keys.
+ * wallet's own UI; the widget never sees keys. Dismissing the iframe
+ * (modal backdrop, host close control, etc.) is owned by the host page.
  */
 (function () {
   "use strict";
@@ -36,7 +36,7 @@
    *   EIP-1193 provider whose requests the widget will proxy
    * @param {{ origin?: string, onEvent?: (event: string, payload: any) => void }} [options]
    *   origin: widget origin if not noblocks.xyz (e.g. http://localhost:3000)
-   *   onEvent: called for every widget event (noblocks:ready/resize/close/tx_status)
+   *   onEvent: called for every widget event (noblocks:ready/resize/tx_status)
    * @returns {() => void} unbind function
    */
   function bindWallet(iframeEl, provider, options) {


### PR DESCRIPTION
### Description

Widget UX polish for the embeddable `/widget` experience:

- **Sticky wallet header** — when the user is connected, the wallet pill sits outside the scroll region so it stays visible while the swap form scrolls.
- **Host-owned dismiss** — the widget no longer renders a close (X) control and no longer emits `noblocks:close`. Partners dismiss the iframe with their own UX (backdrop, host close button, drawer handle, etc.).
- **Docs / SDK** — `docs/embed-widget.md` and `public/embed.js` describe the current contract (ready / resize / tx_status only) without referring to a prior close button.

### References

- Builds on the embeddable widget shipped in #609 / #611

### Testing

- Load `/widget` in an iframe from a whitelisted origin
- Connect a wallet and scroll a tall step (e.g. recipient / preview) — wallet pill remains visible at the top
- Confirm there is no close (X) control in the widget chrome
- Confirm host still receives `noblocks:ready`, `noblocks:resize`, and `noblocks:tx_status` as needed
- Confirm `?injected=bridge` + `embed.js` still works (examples no longer reference a close event)
- Environment: widget embed against `stable` (or local with `NEXT_PUBLIC_EMBED_ENABLED=true`)

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
