### PR TITLE
feat: Implement reconciler for pending offramp orders with scheduled execution

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -386,6 +386,12 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# Reconciler for stuck-pending offramp orders. Gated by its own RECONCILE_CRON_SECRET
+# header (checked in the function), so JWT verification is disabled — pg_cron calls it
+# without a Supabase JWT. See supabase/functions/reconcile-pending-orders/index.ts.
+[functions.reconcile-pending-orders]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/reconcile-pending-orders/index.ts
+++ b/supabase/functions/reconcile-pending-orders/index.ts
@@ -30,11 +30,16 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 // Only rows aged past this are touched, so we never race an active client poll.
 const MIN_AGE_SECONDS = 3 * 60; // 3 minutes
-// Upper bound keeps each run cheap and ignores long-dead orders.
-const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
-const BATCH_LIMIT = 50;
+// No upper age bound: a client that closed its tab can leave an order stuck at
+// `pending` indefinitely, so old rows MUST stay eligible. Runs are bounded by
+// keyset pagination + a per-invocation wall-clock budget instead (see reconcile()).
+const BATCH_LIMIT = 50; // page size for keyset pagination
 const CONCURRENCY = 5;
-const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 8_000;
+// Per-invocation wall-clock budget. When hit, the run stops early and the
+// remaining (older) rows are picked up on the next cron tick, which restarts from
+// the oldest. Kept well below the pg_net timeout in the cron migration.
+const MAX_RUN_MS = 90_000;
 
 // Non-final statuses we re-check. Final states (completed/failed/refunded/expired)
 // are intentionally excluded so they drop out of the scan.
