### PR TITLE
feat: Implement end-of-campaign announcement for Noblocks Play (#614)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,7 +207,12 @@ KYC_DOCUMENTS_BUCKET=kyc-documents
 # Format: ISO 8601 with timezone (YYYY-MM-DDTHH:mm:ss±HH:mm)
 # Example: 2025-10-11T23:59:00+01:00 (October 11th, 2025 at 11:59 PM UTC+1)
 NEXT_PUBLIC_BLOCKFEST_END_DATE=2025-10-11T23:59:00+01:00
-# World Cup footer Lottie (requires NEXT_PUBLIC_FANTASY_ENABLED=true; ends Jul 19 2026 by default)
+# Noblocks Play (fantasy league). Keep ENABLED=true for /play announcement + /play/admin.
+NEXT_PUBLIC_FANTASY_ENABLED=true
+# When true, public /play shows the campaign-ended announcement (deep links redirect to /play).
+# /play/admin stays available. Flip false to revive a live league after rebranding.
+NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED=true
+# World Cup footer Lottie (requires fantasy enabled and not campaign-ended; ends Jul 19 2026 by default)
 NEXT_PUBLIC_WORLDCUP_FOOTER_END_DATE=2026-07-19T23:59:59+01:00
 
 # BlockFest Cashback Wallet

--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -36,8 +36,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const isBareExperience = isPlayExperience || isWidgetExperience;
   const isHomepage = pathname === "/";
   const playPromoBannerVisible = usePlayPromoBannerVisible();
-  const showPlayPromoBanner =
-    isHomepage && config.fantasyEnabled && playPromoBannerVisible;
+  const showPlayPromo =
+    isHomepage && config.fantasyEnabled && !config.fantasyCampaignEnded;
+  const showPlayPromoBanner = showPlayPromo && playPromoBannerVisible;
 
   // The Brevo widget appends its own container directly to <body>, outside
   // this component's tree, so a body-level class (not a wrapper div class)
@@ -93,10 +94,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <MainContent>{children}</MainContent>
             </LayoutWrapper>
 
-            {isHomepage && <PlayPromoButton />}
+            {showPlayPromo && <PlayPromoButton />}
             <PWAInstall />
             <MaintenanceNoticeModal />
-            {isHomepage && <PlayPromoModal />}
+            {showPlayPromo && <PlayPromoModal />}
           </div>
         )}
         {/* Brevo Chat Widget */}