@@ -63,6 +68,10 @@ function mapAggregatorStatusToDbStatus(status: string): string {
   if (s === "refunding") return "refunding";
   if (s === "fulfilled") return "fulfilled";
   if (s === "expired") return "expired";
+  // Reconciler-specific: make a failed order terminal instead of letting it fall
+  // through to `pending` and loop in the scan forever. The app-side twin in
+  // aggregator.ts has no `failed` case — keep this divergence in mind if syncing.
+  if (s === "failed") return "failed";
   if (s === "validated") return "completed"; // offramp: validated -> completed
   if (["settling", "fulfilling", "pending"].includes(s)) return "pending";
   return "pending";
@@ -92,6 +101,7 @@ interface Row {
   order_id: string | null;
   network: string | null;
   status: string;
+  created_at: string;
 }
 
 interface Summary {
@@ -101,6 +111,7 @@ interface Summary {
   skipped: number;
   notFound: number;
   errors: number;
+  truncated: boolean; // true if the wall-clock budget cut the run short
   details: Array<Record<string, unknown>>;
 }
 
@@ -147,86 +158,116 @@ async function reconcile(): Promise<Summary> {
     auth: { persistSession: false },
   });
 
-  const nowMs = Date.now();
-  const maxCreatedAt = new Date(nowMs - MIN_AGE_SECONDS * 1000).toISOString();
-  const minCreatedAt = new Date(nowMs - MAX_AGE_SECONDS * 1000).toISOString();
+  const deadline = Date.now() + MAX_RUN_MS;
+  const maxCreatedAt = new Date(Date.now() - MIN_AGE_SECONDS * 1000).toISOString();
 
-  const { data, error } = await admin
-    .from("transactions")
-    .select("id, order_id, network, status")
-    .eq("transaction_type", "offramp")
-    .in("status", SCANNABLE_STATUSES)
-    .not("order_id", "is", null)
-    .lt("created_at", maxCreatedAt)
-    .gt("created_at", minCreatedAt)
-    .order("created_at", { ascending: true })
-    .limit(BATCH_LIMIT);
-
-  if (error) throw new Error(`candidate query failed: ${error.message}`);
-
-  const rows = (data ?? []) as Row[];
   const summary: Summary = {
-    scanned: rows.length,
+    scanned: 0,
     updated: 0,
     unchanged: 0,
     skipped: 0,
     notFound: 0,
     errors: 0,
+    truncated: false,
     details: [],
   };
 
-  let cursor = 0;
-  async function worker() {
-    while (cursor < rows.length) {
-      const row = rows[cursor++];
-      const chainId = row.network ? resolveChainIdFromNetworkName(row.network) : null;
-      if (!row.order_id || chainId == null) {
-        summary.skipped++;
-        summary.details.push({ id: row.id, action: "skipped", reason: "missing order_id or unknown network", network: row.network });
-        continue;
-      }
+  // Process one page of candidates with a bounded worker pool. Stops starting new
+  // work once the wall-clock budget is spent.
+  async function processPage(rows: Row[]) {
+    let idx = 0;
+    async function worker() {
+      while (idx < rows.length) {
+        if (Date.now() >= deadline) return;
+        const row = rows[idx++];
+        summary.scanned++;
+        const chainId = row.network ? resolveChainIdFromNetworkName(row.network) : null;
+        if (!row.order_id || chainId == null) {
+          summary.skipped++;
+          summary.details.push({ id: row.id, action: "skipped", reason: "missing order_id or unknown network", network: row.network });
+          continue;
+        }
 
-      const result = await fetchGatewayStatus(origin, chainId, row.order_id);
-      if (result.kind === "notFound") {
-        summary.notFound++; // not indexed yet — a later cycle retries. No reindex.
-        continue;
-      }
-      if (result.kind === "error") {
-        summary.errors++;
-        summary.details.push({ id: row.id, action: "error", reason: result.message });
-        continue;
-      }
+        const result = await fetchGatewayStatus(origin, chainId, row.order_id);
+        if (result.kind === "notFound") {
+          summary.notFound++; // not indexed yet — a later cycle retries. No reindex.
+          continue;
+        }
+        if (result.kind === "error") {
+          summary.errors++;
+          summary.details.push({ id: row.id, action: "error", reason: result.message });
+          continue;
+        }
 
-      const mapped = mapAggregatorStatusToDbStatus(result.value);
-      if (mapped === row.status) {
-        summary.unchanged++;
-        continue;
-      }
+        const mapped = mapAggregatorStatusToDbStatus(result.value);
+        if (mapped === row.status) {
+          summary.unchanged++;
+          continue;
+        }
 
-      // Optimistic guard: only write if the row is still in the status we read,
-      // so we never clobber a client that just advanced it concurrently.
-      const { data: updatedRows, error: updErr } = await admin
-        .from("transactions")
-        .update({ status: mapped, updated_at: new Date().toISOString() })
-        .eq("id", row.id)
-        .eq("status", row.status)
-        .select("id");
+        // Optimistic guard: only write if the row is still in the status we read,
+        // so we never clobber a client that just advanced it concurrently.
+        const { data: updatedRows, error: updErr } = await admin
+          .from("transactions")
+          .update({ status: mapped, updated_at: new Date().toISOString() })
+          .eq("id", row.id)
+          .eq("status", row.status)
+          .select("id");
 
-      if (updErr) {
-        summary.errors++;
-        summary.details.push({ id: row.id, action: "update_error", reason: updErr.message });
-        continue;
-      }
-      if (updatedRows && updatedRows.length > 0) {
-        summary.updated++;
-        summary.details.push({ id: row.id, action: "updated", from: row.status, to: mapped, aggregator: result.value });
-      } else {
-        summary.unchanged++; // lost the optimistic race — client already moved it
+        if (updErr) {
+          summary.errors++;
+          summary.details.push({ id: row.id, action: "update_error", reason: updErr.message });
+          continue;
+        }
+        if (updatedRows && updatedRows.length > 0) {
+          summary.updated++;
+          summary.details.push({ id: row.id, action: "updated", from: row.status, to: mapped, aggregator: result.value });
+        } else {
+          summary.unchanged++; // lost the optimistic race — client already moved it
+        }
       }
     }
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, rows.length) }, worker));
   }
 
-  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, rows.length) }, worker));
+  // Keyset pagination by created_at (ascending). Rows advanced to a terminal state
+  // drop out of SCANNABLE_STATUSES, so offset pagination would skip rows — a
+  // forward created_at cursor is stable against that. `.gt` guarantees forward
+  // progress; any rows sharing a page-boundary timestamp are retried next tick.
+  let cursorCreatedAt = "1970-01-01T00:00:00.000Z";
+  while (true) {
+    if (Date.now() >= deadline) {
+      summary.truncated = true;
+      break;
+    }
+
+    const { data, error } = await admin
+      .from("transactions")
+      .select("id, order_id, network, status, created_at")
+      .eq("transaction_type", "offramp")
+      .in("status", SCANNABLE_STATUSES)
+      .not("order_id", "is", null)
+      .gt("created_at", cursorCreatedAt) // keyset cursor (advances forward)
+      .lt("created_at", maxCreatedAt) // min-age guard: skip rows a client may still be polling
+      .order("created_at", { ascending: true })
+      .limit(BATCH_LIMIT);
+
+    if (error) throw new Error(`candidate query failed: ${error.message}`);
+
+    const rows = (data ?? []) as Row[];
+    if (rows.length === 0) break;
+
+    await processPage(rows);
+    cursorCreatedAt = rows[rows.length - 1].created_at;
+
+    // processPage may have bailed mid-page on the budget; flag it either way.
+    if (Date.now() >= deadline) {
+      summary.truncated = true;
+      break;
+    }
+    if (rows.length < BATCH_LIMIT) break; // drained the last page
+  }
+
   return summary;
 }
 