--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -176,7 +176,8 @@ export function PlayPromoModal() {
   }, []);
 
   useEffect(() => {
-    if (!mounted || !config.fantasyEnabled) return;
+    if (!mounted || !config.fantasyEnabled || config.fantasyCampaignEnded)
+      return;
     if (isModalDismissed()) return;
     const timer = setTimeout(() => setIsOpen(true), 500);
     return () => clearTimeout(timer);
@@ -187,7 +188,8 @@ export function PlayPromoModal() {
     setIsOpen(false);
   }, []);
 
-  if (!config.fantasyEnabled || !mounted) return null;
+  if (!config.fantasyEnabled || config.fantasyCampaignEnded || !mounted)
+    return null;
 
   return (
     <AnimatePresence>
@@ -348,7 +350,13 @@ export function PlayPromoBanner() {
     setDismissed(true);
   }, []);
 
-  if (!config.fantasyEnabled || !ready || dismissed) return null;
+  if (
+    !config.fantasyEnabled ||
+    config.fantasyCampaignEnded ||
+    !ready ||
+    dismissed
+  )
+    return null;
 
   return (
     <>
@@ -477,7 +485,8 @@ export function PlayPromoButton() {
 
   // Only takes the banner's place: hidden while the banner is showing, and
   // gone entirely once the campaign (fantasy) is switched off.
-  if (!config.fantasyEnabled || bannerVisible) return null;
+  if (!config.fantasyEnabled || config.fantasyCampaignEnded || bannerVisible)
+    return null;
 
   return (
     <motion.div

--- a/app/components/play/CampaignEnded.tsx
+++ b/app/components/play/CampaignEnded.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * End-of-campaign announcement for Noblocks Play (World Cup sunset).
+ * Shown at /play when fantasyCampaignEnded; deep links redirect here.
+ */
+
+import Link from "next/link";
+import { ArrowUpRight01Icon, NewTwitterIcon } from "hugeicons-react";
+import {
+  PlayCard,
+  primaryButtonClasses,
+  secondaryButtonClasses,
+} from "@/app/components/play/ui";
+
+const X_URL = "https://x.com/noblocks_xyz";
+
+export const CampaignEnded = () => (
+  <div className="mx-auto flex w-full max-w-xl flex-col gap-6 py-6 sm:py-10">
+    <div className="space-y-3 text-center">
+      <p className="text-xs font-semibold uppercase tracking-wider text-lavender-500">
+        Noblocks Play
+      </p>
+      <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
+        World Cup fantasy league is over
+      </h1>
+      <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
+        Thanks for playing. Follow us on X for the winners announcement.
+      </p>
+    </div>
+
+    <PlayCard className="space-y-3 sm:p-6">
+      <p className="text-sm leading-relaxed text-text-body dark:text-white/80">
+        Noblocks Play will be back for the Premier League and Champions League
+        — stay tuned.
+      </p>
+      <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
+        <a
+          href={X_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${primaryButtonClasses} inline-flex items-center justify-center gap-2`}
+        >
+          <NewTwitterIcon className="size-4" />
+          Follow on X
+          <ArrowUpRight01Icon className="size-4" />
+        </a>
+        <Link
+          href="/"
+          className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}
+        >
+          Back to Noblocks
+        </Link>
+      </div>
+    </PlayCard>
+  </div>
+);

--- a/app/components/play/PlayShell.tsx
+++ b/app/components/play/PlayShell.tsx
@@ -9,6 +9,9 @@
  * Desktop: collapsed icon rail on the left that expands in flow on hover,
  * pushing the content right like a slide-out panel.
  * Mobile: fixed bottom tab bar.
+ *
+ * When campaignEnded, hide live-game nav (tabs + countdown) so /play reads
+ * as an announcement; /play/admin still uses this shell without game chrome.
  */
 
 import { ReactNode } from "react";
@@ -49,19 +52,30 @@ export const PlayHeader = ({ right }: { right?: ReactNode }) => (
   </header>
 );
 
-const PlayFooter = () => (
+const PlayFooter = ({ campaignEnded }: { campaignEnded?: boolean }) => (
   // Mobile has the bottom tab bar instead — the footer only earns its keep
-  // on wider screens.
-  <footer className="border-t border-border-light py-6 max-lg:hidden dark:border-white/10">
+  // on wider screens. When the campaign has ended there is no bottom bar,
+  // so show the footer at all breakpoints.
+  <footer
+    className={`border-t border-border-light py-6 dark:border-white/10 ${
+      campaignEnded ? "" : "max-lg:hidden"
+    }`}
+  >
     <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 text-xs text-text-secondary dark:text-white/40 sm:px-6">
-      <span>Noblocks Play · World Cup 2026 Fantasy League</span>
+      <span>
+        {campaignEnded
+          ? "Noblocks Play · Season complete"
+          : "Noblocks Play · World Cup 2026 Fantasy League"}
+      </span>
       <span className="flex items-center gap-4">
-        <Link
-          href="/play/terms"
-          className="transition-colors hover:text-text-body dark:hover:text-white"
-        >
-          Terms &amp; Conditions
-        </Link>
+        {!campaignEnded && (
+          <Link
+            href="/play/terms"
+            className="transition-colors hover:text-text-body dark:hover:text-white"
+          >
+            Terms &amp; Conditions
+          </Link>
+        )}
         <Link
           href="/"
           className="transition-colors hover:text-text-body dark:hover:text-white"
@@ -73,32 +87,45 @@ const PlayFooter = () => (
   </footer>
 );
 
-export const PlayShell = ({ children }: { children: ReactNode }) => (
+export const PlayShell = ({
+  children,
+  campaignEnded = false,
+}: {
+  children: ReactNode;
+  campaignEnded?: boolean;
+}) => (
   <div className="flex min-h-dvh flex-col">
     <PlayHeader />
 
-    <div className="mx-auto w-full max-w-6xl flex-1 px-4 pb-28 pt-4 sm:px-6 lg:pb-20">
-      {/* The ONE countdown pill: first element under the header, right-aligned
-          (all breakpoints — it is deliberately not in the header). */}
-      <div className="mb-4 flex justify-end">
-        <CountdownChip />
-      </div>
+    <div
+      className={`mx-auto w-full max-w-6xl flex-1 px-4 pt-4 sm:px-6 ${
+        campaignEnded ? "pb-10" : "pb-28 lg:pb-20"
+      }`}
+    >
+      {!campaignEnded && (
+        /* The ONE countdown pill: first element under the header, right-aligned
+            (all breakpoints — it is deliberately not in the header). */
+        <div className="mb-4 flex justify-end">
+          <CountdownChip />
+        </div>
+      )}
 
       <div className="lg:flex lg:items-start lg:gap-6">
-        {/* Desktop: icon rail that expands IN FLOW on hover — a slide-out
-            panel that pushes the content right, never an overlay. */}
-        <aside className="group hidden lg:block lg:w-[4.25rem] lg:shrink-0 lg:transition-[width] lg:duration-200 lg:ease-out lg:hover:w-56">
-          <div className="sticky top-24 overflow-hidden rounded-2xl border border-border-light bg-white shadow-sm dark:border-white/10 dark:bg-surface-overlay">
-            <PlayTabs variant="rail" />
-          </div>
-        </aside>
+        {!campaignEnded && (
+          /* Desktop: icon rail that expands IN FLOW on hover — a slide-out
+              panel that pushes the content right, never an overlay. */
+          <aside className="group hidden lg:block lg:w-[4.25rem] lg:shrink-0 lg:transition-[width] lg:duration-200 lg:ease-out lg:hover:w-56">
+            <div className="sticky top-24 overflow-hidden rounded-2xl border border-border-light bg-white shadow-sm dark:border-white/10 dark:bg-surface-overlay">
+              <PlayTabs variant="rail" />
+            </div>
+          </aside>
+        )}
 
         <main className="min-w-0 flex-1">{children}</main>
       </div>
     </div>
 
-    <PlayFooter />
-    {/* Mobile app-style navigation */}
-    <PlayTabs variant="bottom" />
+    <PlayFooter campaignEnded={campaignEnded} />
+    {!campaignEnded && <PlayTabs variant="bottom" />}
   </div>
 );

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -74,6 +74,11 @@ const config: Config = {
   onrampChainedForwardingEnabled:
     process.env.NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED === "true",
   fantasyEnabled: process.env.NEXT_PUBLIC_FANTASY_ENABLED === "true",
+  // When true (and fantasyEnabled), public /play shows the end-of-campaign
+  // announcement instead of the live game. Flip off to revive Play for a
+  // later league (EPL / UCL) after rebranding assets/copy.
+  fantasyCampaignEnded:
+    process.env.NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED === "true",
   embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
 };
 

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1749,6 +1749,7 @@ export function TransactionStatus({
 
         <AnimatePresence>
           {config.fantasyEnabled &&
+            !config.fantasyCampaignEnded &&
             showSuccessVisual &&
             !isFantasyBannerDismissed && (
               <AnimatedComponent

--- a/app/play/layout.tsx
+++ b/app/play/layout.tsx
@@ -3,11 +3,17 @@ import { notFound } from "next/navigation";
 import config from "@/app/lib/config";
 import { PlayShell } from "@/app/components/play/PlayShell";
 
-export const metadata: Metadata = {
-  title: "Noblocks Play — World Cup Fantasy League",
-  description:
-    "Build your World Cup fantasy squad, climb the leaderboard and qualify for a share of 600 USDC on Base.",
-};
+export const metadata: Metadata = config.fantasyCampaignEnded
+  ? {
+      title: "Noblocks Play — World Cup Fantasy League",
+      description:
+        "The World Cup fantasy league has ended. Follow Noblocks on X for the winners announcement — Play returns for Premier League and Champions League.",
+    }
+  : {
+      title: "Noblocks Play — World Cup Fantasy League",
+      description:
+        "Build your World Cup fantasy squad, climb the leaderboard and qualify for a share of 600 USDC on Base.",
+    };
 
 export default function PlayLayout({
   children,
@@ -18,5 +24,7 @@ export default function PlayLayout({
   // this for /api/play/*).
   if (!config.fantasyEnabled) notFound();
 
-  return <PlayShell>{children}</PlayShell>;
+  return (
+    <PlayShell campaignEnded={config.fantasyCampaignEnded}>{children}</PlayShell>
+  );
 }

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -17,6 +17,7 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { trackEvent } from "@/app/hooks/analytics/client";
+import { CampaignEnded } from "@/app/components/play/CampaignEnded";
 import { JoinModal } from "@/app/components/play/JoinModal";
 import { LeaderboardTable } from "@/app/components/play/LeaderboardTable";
 import { useJoinStatus, useLeaderboard } from "@/app/components/play/hooks";
@@ -26,6 +27,7 @@ import {
   Skeleton,
   primaryButtonClasses,
 } from "@/app/components/play/ui";
+import config from "@/app/lib/config";
 
 const ASSET = (name: string) => `/images/play-promo/${name}`;
 const HERO_PILL_BUTTON =
@@ -279,8 +281,14 @@ const LeaderboardPreview = () => {
 
 export default function PlayLandingPage() {
   useEffect(() => {
-    trackEvent("play_landing_view");
+    if (!config.fantasyCampaignEnded) {
+      trackEvent("play_landing_view");
+    }
   }, []);
+
+  if (config.fantasyCampaignEnded) {
+    return <CampaignEnded />;
+  }
 
   return (
     <div className="space-y-10 md:space-y-20 md:mt-20">

--- a/app/types.ts
+++ b/app/types.ts
@@ -456,6 +456,11 @@ export type Config = {
   onrampChainedForwardingEnabled: boolean;
   /** Noblocks Play (World Cup fantasy league) feature flag. Gates /play UI + API. */
   fantasyEnabled: boolean;
+  /**
+   * When true with fantasyEnabled, public /play is the campaign-ended
+   * announcement (live game hidden; /play/admin still works).
+   */
+  fantasyCampaignEnded: boolean;
   /** Embeddable widget feature flag. Gates the /widget route (iframe embed for whitelisted partners). */
   embedEnabled: boolean;
 };

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -2243,10 +2243,11 @@ export const isBlockFestActive = (): boolean => {
 
 export const WORLDCUP_FOOTER_END_DATE = new Date(config.worldcupFooterEndDate);
 
-/** World Cup footer Lottie: fantasy flag on and before campaign end date. */
+/** World Cup footer Lottie: live Play acquisition only (not post-campaign). */
 export const isWorldcupFooterActive = (): boolean => {
   return (
     config.fantasyEnabled &&
+    !config.fantasyCampaignEnded &&
     Date.now() <= WORLDCUP_FOOTER_END_DATE.getTime()
   );
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -464,16 +464,59 @@ async function embedMiddleware(req: NextRequest) {
   return response;
 }
 
+/**
+ * When the World Cup campaign has ended, funnel all public /play/* deep links
+ * to the announcement at /play. Admin stays live for winner ops.
+ */
+function playCampaignEndedRedirect(req: NextRequest): NextResponse | null {
+  if (process.env.NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED !== "true") {
+    return null;
+  }
+  if (process.env.NEXT_PUBLIC_FANTASY_ENABLED !== "true") {
+    return null;
+  }
+
+  const pathname = req.nextUrl.pathname;
+  // Landing announcement + admin console stay reachable.
+  if (
+    pathname === "/play" ||
+    pathname === "/play/" ||
+    pathname === "/play/admin" ||
+    pathname.startsWith("/play/admin/")
+  ) {
+    return null;
+  }
+  if (!pathname.startsWith("/play/")) {
+    return null;
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = "/play";
+  url.search = "";
+  return NextResponse.redirect(url);
+}
+
 export default async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
   if (pathname === "/widget" || pathname.startsWith("/widget/")) {
     return embedMiddleware(req);
   }
+
+  // Page routes under /play (not /api/play): optional campaign-ended redirect,
+  // then pass through — never run Privy JWT auth on HTML pages.
+  if (pathname === "/play" || pathname.startsWith("/play/")) {
+    const playRedirect = playCampaignEndedRedirect(req);
+    if (playRedirect) return playRedirect;
+    return NextResponse.next();
+  }
+
   return authorizationMiddleware(req);
 }
 
 export const config = {
   matcher: [
+    "/play",
+    "/play/:path*",
     "/widget",
     "/widget/:path*",
     "/api/v1/transactions",


### PR DESCRIPTION
* feat: Implement end-of-campaign announcement for Noblocks Play

- Added a new CampaignEnded component to display an announcement when the fantasy league has concluded.
- Updated middleware to redirect public /play links to the announcement when the campaign has ended.
- Enhanced PlayShell and PlayFooter components to conditionally render content based on campaign status.
- Modified metadata for the Play layout to reflect the end of the campaign.
- Updated various components to hide or show elements based on the campaign's active status.

This change introduces a clear user experience for the transition from active gameplay to post-campaign announcements.

* style: Adjust text alignment in CampaignEnded component for improved layout

- Modified the text alignment in the CampaignEnded component to enhance the visual presentation of the end-of-campaign announcement. This change improves the overall user experience by ensuring consistent styling.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed e.g closes #407
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).