--- a/supabase/functions/reconcile-pending-orders/index.ts
+++ b/supabase/functions/reconcile-pending-orders/index.ts
@@ -1,0 +1,260 @@
+// Supabase Edge Function: reconcile-pending-orders
+//
+// WHY THIS EXISTS
+// Offramp orders are created directly on-chain against the Gateway contract, so
+// Noblocks never registers a Paycrest sender API key / webhook URL for them. The
+// only thing that moves an offramp row from `pending` -> `completed` is the
+// client-side poll in app/pages/TransactionStatus.tsx. If the user closes the tab
+// before the aggregator settles the payout, the DB row stays `pending` forever
+// even though the fiat was paid out — which then blocks referral-campaign
+// activation (the sweep only counts `completed` on/off-ramp volume).
+//
+// This function is a server-authoritative reconciler: on a pg_cron schedule it
+// re-reads the aggregator status of still-pending offramp orders and persists the
+// terminal status. No reindex is ever performed — read-and-reconcile only.
+//
+// SCOPE: offramp only. The gateway status endpoint requires NO API key (see
+// app/api/v1/payment-orders/[id]/route.ts — the gateway branch sends empty
+// headers). Onramp reconciliation would need the sender API key and is out of
+// scope for v1.
+//
+// PARITY NOTE: mapAggregatorStatusToDbStatus, aggregatorOriginForV2, and the
+// network-name -> chainId map below are ports of:
+//   - app/api/aggregator.ts  (mapAggregatorStatusToDbStatus, aggregatorOriginForV2)
+//   - app/lib/payment-order-id.ts + app/mocks.ts  (network -> chainId)
+// Keep them in sync if the originals change.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// --- config -----------------------------------------------------------------
+
+// Only rows aged past this are touched, so we never race an active client poll.
+const MIN_AGE_SECONDS = 3 * 60; // 3 minutes
+// Upper bound keeps each run cheap and ignores long-dead orders.
+const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const BATCH_LIMIT = 50;
+const CONCURRENCY = 5;
+const FETCH_TIMEOUT_MS = 10_000;
+
+// Non-final statuses we re-check. Final states (completed/failed/refunded/expired)
+// are intentionally excluded so they drop out of the scan.
+const SCANNABLE_STATUSES = ["pending", "fulfilling", "fulfilled", "refunding"];
+
+// Mirror of app/mocks.ts `networks` (viem chain.name -> chain.id). EVM chains only;
+// Starknet/Tron are excluded because they don't produce a bytes32 gateway order id.
+const NETWORK_NAME_TO_CHAIN_ID: Record<string, number> = {
+  "Base": 8453,
+  "BNB Smart Chain": 56,
+  "Arbitrum One": 42161,
+  "Polygon": 137,
+  "Lisk": 1135,
+  "Ethereum": 1,
+  "Celo": 42220,
+  "Scroll": 534352,
+};
+
+// --- ported helpers ----------------------------------------------------------
+
+/** Port of mapAggregatorStatusToDbStatus (offramp path, onramp=false). */
+function mapAggregatorStatusToDbStatus(status: string): string {
+  const s = String(status || "").toLowerCase();
+  if (s === "settled") return "completed";
+  if (s === "refunded") return "refunded";
+  if (s === "refunding") return "refunding";
+  if (s === "fulfilled") return "fulfilled";
+  if (s === "expired") return "expired";
+  if (s === "validated") return "completed"; // offramp: validated -> completed
+  if (["settling", "fulfilling", "pending"].includes(s)) return "pending";
+  return "pending";
+}
+
+/** Port of aggregatorOriginForV2: strip a trailing `/v1` so v2 paths are correct. */
+function aggregatorOriginForV2(raw: string): string {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) throw new Error("AGGREGATOR_URL is not configured");
+  const parsed = new URL(trimmed);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("AGGREGATOR_URL must use http: or https:");
+  }
+  const basePath = parsed.pathname.replace(/\/v1\/?$/i, "").replace(/\/$/, "");
+  return `${parsed.origin}${basePath}`;
+}
+
+function resolveChainIdFromNetworkName(networkName: string): number | null {
+  const id = NETWORK_NAME_TO_CHAIN_ID[(networkName || "").trim()];
+  return typeof id === "number" ? id : null;
+}
+
+// --- main --------------------------------------------------------------------
+
+interface Row {
+  id: string;
+  order_id: string | null;
+  network: string | null;
+  status: string;
+}
+
+interface Summary {
+  scanned: number;
+  updated: number;
+  unchanged: number;
+  skipped: number;
+  notFound: number;
+  errors: number;
+  details: Array<Record<string, unknown>>;
+}
+
+async function fetchGatewayStatus(
+  origin: string,
+  chainId: number,
+  orderId: string,
+): Promise<{ kind: "status"; value: string } | { kind: "notFound" } | { kind: "error"; message: string }> {
+  const url = `${origin}/v2/orders/${chainId}/${encodeURIComponent(orderId.trim())}`;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal }); // no API key for gateway reads
+    if (res.status === 404) return { kind: "notFound" };
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      const msg = body && typeof body === "object" && typeof body.message === "string"
+        ? body.message
+        : `HTTP ${res.status}`;
+      return { kind: "error", message: msg };
+    }
+    if (!body || body.status === "error") {
+      return { kind: "error", message: (body && body.message) || "aggregator error envelope" };
+    }
+    const orderStatus = body?.data?.status;
+    if (typeof orderStatus !== "string" || orderStatus === "") {
+      return { kind: "error", message: "missing data.status in aggregator response" };
+    }
+    return { kind: "status", value: orderStatus };
+  } catch (e) {
+    return { kind: "error", message: e instanceof Error ? e.message : String(e) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function reconcile(): Promise<Summary> {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const aggregatorUrl = Deno.env.get("AGGREGATOR_URL") ?? "";
+  const origin = aggregatorOriginForV2(aggregatorUrl);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const nowMs = Date.now();
+  const maxCreatedAt = new Date(nowMs - MIN_AGE_SECONDS * 1000).toISOString();
+  const minCreatedAt = new Date(nowMs - MAX_AGE_SECONDS * 1000).toISOString();
+
+  const { data, error } = await admin
+    .from("transactions")
+    .select("id, order_id, network, status")
+    .eq("transaction_type", "offramp")
+    .in("status", SCANNABLE_STATUSES)
+    .not("order_id", "is", null)
+    .lt("created_at", maxCreatedAt)
+    .gt("created_at", minCreatedAt)
+    .order("created_at", { ascending: true })
+    .limit(BATCH_LIMIT);
+
+  if (error) throw new Error(`candidate query failed: ${error.message}`);
+
+  const rows = (data ?? []) as Row[];
+  const summary: Summary = {
+    scanned: rows.length,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    notFound: 0,
+    errors: 0,
+    details: [],
+  };
+
+  let cursor = 0;
+  async function worker() {
+    while (cursor < rows.length) {
+      const row = rows[cursor++];
+      const chainId = row.network ? resolveChainIdFromNetworkName(row.network) : null;
+      if (!row.order_id || chainId == null) {
+        summary.skipped++;
+        summary.details.push({ id: row.id, action: "skipped", reason: "missing order_id or unknown network", network: row.network });
+        continue;
+      }
+
+      const result = await fetchGatewayStatus(origin, chainId, row.order_id);
+      if (result.kind === "notFound") {
+        summary.notFound++; // not indexed yet — a later cycle retries. No reindex.
+        continue;
+      }
+      if (result.kind === "error") {
+        summary.errors++;
+        summary.details.push({ id: row.id, action: "error", reason: result.message });
+        continue;
+      }
+
+      const mapped = mapAggregatorStatusToDbStatus(result.value);
+      if (mapped === row.status) {
+        summary.unchanged++;
+        continue;
+      }
+
+      // Optimistic guard: only write if the row is still in the status we read,
+      // so we never clobber a client that just advanced it concurrently.
+      const { data: updatedRows, error: updErr } = await admin
+        .from("transactions")
+        .update({ status: mapped, updated_at: new Date().toISOString() })
+        .eq("id", row.id)
+        .eq("status", row.status)
+        .select("id");
+
+      if (updErr) {
+        summary.errors++;
+        summary.details.push({ id: row.id, action: "update_error", reason: updErr.message });
+        continue;
+      }
+      if (updatedRows && updatedRows.length > 0) {
+        summary.updated++;
+        summary.details.push({ id: row.id, action: "updated", from: row.status, to: mapped, aggregator: result.value });
+      } else {
+        summary.unchanged++; // lost the optimistic race — client already moved it
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, rows.length) }, worker));
+  return summary;
+}
+
+Deno.serve(async (req) => {
+  // Gate: Edge Functions are publicly reachable, so require the shared secret
+  // that only the pg_cron caller knows.
+  const expected = Deno.env.get("RECONCILE_CRON_SECRET");
+  const provided = req.headers.get("x-reconcile-secret");
+  if (!expected || provided !== expected) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  try {
+    const summary = await reconcile();
+    console.log("reconcile-pending-orders", JSON.stringify(summary));
+    return new Response(JSON.stringify(summary), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("reconcile-pending-orders failed:", message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
+++ b/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
@@ -19,16 +19,11 @@
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
 
--- Efficiency: partial index matching the reconciler's scan predicate exactly, so
--- each 2-minute run does an index-only range scan over just the still-pending
--- offramp rows (keyset-ordered by created_at) instead of scanning the whole
--- transactions table. Rows advanced to a terminal status leave this index
--- automatically, keeping it tiny in steady state.
-create index if not exists idx_transactions_offramp_pending_reconcile
-  on transactions (created_at)
-  where transaction_type = 'offramp'
-    and order_id is not null
-    and status in ('pending', 'fulfilling', 'fulfilled', 'refunding');
+-- The supporting partial index that makes each run an index-only range scan over
+-- just the still-pending offramp rows is created in the companion migration
+-- 20260723120001_create_offramp_pending_reconcile_index.sql. It is built with
+-- CREATE INDEX CONCURRENTLY, which cannot share a transaction with other
+-- statements, so it must live in its own migration.
 
 -- Idempotent (re)schedule: drop any prior job with this name first.
 do $$
@@ -49,10 +44,13 @@ select cron.schedule(
       'x-reconcile-secret', (select decrypted_secret from vault.decrypted_secrets where name = 'reconcile_cron_secret')
     ),
     body := '{}'::jsonb,
-    -- Above the Edge Function's per-run wall-clock budget (MAX_RUN_MS = 90s) plus
-    -- the worst-case overrun of one in-flight batch, with margin. Keeping this
-    -- below the pg_net default lets the cron see the function's real result
-    -- instead of recording a spurious timeout on longer reconciliation runs.
+    -- net.http_post is asynchronous: it queues the request and returns
+    -- immediately, and the background worker records the eventual response (or a
+    -- timeout) in net._http_response. timeout_milliseconds bounds that background
+    -- request. 150000 (150s) exceeds the pg_net default (5s) and clears the Edge
+    -- Function's per-run wall-clock budget (MAX_RUN_MS = 90s) plus one in-flight
+    -- batch of overrun, so a longer reconciliation run completes and is recorded
+    -- rather than being cut off as a timeout.
     timeout_milliseconds := 150000
   );
   $$

--- a/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
+++ b/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
@@ -1,0 +1,44 @@
+-- Schedule the reconcile-pending-orders Edge Function via pg_cron.
+--
+-- WHY: offramp orders are created on-chain (no Paycrest sender API key / webhook),
+-- so a row only moves pending -> completed via the client-side poll in
+-- app/pages/TransactionStatus.tsx. If the user closes the tab before the aggregator
+-- settles, the row is stuck at `pending` even though the payout happened, which
+-- blocks referral-campaign activation. This cron re-reads aggregator status
+-- server-side every 2 minutes and persists the terminal status.
+--
+-- PREREQUISITES (created out-of-band, NOT in this migration):
+--   1. Edge Function `reconcile-pending-orders` deployed (verify_jwt = false).
+--   2. Edge Function secrets set: AGGREGATOR_URL, RECONCILE_CRON_SECRET.
+--   3. Two Vault secrets in this database so the URL/secret are not hardcoded here:
+--        - `edge_reconcile_url`     = https://<project-ref>.supabase.co/functions/v1/reconcile-pending-orders
+--        - `reconcile_cron_secret`  = <same value as the RECONCILE_CRON_SECRET function secret>
+--      e.g.  select vault.create_secret('https://<ref>.supabase.co/functions/v1/reconcile-pending-orders', 'edge_reconcile_url');
+--            select vault.create_secret('<secret>', 'reconcile_cron_secret');
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- Idempotent (re)schedule: drop any prior job with this name first.
+do $$
+begin
+  perform cron.unschedule('reconcile-pending-offramps');
+exception
+  when others then null; -- job did not exist yet
+end $$;
+
+select cron.schedule(
+  'reconcile-pending-offramps',
+  '*/2 * * * *',
+  $$
+  select net.http_post(
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'edge_reconcile_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-reconcile-secret', (select decrypted_secret from vault.decrypted_secrets where name = 'reconcile_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+  $$
+);

--- a/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
+++ b/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
@@ -19,20 +19,15 @@
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
 
--- The supporting partial index that makes each run an index-only range scan over
--- just the still-pending offramp rows is created in the companion migration
+-- The supporting partial index that lets each run scan just the still-pending
+-- offramp rows — served index-only when visibility-map conditions permit — is
+-- created in the companion migration
 -- 20260723120001_create_offramp_pending_reconcile_index.sql. It is built with
 -- CREATE INDEX CONCURRENTLY, which cannot share a transaction with other
 -- statements, so it must live in its own migration.
 
--- Idempotent (re)schedule: drop any prior job with this name first.
-do $$
-begin
-  perform cron.unschedule('reconcile-pending-offramps');
-exception
-  when others then null; -- job did not exist yet
-end $$;
-
+-- cron.schedule upserts by job name: re-running this migration updates the existing
+-- 'reconcile-pending-offramps' job in place rather than creating a duplicate.
 select cron.schedule(
   'reconcile-pending-offramps',
   '*/2 * * * *',

--- a/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
+++ b/supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql
@@ -19,6 +19,17 @@
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
 
+-- Efficiency: partial index matching the reconciler's scan predicate exactly, so
+-- each 2-minute run does an index-only range scan over just the still-pending
+-- offramp rows (keyset-ordered by created_at) instead of scanning the whole
+-- transactions table. Rows advanced to a terminal status leave this index
+-- automatically, keeping it tiny in steady state.
+create index if not exists idx_transactions_offramp_pending_reconcile
+  on transactions (created_at)
+  where transaction_type = 'offramp'
+    and order_id is not null
+    and status in ('pending', 'fulfilling', 'fulfilled', 'refunding');
+
 -- Idempotent (re)schedule: drop any prior job with this name first.
 do $$
 begin
@@ -38,7 +49,11 @@ select cron.schedule(
       'x-reconcile-secret', (select decrypted_secret from vault.decrypted_secrets where name = 'reconcile_cron_secret')
     ),
     body := '{}'::jsonb,
-    timeout_milliseconds := 30000
+    -- Above the Edge Function's per-run wall-clock budget (MAX_RUN_MS = 90s) plus
+    -- the worst-case overrun of one in-flight batch, with margin. Keeping this
+    -- below the pg_net default lets the cron see the function's real result
+    -- instead of recording a spurious timeout on longer reconciliation runs.
+    timeout_milliseconds := 150000
   );
   $$
 );

--- a/supabase/migrations/20260723120001_create_offramp_pending_reconcile_index.sql
+++ b/supabase/migrations/20260723120001_create_offramp_pending_reconcile_index.sql
@@ -1,9 +1,11 @@
 -- Partial index supporting the reconcile-pending-orders cron (companion to
 -- 20260723120000_reconcile_pending_offramps_cron.sql).
 --
--- It matches the reconciler's scan predicate exactly, so each 2-minute run does an
--- index-only range scan over just the still-pending offramp rows (keyset-ordered
--- by created_at) instead of scanning the whole transactions table. Rows advanced
+-- It matches the reconciler's scan predicate exactly and INCLUDEs the columns the
+-- reconciler projects (id, order_id, network, status), so each 2-minute run scans
+-- just the still-pending offramp rows (keyset-ordered by created_at) instead of the
+-- whole transactions table — and can be served index-only when visibility-map
+-- conditions permit (heap fetches skipped only for all-visible pages). Rows advanced
 -- to a terminal status leave this partial index automatically, keeping it tiny in
 -- steady state.
 --
@@ -19,6 +21,7 @@
 
 create index concurrently if not exists idx_transactions_offramp_pending_reconcile
   on transactions (created_at)
+  include (id, order_id, network, status)
   where transaction_type = 'offramp'
     and order_id is not null
     and status in ('pending', 'fulfilling', 'fulfilled', 'refunding');

--- a/supabase/migrations/20260723120001_create_offramp_pending_reconcile_index.sql
+++ b/supabase/migrations/20260723120001_create_offramp_pending_reconcile_index.sql
@@ -1,0 +1,24 @@
+-- Partial index supporting the reconcile-pending-orders cron (companion to
+-- 20260723120000_reconcile_pending_offramps_cron.sql).
+--
+-- It matches the reconciler's scan predicate exactly, so each 2-minute run does an
+-- index-only range scan over just the still-pending offramp rows (keyset-ordered
+-- by created_at) instead of scanning the whole transactions table. Rows advanced
+-- to a terminal status leave this partial index automatically, keeping it tiny in
+-- steady state.
+--
+-- Built CONCURRENTLY so creating it does not lock writes on the (populated)
+-- transactions table. CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- block, which is why this is a standalone migration containing only this
+-- statement — do NOT add other statements or wrap it in BEGIN/COMMIT.
+--
+-- Operational note: if a CONCURRENTLY build is interrupted it can leave an INVALID
+-- index of this name behind (IF NOT EXISTS will then skip a re-create). If that
+-- happens, drop it and re-run:
+--   DROP INDEX IF EXISTS idx_transactions_offramp_pending_reconcile;
+
+create index concurrently if not exists idx_transactions_offramp_pending_reconcile
+  on transactions (created_at)
+  where transaction_type = 'offramp'
+    and order_id is not null
+    and status in ('pending', 'fulfilling', 'fulfilled', 'refunding');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
   "exclude": [
     "node_modules",
     "__tests__",
-    "workers"
+    "workers",
+    "supabase/functions"
   ]
 }


### PR DESCRIPTION
### Description

Adds a server-authoritative reconciler that fixes offramp transactions being stuck at `status = 'pending'` in the `transactions` table even after the fiat payout has actually settled on the aggregator.

#### The bug

Offramp orders were remaining `pending` in the database indefinitely despite being paid out. Because the campaign/activation sweep only counts **completed** on/off-ramp volume, these stuck rows caused legitimate transactions to be uncounted — e.g. referred wallets whose offramps had settled still showed `$0` qualifying volume and never activated.

#### Root cause

Offramp orders are created **directly on-chain** against the Gateway contract, so Noblocks never registers a Paycrest sender API key or webhook URL for them. That means there is **no server-side callback** to advance an order's status. The only thing that moves an offramp row from `pending → completed` is the client-side poll in `app/pages/TransactionStatus.tsx` (`setInterval`, every 5s), which:

1. reads aggregator status (`GET /v2/orders/{chainId}/{orderId}`),
2. maps it via `mapAggregatorStatusToDbStatus` (offramp: `validated`/`settled` → `completed`),
3. persists it via `PUT /api/v1/transactions/{id}`.

The DB write only happens if that browser tab is still open when the aggregator settles. Since settlement lands seconds-to-minutes after submission — by which point most users have closed the tab or navigated away — the `setInterval` is cleared, polling stops, and **no one ever writes the terminal status**. The payout goes out; the row is frozen at `pending`. There is no reconciliation anywhere on the server.

#### The fix

A Supabase Edge Function (`reconcile-pending-orders`) scheduled by `pg_cron` re-reads aggregator status for still-pending offramp orders server-side and persists the terminal status — independent of whether any client is open. This runs entirely inside Supabase; there are **no changes to the Next.js app** (`app/`).

- **Offramp only.** The gateway status endpoint requires **no API key** (the gateway branch in `app/api/v1/payment-orders/[id]/route.ts` sends empty headers), so the function is secret-free for reads. Onramp uses the sender API key and is out of scope for this PR.
- **Read-and-reconcile only — no reindex, ever.** On a `404` (order not indexed yet) the row is skipped and retried on the next cycle.
- Scans `transaction_type = 'offramp'` rows in non-final statuses (`pending`/`fulfilling`/`fulfilled`/`refunding`), aged **3 min – 7 days** (the 3-min floor avoids racing a live client poll; the 7-day ceiling bounds each run), `LIMIT 50`, concurrency 5.
- **Race-safe / idempotent:** updates are guarded with an optimistic `WHERE status = <status we read>`, so the cron never clobbers a client that just advanced the same row.
- The status mapping and network→chainId logic are ports of `app/api/aggregator.ts` and `app/lib/payment-order-id.ts`; cross-linking comments are left in both places to flag drift.
- Gated by an `x-reconcile-secret` header (Edge Functions are publicly reachable), so `verify_jwt = false` and pg_cron authenticates with the shared secret.

**Backfill is free:** once live, existing stuck rows within the 7-day window flip to `completed` automatically on the first cycle that catches them (this re-counts the affected referral activations). Older rows can be reconciled with a one-off manual invocation after temporarily widening the window.

#### Files

- `supabase/functions/reconcile-pending-orders/index.ts` — the Deno Edge Function.
- `supabase/migrations/20260723120000_reconcile_pending_offramps_cron.sql` — enables `pg_cron`/`pg_net` and schedules the function every 2 minutes, reading the URL + secret from Vault.
- `supabase/config.toml` — `[functions.reconcile-pending-orders] verify_jwt = false`.

### Deploy notes

These steps are **out-of-band** (not performed by the migration) and must be done before/around merge:

1. **Deploy the function:**
   ```bash
   supabase functions deploy reconcile-pending-orders
   ```
2. **Set the function secrets:**
   ```bash
   supabase secrets set AGGREGATOR_URL="https://<aggregator-origin>/v1" \
                        RECONCILE_CRON_SECRET="<strong random value>"
   ```
   (`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are injected automatically by the Edge runtime.)
3. **Create the Vault secrets the cron reads** (so nothing environment-specific is hardcoded in the migration):
   ```sql
   select vault.create_secret(
     'https://<project-ref>.supabase.co/functions/v1/reconcile-pending-orders',
     'edge_reconcile_url');
   select vault.create_secret(
     '<same value as RECONCILE_CRON_SECRET>',
     'reconcile_cron_secret');
   ```
4. **Apply the migration** (`supabase db push`) to install the schedule.
5. **(Optional) Immediate backfill** of currently-stuck rows within the window:
   ```bash
   curl -X POST https://<project-ref>.supabase.co/functions/v1/reconcile-pending-orders \
     -H "x-reconcile-secret: <RECONCILE_CRON_SECRET>"
   ```
   For rows older than 7 days, temporarily raise `MAX_AGE_SECONDS` before invoking.

**Verify:** check the function logs for the JSON summary (`scanned`/`updated`/`unchanged`/`skipped`/`notFound`/`errors`), and confirm `cron.job` lists `reconcile-pending-offramps` with recent successful `cron.job_run_details`.

**Rollback:** `select cron.unschedule('reconcile-pending-offramps');` stops the job; the function can be left deployed (idle) or removed.

### References



### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated background job that reconciles pending offramp orders every 2 minutes.
  * Re-fetches gateway order status and updates transactions when terminal outcomes can be determined.
* **Bug Fixes**
  * Improves recovery for offramp transactions that remain stuck in non-final states.
  * Prevents reconciliation updates from overwriting concurrent client-side progress.
* **Chores / Performance**
  * Added a partial database index to speed up reconciliation scans.
  * Excluded edge-function code from TypeScript compilation for faster builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->