### PR TITLE
feat(widget): Sign in, allowlists, set_config, and cNGN display

### DIFF
--- a/__tests__/NetworksContext.test.tsx
+++ b/__tests__/NetworksContext.test.tsx
@@ -45,6 +45,12 @@ describe("NetworkProvider", () => {
     mockUseEmbed.mockReturnValue({
       isEmbed: false,
       isNetworkLocked: false,
+      networkAllowlist: null,
+      tokenAllowlist: null,
+      currencyAllowlist: null,
+      hideSideToggle: false,
+      isSideLocked: false,
+      hostFormConfig: { version: 0 },
     });
 
     window.ethereum.request = jest.fn().mockResolvedValue(undefined);

--- a/__tests__/NetworksContext.test.tsx
+++ b/__tests__/NetworksContext.test.tsx
@@ -6,9 +6,14 @@ import { networks } from "../app/mocks";
 import { NetworkProvider, useNetwork } from "../app/context/NetworksContext";
 
 const mockUseInjectedWallet = jest.fn();
+const mockUseEmbed = jest.fn();
 
 jest.mock("../app/context/InjectedWalletContext", () => ({
   useInjectedWallet: () => mockUseInjectedWallet(),
+}));
+
+jest.mock("../app/context/EmbedContext", () => ({
+  useEmbed: () => mockUseEmbed(),
 }));
 
 function NetworkConsumer() {
@@ -35,6 +40,11 @@ describe("NetworkProvider", () => {
     mockUseInjectedWallet.mockReturnValue({
       isInjectedWallet: true,
       injectedReady: true,
+    });
+
+    mockUseEmbed.mockReturnValue({
+      isEmbed: false,
+      isNetworkLocked: false,
     });
 
     window.ethereum.request = jest.fn().mockResolvedValue(undefined);

--- a/__tests__/embed-config.test.ts
+++ b/__tests__/embed-config.test.ts
@@ -1,0 +1,95 @@
+import {
+  parseCurrencyAllowlist,
+  parseEmbedConfig,
+  parseTokenAllowlist,
+  isTokenInAllowlist,
+  isCurrencyInAllowlist,
+} from "../app/lib/embed-config";
+
+function params(entries: Record<string, string | null>) {
+  return {
+    get: (key: string) =>
+      Object.prototype.hasOwnProperty.call(entries, key)
+        ? entries[key]
+        : null,
+  };
+}
+
+describe("embed-config allowlists", () => {
+  describe("parseTokenAllowlist", () => {
+    it("returns null when the key is absent", () => {
+      expect(parseTokenAllowlist(null)).toBeNull();
+    });
+
+    it("canonicalizes and dedupes cNGN variants", () => {
+      expect(parseTokenAllowlist("cNGN,USDC,CNGN")).toEqual(["cNGN", "USDC"]);
+    });
+
+    it("returns empty array for empty CSV", () => {
+      expect(parseTokenAllowlist("")).toEqual([]);
+      expect(parseTokenAllowlist("  ,  ")).toEqual([]);
+    });
+  });
+
+  describe("parseCurrencyAllowlist", () => {
+    it("returns null when absent and uppercases present values", () => {
+      expect(parseCurrencyAllowlist(null)).toBeNull();
+      expect(parseCurrencyAllowlist("ngn,kes")).toEqual(["NGN", "KES"]);
+    });
+  });
+
+  describe("isTokenInAllowlist / isCurrencyInAllowlist", () => {
+    it("allows all when allowlist is null", () => {
+      expect(isTokenInAllowlist("USDC", null)).toBe(true);
+      expect(isCurrencyInAllowlist("NGN", null)).toBe(true);
+    });
+
+    it("matches tokens case-insensitively against the allowlist", () => {
+      expect(isTokenInAllowlist("CNGN", ["cNGN"])).toBe(true);
+      expect(isTokenInAllowlist("USDT", ["cNGN"])).toBe(false);
+    });
+  });
+
+  describe("parseEmbedConfig", () => {
+    it("parses allowlists, defaults, and hideSideToggle", () => {
+      const config = parseEmbedConfig(
+        params({
+          token: "CNGN",
+          tokens: "cNGN,USDC",
+          currency: "ngn",
+          currencies: "NGN",
+          network: "base",
+          networks: "base,arbitrum-one",
+          hideSideToggle: "1",
+          side: "sell",
+        }),
+      );
+
+      expect(config.tokenAllowlist).toEqual(["cNGN", "USDC"]);
+      expect(config.currencyAllowlist).toEqual(["NGN"]);
+      expect(config.defaultToken).toBe("cNGN");
+      expect(config.defaultCurrency).toBe("NGN");
+      expect(config.hideSideToggle).toBe(true);
+      expect(config.sideLockedFromUrl).toBe(true);
+      expect(config.networkConfig.isLocked).toBe(false);
+      expect(config.networkConfig.allowlist?.map((n) => n.chain.name)).toEqual([
+        "Base",
+        "Arbitrum One",
+      ]);
+      expect(config.networkConfig.defaultNetwork?.chain.name).toBe("Base");
+    });
+
+    it("locks network when networks has a single entry", () => {
+      const config = parseEmbedConfig(params({ networks: "base" }));
+      expect(config.networkConfig.isLocked).toBe(true);
+      expect(config.networkConfig.allowlist).toHaveLength(1);
+    });
+
+    it("rejects default token outside the allowlist", () => {
+      const config = parseEmbedConfig(
+        params({ token: "USDT", tokens: "cNGN" }),
+      );
+      expect(config.defaultToken).toBeNull();
+    });
+  });
+});

--- a/__tests__/embed-network.test.ts
+++ b/__tests__/embed-network.test.ts
@@ -1,10 +1,18 @@
 import {
   hasEmbedNetworkLockParams,
+  hasEmbedNetworksAllowlistParam,
   parseChainIdParam,
+  parseCsvParam,
+  parseEmbedNetworkConfig,
   resolveNetworkByChainId,
   resolveNetworkByName,
+  resolveNetworkBySlug,
   resolveNetworkFromEmbedParams,
+  resolveNetworksAllowlist,
+  networkSlug,
+  isNetworkInAllowlist,
 } from "../app/lib/embed-network";
+import { networks } from "../app/mocks";
 
 function params(entries: Record<string, string | null>) {
   return {
@@ -43,14 +51,64 @@ describe("embed-network", () => {
     });
   });
 
+  describe("resolveNetworkBySlug", () => {
+    it("matches rate-fetch slugs and display names", () => {
+      expect(resolveNetworkBySlug("base")?.chain.name).toBe("Base");
+      expect(resolveNetworkBySlug("arbitrum-one")?.chain.name).toBe(
+        "Arbitrum One",
+      );
+      expect(resolveNetworkBySlug("starknet")?.chain.name).toBe("Starknet");
+      expect(resolveNetworkBySlug("Starknet")?.chain.name).toBe("Starknet");
+    });
+
+    it("accepts legacy starknet-mainnet alias", () => {
+      expect(resolveNetworkBySlug("starknet-mainnet")?.chain.name).toBe(
+        "Starknet",
+      );
+    });
+
+    it("returns null for unknown slugs", () => {
+      expect(resolveNetworkBySlug("NotAChain")).toBeNull();
+    });
+  });
+
   describe("resolveNetworkByName", () => {
-    it("matches case-insensitively", () => {
+    it("matches case-insensitively via slug resolve", () => {
       expect(resolveNetworkByName("base")?.chain.name).toBe("Base");
       expect(resolveNetworkByName("Starknet")?.chain.name).toBe("Starknet");
     });
+  });
 
-    it("returns null for unknown names", () => {
-      expect(resolveNetworkByName("NotAChain")).toBeNull();
+  describe("networkSlug", () => {
+    it("slugifies Starknet to starknet (not starknet-mainnet)", () => {
+      const starknet = networks.find((n) => n.chain.name === "Starknet");
+      expect(starknet).toBeDefined();
+      expect(networkSlug(starknet!)).toBe("starknet");
+      expect(starknet!.chain.network).toBe("starknet");
+    });
+  });
+
+  describe("parseCsvParam / resolveNetworksAllowlist", () => {
+    it("parses CSV and drops unknown slugs", () => {
+      expect(parseCsvParam("base, arbitrum-one")).toEqual([
+        "base",
+        "arbitrum-one",
+      ]);
+      const list = resolveNetworksAllowlist("base,nope,starknet");
+      expect(list.map((n) => n.chain.name)).toEqual(["Base", "Starknet"]);
+    });
+  });
+
+  describe("isNetworkInAllowlist", () => {
+    it("allows all when allowlist is null", () => {
+      expect(isNetworkInAllowlist(networks[0], null)).toBe(true);
+    });
+
+    it("checks membership by chain name", () => {
+      const base = resolveNetworkBySlug("base")!;
+      const arb = resolveNetworkBySlug("arbitrum-one")!;
+      expect(isNetworkInAllowlist(base, [base])).toBe(true);
+      expect(isNetworkInAllowlist(arb, [base])).toBe(false);
     });
   });
 
@@ -62,9 +120,9 @@ describe("embed-network", () => {
       expect(network?.chain.name).toBe("Base");
     });
 
-    it("falls back to network name when chainId is absent", () => {
+    it("falls back to network slug when chainId is absent", () => {
       const network = resolveNetworkFromEmbedParams(
-        params({ network: "Starknet" }),
+        params({ network: "starknet" }),
       );
       expect(network?.chain.name).toBe("Starknet");
     });
@@ -73,6 +131,34 @@ describe("embed-network", () => {
       expect(
         resolveNetworkFromEmbedParams(params({ chainId: "999999" })),
       ).toBeNull();
+    });
+  });
+
+  describe("parseEmbedNetworkConfig", () => {
+    it("locks on legacy network/chainId without networks=", () => {
+      const config = parseEmbedNetworkConfig(params({ chainId: "8453" }));
+      expect(config.isLocked).toBe(true);
+      expect(config.allowlist).toHaveLength(1);
+      expect(config.defaultNetwork?.chain.name).toBe("Base");
+      expect(config.unresolved).toBe(false);
+    });
+
+    it("uses networks CSV as a multi-chain allowlist", () => {
+      const config = parseEmbedNetworkConfig(
+        params({ networks: "base,arbitrum-one", network: "arbitrum-one" }),
+      );
+      expect(config.isLocked).toBe(false);
+      expect(config.allowlist?.map((n) => n.chain.name)).toEqual([
+        "Base",
+        "Arbitrum One",
+      ]);
+      expect(config.defaultNetwork?.chain.name).toBe("Arbitrum One");
+    });
+
+    it("is unrestricted when no network params are set", () => {
+      const config = parseEmbedNetworkConfig(params({}));
+      expect(config.allowlist).toBeNull();
+      expect(config.isLocked).toBe(false);
     });
   });
 
@@ -86,6 +172,15 @@ describe("embed-network", () => {
       );
       expect(hasEmbedNetworkLockParams(params({ chainId: "" }))).toBe(true);
       expect(hasEmbedNetworkLockParams(params({}))).toBe(false);
+    });
+  });
+
+  describe("hasEmbedNetworksAllowlistParam", () => {
+    it("detects the networks key", () => {
+      expect(hasEmbedNetworksAllowlistParam(params({ networks: "base" }))).toBe(
+        true,
+      );
+      expect(hasEmbedNetworksAllowlistParam(params({}))).toBe(false);
     });
   });
 });

--- a/__tests__/embed-network.test.ts
+++ b/__tests__/embed-network.test.ts
@@ -1,0 +1,91 @@
+import {
+  hasEmbedNetworkLockParams,
+  parseChainIdParam,
+  resolveNetworkByChainId,
+  resolveNetworkByName,
+  resolveNetworkFromEmbedParams,
+} from "../app/lib/embed-network";
+
+function params(entries: Record<string, string | null>) {
+  return {
+    get: (key: string) =>
+      Object.prototype.hasOwnProperty.call(entries, key)
+        ? entries[key]
+        : null,
+  };
+}
+
+describe("embed-network", () => {
+  describe("parseChainIdParam", () => {
+    it("parses decimal and hex chainIds", () => {
+      expect(parseChainIdParam("8453")).toBe(8453);
+      expect(parseChainIdParam("0x2105")).toBe(8453);
+      expect(parseChainIdParam("0X2105")).toBe(8453);
+    });
+
+    it("returns null for missing or invalid values", () => {
+      expect(parseChainIdParam(null)).toBeNull();
+      expect(parseChainIdParam("")).toBeNull();
+      expect(parseChainIdParam("  ")).toBeNull();
+      expect(parseChainIdParam("abc")).toBeNull();
+      expect(parseChainIdParam("84.53")).toBeNull();
+    });
+  });
+
+  describe("resolveNetworkByChainId", () => {
+    it("resolves Base by numeric and hex id", () => {
+      expect(resolveNetworkByChainId(8453)?.chain.name).toBe("Base");
+      expect(resolveNetworkByChainId("0x2105")?.chain.name).toBe("Base");
+    });
+
+    it("returns null for unknown EVM ids", () => {
+      expect(resolveNetworkByChainId(999999)).toBeNull();
+    });
+  });
+
+  describe("resolveNetworkByName", () => {
+    it("matches case-insensitively", () => {
+      expect(resolveNetworkByName("base")?.chain.name).toBe("Base");
+      expect(resolveNetworkByName("Starknet")?.chain.name).toBe("Starknet");
+    });
+
+    it("returns null for unknown names", () => {
+      expect(resolveNetworkByName("NotAChain")).toBeNull();
+    });
+  });
+
+  describe("resolveNetworkFromEmbedParams", () => {
+    it("prefers chainId over network when both are set", () => {
+      const network = resolveNetworkFromEmbedParams(
+        params({ chainId: "8453", network: "Arbitrum One" }),
+      );
+      expect(network?.chain.name).toBe("Base");
+    });
+
+    it("falls back to network name when chainId is absent", () => {
+      const network = resolveNetworkFromEmbedParams(
+        params({ network: "Starknet" }),
+      );
+      expect(network?.chain.name).toBe("Starknet");
+    });
+
+    it("returns null when chainId is present but invalid", () => {
+      expect(
+        resolveNetworkFromEmbedParams(params({ chainId: "999999" })),
+      ).toBeNull();
+    });
+  });
+
+  describe("hasEmbedNetworkLockParams", () => {
+    it("is true when either param key is present", () => {
+      expect(hasEmbedNetworkLockParams(params({ chainId: "8453" }))).toBe(
+        true,
+      );
+      expect(hasEmbedNetworkLockParams(params({ network: "Base" }))).toBe(
+        true,
+      );
+      expect(hasEmbedNetworkLockParams(params({ chainId: "" }))).toBe(true);
+      expect(hasEmbedNetworkLockParams(params({}))).toBe(false);
+    });
+  });
+});

--- a/__tests__/token-symbol.test.ts
+++ b/__tests__/token-symbol.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Token symbol helpers — display `cNGN` vs aggregator wire `CNGN`.
+ */
+import {
+  canonicalTokenSymbol,
+  tokensEqual,
+  toAggregatorToken,
+} from "../app/lib/token-symbol";
+
+describe("token-symbol", () => {
+  describe("canonicalTokenSymbol", () => {
+    it("normalizes cngn variants to cNGN", () => {
+      expect(canonicalTokenSymbol("cNGN")).toBe("cNGN");
+      expect(canonicalTokenSymbol("CNGN")).toBe("cNGN");
+      expect(canonicalTokenSymbol("cngn")).toBe("cNGN");
+      expect(canonicalTokenSymbol(" CnGn ")).toBe("cNGN");
+    });
+
+    it("passes through other symbols", () => {
+      expect(canonicalTokenSymbol("USDC")).toBe("USDC");
+      expect(canonicalTokenSymbol("usdt")).toBe("usdt");
+    });
+
+    it("returns empty for missing values", () => {
+      expect(canonicalTokenSymbol(null)).toBe("");
+      expect(canonicalTokenSymbol("")).toBe("");
+      expect(canonicalTokenSymbol("  ")).toBe("");
+    });
+  });
+
+  describe("tokensEqual", () => {
+    it("matches case-insensitively", () => {
+      expect(tokensEqual("cNGN", "CNGN")).toBe(true);
+      expect(tokensEqual("usdc", "USDC")).toBe(true);
+      expect(tokensEqual("USDC", "USDT")).toBe(false);
+    });
+  });
+
+  describe("toAggregatorToken", () => {
+    it("maps cNGN to CNGN for aggregator APIs", () => {
+      expect(toAggregatorToken("cNGN")).toBe("CNGN");
+      expect(toAggregatorToken("CNGN")).toBe("CNGN");
+      expect(toAggregatorToken("cngn")).toBe("CNGN");
+    });
+
+    it("leaves other tokens unchanged", () => {
+      expect(toAggregatorToken("USDC")).toBe("USDC");
+    });
+  });
+});

--- a/app/components/EmbedNetworkLockApplier.tsx
+++ b/app/components/EmbedNetworkLockApplier.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { useEmbed } from "../context/EmbedContext";
+import { useInjectedWallet } from "../context/InjectedWalletContext";
+import { useNetwork } from "../context/NetworksContext";
+import {
+  hasEmbedNetworkLockParams,
+  resolveNetworkByChainId,
+  resolveNetworkFromEmbedParams,
+} from "../lib/embed-network";
+
+/**
+ * Applies host `?chainId=` / `?network=` on mount, and follows EIP-1193
+ * `chainChanged` from injected/bridge wallets while in embed mode.
+ * Must render under NetworkProvider and InjectedWalletProvider.
+ */
+export function EmbedNetworkLockApplier() {
+  const { isEmbed, isNetworkLocked, lockNetworkFromWallet } = useEmbed();
+  const { setDisplayedNetwork } = useNetwork();
+  const { injectedProvider } = useInjectedWallet();
+  const searchParams = useSearchParams();
+  const appliedRef = useRef(false);
+  const urlToastRef = useRef(false);
+  const unsupportedChainToastRef = useRef(false);
+
+  // URL lock → set displayed network once.
+  useEffect(() => {
+    if (!isEmbed || !isNetworkLocked) return;
+    if (!hasEmbedNetworkLockParams(searchParams)) return;
+    if (appliedRef.current) return;
+
+    appliedRef.current = true;
+    const network = resolveNetworkFromEmbedParams(searchParams);
+    if (network) {
+      setDisplayedNetwork(network);
+      return;
+    }
+
+    if (!urlToastRef.current) {
+      urlToastRef.current = true;
+      toast.error("Unsupported network", {
+        description:
+          "The network from the embed URL is not supported. Keeping the default network.",
+      });
+    }
+  }, [isEmbed, isNetworkLocked, searchParams, setDisplayedNetwork]);
+
+  // Injected / bridge wallet chain switches → update + keep locked.
+  useEffect(() => {
+    if (!isEmbed || !injectedProvider?.on) return;
+
+    const handleChainChanged = (chainId: unknown) => {
+      const network = resolveNetworkByChainId(
+        typeof chainId === "string" || typeof chainId === "number"
+          ? chainId
+          : String(chainId ?? ""),
+      );
+      if (network) {
+        setDisplayedNetwork(network);
+        lockNetworkFromWallet();
+        unsupportedChainToastRef.current = false;
+        return;
+      }
+
+      if (!unsupportedChainToastRef.current) {
+        unsupportedChainToastRef.current = true;
+        toast.error("Unsupported network", {
+          description:
+            "Your wallet switched to a network Noblocks does not support yet.",
+        });
+      }
+    };
+
+    injectedProvider.on("chainChanged", handleChainChanged);
+    return () => {
+      injectedProvider.removeListener?.("chainChanged", handleChainChanged);
+    };
+  }, [
+    isEmbed,
+    injectedProvider,
+    setDisplayedNetwork,
+    lockNetworkFromWallet,
+  ]);
+
+  return null;
+}

--- a/app/components/EmbedNetworkLockApplier.tsx
+++ b/app/components/EmbedNetworkLockApplier.tsx
@@ -1,54 +1,100 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { useEmbed } from "../context/EmbedContext";
 import { useInjectedWallet } from "../context/InjectedWalletContext";
 import { useNetwork } from "../context/NetworksContext";
 import {
-  hasEmbedNetworkLockParams,
+  isNetworkInAllowlist,
   resolveNetworkByChainId,
-  resolveNetworkFromEmbedParams,
 } from "../lib/embed-network";
 
 /**
- * Applies host `?chainId=` / `?network=` on mount, and follows EIP-1193
- * `chainChanged` from injected/bridge wallets while in embed mode.
- * Must render under NetworkProvider and InjectedWalletProvider.
+ * Applies embed URL network defaults/allowlists on mount, follows EIP-1193
+ * `chainChanged` from injected/bridge wallets, and handles host
+ * `noblocks:set_config`. Must render under NetworkProvider and InjectedWalletProvider.
  */
 export function EmbedNetworkLockApplier() {
-  const { isEmbed, isNetworkLocked, lockNetworkFromWallet } = useEmbed();
+  const {
+    isEmbed,
+    networkAllowlist,
+    defaultNetwork,
+    networkLockUnresolved,
+    lockNetworkFromWallet,
+    parentOrigin,
+    applyHostConfig,
+  } = useEmbed();
   const { setDisplayedNetwork } = useNetwork();
   const { injectedProvider } = useInjectedWallet();
-  const searchParams = useSearchParams();
   const appliedRef = useRef(false);
   const urlToastRef = useRef(false);
   const unsupportedChainToastRef = useRef(false);
 
-  // URL lock → set displayed network once.
+  // URL default / allowlist → set displayed network once.
   useEffect(() => {
-    if (!isEmbed || !isNetworkLocked) return;
-    if (!hasEmbedNetworkLockParams(searchParams)) return;
+    if (!isEmbed) return;
     if (appliedRef.current) return;
 
+    const hasNetworkConstraint =
+      networkAllowlist != null ||
+      defaultNetwork != null ||
+      networkLockUnresolved;
+    if (!hasNetworkConstraint) return;
+
     appliedRef.current = true;
-    const network = resolveNetworkFromEmbedParams(searchParams);
-    if (network) {
-      setDisplayedNetwork(network);
+
+    if (defaultNetwork) {
+      setDisplayedNetwork(defaultNetwork);
       return;
     }
 
-    if (!urlToastRef.current) {
+    if (networkLockUnresolved && !urlToastRef.current) {
       urlToastRef.current = true;
       toast.error("Unsupported network", {
         description:
           "The network from the embed URL is not supported. Keeping the default network.",
       });
     }
-  }, [isEmbed, isNetworkLocked, searchParams, setDisplayedNetwork]);
+  }, [
+    isEmbed,
+    networkAllowlist,
+    defaultNetwork,
+    networkLockUnresolved,
+    setDisplayedNetwork,
+  ]);
 
-  // Injected / bridge wallet chain switches → update + keep locked.
+  // Host → widget live config updates.
+  useEffect(() => {
+    if (!isEmbed || !parentOrigin) return;
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== parentOrigin) return;
+      if (event.source !== window.parent) return;
+      const data = event.data;
+      if (!data || data.source !== "noblocks-host") return;
+      if (data.event !== "noblocks:set_config") return;
+
+      const payload =
+        data.payload && typeof data.payload === "object" ? data.payload : {};
+      const result = applyHostConfig(payload);
+
+      if (result.network) {
+        setDisplayedNetwork(result.network);
+      }
+
+      if (result.rejected.length > 0) {
+        toast.error("Unsupported configuration", {
+          description: `Host update ignored for: ${result.rejected.join(", ")}.`,
+        });
+      }
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [isEmbed, parentOrigin, applyHostConfig, setDisplayedNetwork]);
+
+  // Injected / bridge wallet chain switches → update + keep locked (within allowlist).
   useEffect(() => {
     if (!isEmbed || !injectedProvider?.on) return;
 
@@ -58,7 +104,7 @@ export function EmbedNetworkLockApplier() {
           ? chainId
           : String(chainId ?? ""),
       );
-      if (network) {
+      if (network && isNetworkInAllowlist(network, networkAllowlist)) {
         setDisplayedNetwork(network);
         lockNetworkFromWallet();
         unsupportedChainToastRef.current = false;
@@ -68,8 +114,9 @@ export function EmbedNetworkLockApplier() {
       if (!unsupportedChainToastRef.current) {
         unsupportedChainToastRef.current = true;
         toast.error("Unsupported network", {
-          description:
-            "Your wallet switched to a network Noblocks does not support yet.",
+          description: network
+            ? "Your wallet switched to a network outside this embed’s allowlist."
+            : "Your wallet switched to a network Noblocks does not support yet.",
         });
       }
     };
@@ -83,6 +130,7 @@ export function EmbedNetworkLockApplier() {
     injectedProvider,
     setDisplayedNetwork,
     lockNetworkFromWallet,
+    networkAllowlist,
   ]);
 
   return null;

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -36,6 +36,7 @@ import {
   swapModeFromSideParam,
   networkSupportsOnramp,
 } from "../utils";
+import { toAggregatorToken } from "../lib/token-symbol";
 import { mapReportAndAct } from "../lib/toastMappedError";
 import { reportClientError } from "../lib/sentry.client";
 import { isNoProviderError } from "../lib/errorMessages";
@@ -268,7 +269,7 @@ export function MainPageContent() {
   /** Snapshotted at order create — status fetch/save must not follow live swapMode. */
   const [activeOrderIsOnramp, setActiveOrderIsOnramp] = useState(false);
 
-  const { isEmbed, postToHost, isNetworkLocked } = useEmbed();
+  const { isEmbed, postToHost, isNetworkLocked, networkAllowlist, hostFormConfig } = useEmbed();
 
   // Surface transaction progress to the embedding page (no-op outside /widget).
   useEffect(() => {
@@ -353,6 +354,28 @@ export function MainPageContent() {
       }
     },
     [searchParams, setValue, selectedNetwork.chain],
+  );
+
+  useEffect(
+    function syncRampFromHostConfig() {
+      if (!isEmbed || hostFormConfig.version === 0 || !hostFormConfig.side) {
+        return;
+      }
+      const next = swapModeFromSideParam(hostFormConfig.side);
+      if (next === undefined) return;
+      if (next === "onramp" && !networkSupportsOnramp(selectedNetwork.chain)) {
+        return;
+      }
+      setValue("swapMode", next, { shouldDirty: true });
+      setValue("isSwapped", next === "onramp", { shouldDirty: true });
+    },
+    [
+      isEmbed,
+      hostFormConfig.version,
+      hostFormConfig.side,
+      setValue,
+      selectedNetwork.chain,
+    ],
   );
 
   useEffect(
@@ -526,8 +549,8 @@ export function MainPageContent() {
 
   useEffect(
     function autoSelectLargestBalanceNetwork() {
-      // Host-locked embed network must not hop based on balances.
-      if (isEmbed && isNetworkLocked) return;
+      // Host-locked / allowlisted embed network must not hop based on balances.
+      if (isEmbed && (isNetworkLocked || networkAllowlist != null)) return;
 
       const sessionKey = isInjectedWallet
         ? injectedAddress
@@ -573,6 +596,7 @@ export function MainPageContent() {
       isEmbed,
       isInjectedWallet,
       isNetworkLocked,
+      networkAllowlist,
       ready,
       selectedNetwork.chain.name,
       setDisplayedNetwork,
@@ -658,7 +682,7 @@ export function MainPageContent() {
 
         try {
           const rate = await fetchRate({
-            token,
+            token: toAggregatorToken(token),
             amount: rateQueryAmount,
             currency,
             providerId,

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -268,7 +268,7 @@ export function MainPageContent() {
   /** Snapshotted at order create — status fetch/save must not follow live swapMode. */
   const [activeOrderIsOnramp, setActiveOrderIsOnramp] = useState(false);
 
-  const { isEmbed, postToHost } = useEmbed();
+  const { isEmbed, postToHost, isNetworkLocked } = useEmbed();
 
   // Surface transaction progress to the embedding page (no-op outside /widget).
   useEffect(() => {
@@ -526,6 +526,9 @@ export function MainPageContent() {
 
   useEffect(
     function autoSelectLargestBalanceNetwork() {
+      // Host-locked embed network must not hop based on balances.
+      if (isEmbed && isNetworkLocked) return;
+
       const sessionKey = isInjectedWallet
         ? injectedAddress
           ? `injected:${injectedAddress}`
@@ -567,7 +570,9 @@ export function MainPageContent() {
       injectedAddress,
       injectedReady,
       isBalanceLoading,
+      isEmbed,
       isInjectedWallet,
+      isNetworkLocked,
       ready,
       selectedNetwork.chain.name,
       setDisplayedNetwork,

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { usePrivy, useMfaEnrollment } from "@privy-io/react-auth";
 import { useNetwork } from "../context/NetworksContext";
 import { useBalance, useTokens, useStarknet, useTron } from "../context";
@@ -72,7 +72,14 @@ export const MobileDropdown = ({
 
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { currentStep } = useStep();
-  const { isEmbed, isNetworkLocked } = useEmbed();
+  const { isEmbed, isNetworkLocked, networkAllowlist } = useEmbed();
+  const switchableNetworks = useMemo(
+    () =>
+      networkAllowlist != null && networkAllowlist.length > 0
+        ? networkAllowlist
+        : networks,
+    [networkAllowlist],
+  );
   const hideNetworkSwitcher = isEmbed && isNetworkLocked;
 
   const { user, linkEmail, updateEmail } = usePrivy();
@@ -350,7 +357,7 @@ export const MobileDropdown = ({
                           handleCopyAddress={handleCopyAddress}
                           isNetworkListOpen={isNetworkListOpen}
                           setIsNetworkListOpen={setIsNetworkListOpen}
-                          networks={networks}
+                          networks={switchableNetworks}
                           selectedNetwork={selectedNetwork}
                           isDark={isDark}
                           isNetworkLocked={hideNetworkSwitcher}

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -17,6 +17,7 @@ import { useStep } from "../context/StepContext";
 import { STEPS, type MobileSheetView } from "../types";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useInjectedWallet } from "../context";
+import { useEmbed } from "../context/EmbedContext";
 import { useWalletDisconnect } from "../hooks/useWalletDisconnect";
 import { toastMappedError } from "../lib/toastMappedError";
 import { useActualTheme } from "../hooks/useActualTheme";
@@ -71,6 +72,8 @@ export const MobileDropdown = ({
 
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { currentStep } = useStep();
+  const { isEmbed, isNetworkLocked } = useEmbed();
+  const hideNetworkSwitcher = isEmbed && isNetworkLocked;
 
   const { user, linkEmail, updateEmail } = usePrivy();
   const handleExportEmbeddedWallet = useHandleExportEmbeddedWallet();
@@ -350,6 +353,7 @@ export const MobileDropdown = ({
                           networks={networks}
                           selectedNetwork={selectedNetwork}
                           isDark={isDark}
+                          isNetworkLocked={hideNetworkSwitcher}
                           handleNetworkSwitchWrapper={
                             handleNetworkSwitchWrapper
                           }

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -797,7 +797,12 @@ export const WalletDetails = () => {
                                               isCngn
                                                 ? (entry.balances.rawBalances?.[
                                                   token
-                                                ] ?? balance)
+                                                ] ??
+                                                  entry.balances.rawBalances
+                                                    ?.cNGN ??
+                                                  entry.balances.rawBalances
+                                                    ?.CNGN ??
+                                                  balance)
                                                 : balance;
                                             const usdEquivalent = balance;
                                             const cngnUnknown =

--- a/app/components/WidgetShell.tsx
+++ b/app/components/WidgetShell.tsx
@@ -7,22 +7,25 @@ import {
   SquareLock02Icon,
   Wallet01Icon,
 } from "hugeicons-react";
-import { usePrivy } from "@privy-io/react-auth";
+import { useLogin, usePrivy } from "@privy-io/react-auth";
 
 import { MobileDropdown } from "./MobileDropdown";
 import { NoblocksLogo } from "./ImageAssets";
-import { useInjectedWallet } from "../context";
+import { baseBtnClasses } from "./Styles";
+import { useEmbed, useInjectedWallet } from "../context";
+import { useLoginWithScrollPin } from "../hooks/useLoginWithScrollPin";
 
 /**
  * Compact card chrome for the embedded /widget experience: a flat rounded
  * card that FILLS the entire iframe viewport — no margins, no shadow; the
  * partner sizes/rounds/floats the widget by styling the iframe element
  * itself, and the rounded corners show against the transparent backdrop.
- * Inside: a sticky wallet pill (wallet icon + chevron) opening the mobile
- * wallet drawer, the swap step, and a "Secured by Noblocks" footer row.
- * Dismissing the iframe is owned by the host page (backdrop, host close
- * control, etc.) — the widget does not render a close button.
- * Replaces Navbar/Footer/HomePage, which are hidden in embed mode.
+ * Inside: a sticky header (Sign in when logged out; wallet pill when
+ * connected) opening the mobile wallet drawer, the swap step, and a
+ * "Secured by Noblocks" footer row. Dismissing the iframe is owned by the
+ * host page (backdrop, host close control, etc.) — the widget does not
+ * render a close button. Replaces Navbar/Footer/HomePage, which are hidden
+ * in embed mode.
  *
  * The recommended iframe width (~393-420px, per Figma frame 2429:118606) is
  * below Tailwind's `sm` breakpoint, so the app renders its mobile UI inside
@@ -30,7 +33,10 @@ import { useInjectedWallet } from "../context";
  */
 export function WidgetShell({ children }: { children: React.ReactNode }) {
   const { ready, authenticated } = usePrivy();
+  const { login } = useLogin();
+  const loginWithScrollPin = useLoginWithScrollPin(login);
   const { isInjectedWallet } = useInjectedWallet();
+  const { networkLockUnresolved } = useEmbed();
   const [isWalletDrawerOpen, setIsWalletDrawerOpen] = useState(false);
 
   const isConnected = (ready && authenticated) || isInjectedWallet;
@@ -43,26 +49,44 @@ export function WidgetShell({ children }: { children: React.ReactNode }) {
           footer. The wallet header sits outside the scroll region so it
           stays visible while the form scrolls. */}
       <div className="flex h-dvh w-full flex-col rounded-3xl bg-white p-4 dark:bg-neutral-900">
-        {isConnected && (
-          <div className="mb-3 flex min-h-10 flex-shrink-0 items-center justify-end gap-2">
-            <button
-              type="button"
-              title="Wallet"
-              aria-label="Open wallet"
-              onClick={() => setIsWalletDrawerOpen(true)}
-              className="flex items-center gap-1 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-white/10"
-            >
-              <Wallet01Icon className="size-5 text-outline-gray dark:text-white/80" />
-              <ArrowDown01Icon className="size-4 text-outline-gray dark:text-white/50" />
-            </button>
-            <AnimatePresence>
-              <MobileDropdown
-                isOpen={isWalletDrawerOpen}
-                onClose={() => setIsWalletDrawerOpen(false)}
-              />
-            </AnimatePresence>
-          </div>
-        )}
+        <div className="mb-3 flex min-h-10 flex-shrink-0 items-center justify-end gap-2">
+          {networkLockUnresolved && (
+            <p className="mr-auto max-w-[60%] text-left text-xs leading-snug text-amber-700 dark:text-amber-400">
+              Unsupported network — using default.
+            </p>
+          )}
+
+          {isConnected ? (
+            <>
+              <button
+                type="button"
+                title="Wallet"
+                aria-label="Open wallet"
+                onClick={() => setIsWalletDrawerOpen(true)}
+                className="flex items-center gap-1 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-white/10"
+              >
+                <Wallet01Icon className="size-5 text-outline-gray dark:text-white/80" />
+                <ArrowDown01Icon className="size-4 text-outline-gray dark:text-white/50" />
+              </button>
+              <AnimatePresence>
+                <MobileDropdown
+                  isOpen={isWalletDrawerOpen}
+                  onClose={() => setIsWalletDrawerOpen(false)}
+                />
+              </AnimatePresence>
+            </>
+          ) : (
+            !isInjectedWallet && (
+              <button
+                type="button"
+                className={`${baseBtnClasses} min-h-9 bg-lavender-50 text-lavender-500 hover:bg-lavender-100 dark:bg-lavender-500/[12%] dark:text-lavender-500 dark:hover:bg-lavender-500/[20%]`}
+                onClick={() => loginWithScrollPin()}
+              >
+                Sign in
+              </button>
+            )
+          )}
+        </div>
 
         <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
           {children}

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -24,6 +24,7 @@ import {
   shortenAddress,
   tokenBalanceRowVisible,
 } from "../../utils";
+import { tokensEqual } from "../../lib/token-symbol";
 import type { CrossChainBalanceEntry } from "../../context";
 import TransactionList from "../transaction/TransactionList";
 import type { Network, TransactionHistory } from "../../types";
@@ -256,7 +257,7 @@ export const WalletView: React.FC<WalletViewProps> = ({
 
                 <div className="space-y-1.5">
                   {filteredBalances.map(([token, balance]) => {
-                    const isCNGN = token === "CNGN" || token === "cNGN";
+                    const isCNGN = tokensEqual(token, "cNGN");
                     const rawBalance =
                       entry.balances.rawBalances?.[token] ?? balance;
                     const tokenImageUrl =

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -52,6 +52,8 @@ interface WalletViewProps {
   networks: Network[];
   selectedNetwork: Network;
   isDark: boolean;
+  /** When true (embed host lock), show a read-only chain chip — no switcher. */
+  isNetworkLocked?: boolean;
   handleNetworkSwitchWrapper: (network: Network) => void;
   onSettings: () => void;
   onClose: () => void;
@@ -81,6 +83,7 @@ export const WalletView: React.FC<WalletViewProps> = ({
   networks,
   selectedNetwork,
   isDark,
+  isNetworkLocked = false,
   handleNetworkSwitchWrapper,
   onSettings,
   onClose,
@@ -136,9 +139,23 @@ export const WalletView: React.FC<WalletViewProps> = ({
         </div>
         <button
           type="button"
-          title="Select network"
-          onClick={() => setIsNetworkListOpen(!isNetworkListOpen)}
-          className="flex shrink-0 items-center gap-1.5 rounded-lg py-1 pl-1 pr-0.5 hover:bg-accent-gray dark:hover:bg-white/10"
+          title={isNetworkLocked ? selectedNetwork.chain.name : "Select network"}
+          aria-label={
+            isNetworkLocked
+              ? `Network locked to ${selectedNetwork.chain.name}`
+              : "Select network"
+          }
+          disabled={isNetworkLocked}
+          onClick={() => {
+            if (isNetworkLocked) return;
+            setIsNetworkListOpen(!isNetworkListOpen);
+          }}
+          className={classNames(
+            "flex shrink-0 items-center gap-1.5 rounded-lg py-1 pl-1 pr-0.5",
+            isNetworkLocked
+              ? "cursor-default"
+              : "hover:bg-accent-gray dark:hover:bg-white/10",
+          )}
         >
           <Image
             src={getNetworkImageUrl(selectedNetwork, isDark)}
@@ -150,17 +167,19 @@ export const WalletView: React.FC<WalletViewProps> = ({
           <span className="max-w-[5.5rem] truncate text-sm font-medium text-text-body dark:text-white">
             {selectedNetwork.chain.name}
           </span>
-          <ArrowDown01Icon
-            className={classNames(
-              "size-4 text-outline-gray transition-transform dark:text-white/50",
-              isNetworkListOpen && "rotate-180",
-            )}
-          />
+          {!isNetworkLocked && (
+            <ArrowDown01Icon
+              className={classNames(
+                "size-4 text-outline-gray transition-transform dark:text-white/50",
+                isNetworkListOpen && "rotate-180",
+              )}
+            />
+          )}
         </button>
       </div>
 
       <AnimatePresence>
-        {isNetworkListOpen && (
+        {!isNetworkLocked && isNetworkListOpen && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}

--- a/app/context/EmbedContext.tsx
+++ b/app/context/EmbedContext.tsx
@@ -10,10 +10,22 @@ import {
   type ReactNode,
 } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import type { Network } from "../types";
 import {
-  hasEmbedNetworkLockParams,
-  resolveNetworkFromEmbedParams,
+  parseEmbedConfig,
+  isTokenInAllowlist,
+  isCurrencyInAllowlist,
+  type HostSetConfigPayload,
+} from "../lib/embed-config";
+import {
+  isNetworkInAllowlist,
+  resolveNetworkBySlug,
 } from "../lib/embed-network";
+import {
+  canonicalTokenSymbol,
+  tokensEqual,
+} from "../lib/token-symbol";
+import { swapModeFromSideParam } from "../utils";
 
 /**
  * Embed (widget) mode context.
@@ -24,11 +36,9 @@ import {
  *   noblocks:resize  - { height } content height changed
  *   noblocks:tx_status - { status, orderId } transaction progress
  *
- * Closing / dismissing the iframe is owned by the host page — the widget
- * does not emit a close event.
- *
- * Hosts can lock the widget to a network via `?chainId=` / `?network=`, or by
- * switching an injected/bridge wallet (chainChanged). See docs/embed-widget.md.
+ * Hosts can constrain token/currency/network via URL allowlists, hide the
+ * Buy/Sell chrome, and push live updates with `noblocks:set_config`.
+ * See docs/embed-widget.md.
  *
  * The host origin is derived from document.referrer (the embedding page on an
  * iframe's first load). If the host strips its referrer entirely, events are
@@ -39,6 +49,25 @@ import {
 export const isEmbedPath = (pathname: string | null): boolean =>
   pathname === "/widget" || (pathname ?? "").startsWith("/widget/");
 
+/** Live overrides from host `noblocks:set_config` (and version for effect deps). */
+export type EmbedHostFormConfig = {
+  token?: string;
+  currency?: string;
+  side?: "buy" | "sell";
+  version: number;
+};
+
+export type ApplyHostConfigResult = {
+  network: Network | null;
+  applied: Partial<{
+    token: string;
+    currency: string;
+    side: "buy" | "sell";
+    network: string;
+  }>;
+  rejected: string[];
+};
+
 interface EmbedContextType {
   /** True when rendering the /widget embed route. */
   isEmbed: boolean;
@@ -47,18 +76,40 @@ interface EmbedContextType {
   /** Send an event to the host page. No-op outside an iframe. */
   postToHost: (event: string, payload?: unknown) => void;
   /**
-   * True when the widget network picker is locked (URL `chainId`/`network`,
-   * or a successful wallet-driven lock via chainChanged).
+   * True when the widget network picker is locked (single allowlist entry,
+   * legacy URL lock, or a successful wallet-driven lock via chainChanged).
    */
   isNetworkLocked: boolean;
   /**
-   * True when URL lock params were present but did not resolve to a supported
+   * True when URL lock/allowlist params did not resolve to a supported
    * network — picker stays locked; widget keeps last valid / default network.
    */
   networkLockUnresolved: boolean;
   /** Mark the network as locked after a successful wallet chainChanged follow. */
   lockNetworkFromWallet: () => void;
+  /** null = unrestricted; otherwise only these tokens in swap selectors. */
+  tokenAllowlist: string[] | null;
+  currencyAllowlist: string[] | null;
+  /** null = unrestricted; otherwise only these networks in the switcher. */
+  networkAllowlist: Network[] | null;
+  isTokenLocked: boolean;
+  isCurrencyLocked: boolean;
+  hideSideToggle: boolean;
+  /** Side fixed via URL `side=` or host set_config. */
+  isSideLocked: boolean;
+  defaultToken: string | null;
+  defaultCurrency: string | null;
+  defaultNetwork: Network | null;
+  /** Live host overrides for token/currency/side. */
+  hostFormConfig: EmbedHostFormConfig;
+  /**
+   * Validate host set_config payload against allowlists.
+   * Updates form overrides; returns network for the applier to set.
+   */
+  applyHostConfig: (payload: HostSetConfigPayload) => ApplyHostConfigResult;
 }
+
+const defaultHostFormConfig: EmbedHostFormConfig = { version: 0 };
 
 const EmbedContext = createContext<EmbedContextType>({
   isEmbed: false,
@@ -67,6 +118,18 @@ const EmbedContext = createContext<EmbedContextType>({
   isNetworkLocked: false,
   networkLockUnresolved: false,
   lockNetworkFromWallet: () => {},
+  tokenAllowlist: null,
+  currencyAllowlist: null,
+  networkAllowlist: null,
+  isTokenLocked: false,
+  isCurrencyLocked: false,
+  hideSideToggle: false,
+  isSideLocked: false,
+  defaultToken: null,
+  defaultCurrency: null,
+  defaultNetwork: null,
+  hostFormConfig: defaultHostFormConfig,
+  applyHostConfig: () => ({ network: null, applied: {}, rejected: [] }),
 });
 
 function EmbedProviderContent({ children }: { children: ReactNode }) {
@@ -75,25 +138,108 @@ function EmbedProviderContent({ children }: { children: ReactNode }) {
   const isEmbed = isEmbedPath(pathname);
   const [parentOrigin, setParentOrigin] = useState<string | null>(null);
   const [walletNetworkLocked, setWalletNetworkLocked] = useState(false);
+  const [hostFormConfig, setHostFormConfig] =
+    useState<EmbedHostFormConfig>(defaultHostFormConfig);
+  const [hostSideLocked, setHostSideLocked] = useState(false);
 
-  const urlLockRequested = isEmbed && hasEmbedNetworkLockParams(searchParams);
-  const urlResolvedNetwork = useMemo(
-    () =>
-      isEmbed && urlLockRequested
-        ? resolveNetworkFromEmbedParams(searchParams)
-        : null,
-    [isEmbed, urlLockRequested, searchParams],
+  const parsed = useMemo(
+    () => (isEmbed ? parseEmbedConfig(searchParams) : null),
+    [isEmbed, searchParams],
   );
 
-  const networkLockUnresolved =
-    urlLockRequested && urlResolvedNetwork === null;
+  const tokenAllowlist = parsed?.tokenAllowlist ?? null;
+  const currencyAllowlist = parsed?.currencyAllowlist ?? null;
+  const networkAllowlist = parsed?.networkConfig.allowlist ?? null;
+  const networkLockUnresolved = Boolean(parsed?.networkConfig.unresolved);
+  const urlNetworkLocked = Boolean(parsed?.networkConfig.isLocked);
   const isNetworkLocked =
-    isEmbed && (urlLockRequested || walletNetworkLocked);
+    isEmbed &&
+    (urlNetworkLocked ||
+      walletNetworkLocked ||
+      networkLockUnresolved ||
+      (networkAllowlist != null && networkAllowlist.length === 1));
+
+  const isTokenLocked = Boolean(
+    tokenAllowlist != null && tokenAllowlist.length === 1,
+  );
+  const isCurrencyLocked = Boolean(
+    currencyAllowlist != null && currencyAllowlist.length === 1,
+  );
+  const hideSideToggle = Boolean(parsed?.hideSideToggle);
+  const isSideLocked =
+    Boolean(parsed?.sideLockedFromUrl) || hostSideLocked || hideSideToggle;
 
   const lockNetworkFromWallet = useCallback(() => {
     if (!isEmbed) return;
     setWalletNetworkLocked(true);
   }, [isEmbed]);
+
+  const applyHostConfig = useCallback(
+    (payload: HostSetConfigPayload): ApplyHostConfigResult => {
+      const rejected: string[] = [];
+      const applied: ApplyHostConfigResult["applied"] = {};
+      let network: Network | null = null;
+
+      if (payload.network != null && String(payload.network).trim() !== "") {
+        const resolved = resolveNetworkBySlug(String(payload.network));
+        if (
+          !resolved ||
+          !isNetworkInAllowlist(resolved, networkAllowlist)
+        ) {
+          rejected.push("network");
+        } else {
+          network = resolved;
+          applied.network = resolved.chain.name;
+        }
+      }
+
+      let nextToken: string | undefined;
+      if (payload.token != null && String(payload.token).trim() !== "") {
+        const token = canonicalTokenSymbol(String(payload.token));
+        if (!isTokenInAllowlist(token, tokenAllowlist)) {
+          rejected.push("token");
+        } else {
+          nextToken = token;
+          applied.token = token;
+        }
+      }
+
+      let nextCurrency: string | undefined;
+      if (payload.currency != null && String(payload.currency).trim() !== "") {
+        const currency = String(payload.currency).trim().toUpperCase();
+        if (!isCurrencyInAllowlist(currency, currencyAllowlist)) {
+          rejected.push("currency");
+        } else {
+          nextCurrency = currency;
+          applied.currency = currency;
+        }
+      }
+
+      let nextSide: "buy" | "sell" | undefined;
+      if (payload.side != null && String(payload.side).trim() !== "") {
+        const mode = swapModeFromSideParam(String(payload.side));
+        if (!mode) {
+          rejected.push("side");
+        } else {
+          nextSide = mode === "onramp" ? "buy" : "sell";
+          applied.side = nextSide;
+          setHostSideLocked(true);
+        }
+      }
+
+      if (nextToken || nextCurrency || nextSide) {
+        setHostFormConfig((prev) => ({
+          version: prev.version + 1,
+          token: nextToken ?? prev.token,
+          currency: nextCurrency ?? prev.currency,
+          side: nextSide ?? prev.side,
+        }));
+      }
+
+      return { network, applied, rejected };
+    },
+    [networkAllowlist, tokenAllowlist, currencyAllowlist],
+  );
 
   useEffect(() => {
     if (!isEmbed || window.self === window.top) return;
@@ -137,6 +283,18 @@ function EmbedProviderContent({ children }: { children: ReactNode }) {
       isNetworkLocked,
       networkLockUnresolved,
       lockNetworkFromWallet,
+      tokenAllowlist,
+      currencyAllowlist,
+      networkAllowlist,
+      isTokenLocked,
+      isCurrencyLocked,
+      hideSideToggle,
+      isSideLocked,
+      defaultToken: parsed?.defaultToken ?? null,
+      defaultCurrency: parsed?.defaultCurrency ?? null,
+      defaultNetwork: parsed?.networkConfig.defaultNetwork ?? null,
+      hostFormConfig,
+      applyHostConfig,
     }),
     [
       isEmbed,
@@ -145,6 +303,18 @@ function EmbedProviderContent({ children }: { children: ReactNode }) {
       isNetworkLocked,
       networkLockUnresolved,
       lockNetworkFromWallet,
+      tokenAllowlist,
+      currencyAllowlist,
+      networkAllowlist,
+      isTokenLocked,
+      isCurrencyLocked,
+      hideSideToggle,
+      isSideLocked,
+      parsed?.defaultToken,
+      parsed?.defaultCurrency,
+      parsed?.networkConfig.defaultNetwork,
+      hostFormConfig,
+      applyHostConfig,
     ],
   );
 

--- a/app/context/EmbedContext.tsx
+++ b/app/context/EmbedContext.tsx
@@ -6,9 +6,14 @@ import {
   useEffect,
   useMemo,
   useState,
+  Suspense,
   type ReactNode,
 } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  hasEmbedNetworkLockParams,
+  resolveNetworkFromEmbedParams,
+} from "../lib/embed-network";
 
 /**
  * Embed (widget) mode context.
@@ -21,6 +26,9 @@ import { usePathname } from "next/navigation";
  *
  * Closing / dismissing the iframe is owned by the host page — the widget
  * does not emit a close event.
+ *
+ * Hosts can lock the widget to a network via `?chainId=` / `?network=`, or by
+ * switching an injected/bridge wallet (chainChanged). See docs/embed-widget.md.
  *
  * The host origin is derived from document.referrer (the embedding page on an
  * iframe's first load). If the host strips its referrer entirely, events are
@@ -38,18 +46,54 @@ interface EmbedContextType {
   parentOrigin: string | null;
   /** Send an event to the host page. No-op outside an iframe. */
   postToHost: (event: string, payload?: unknown) => void;
+  /**
+   * True when the widget network picker is locked (URL `chainId`/`network`,
+   * or a successful wallet-driven lock via chainChanged).
+   */
+  isNetworkLocked: boolean;
+  /**
+   * True when URL lock params were present but did not resolve to a supported
+   * network — picker stays locked; widget keeps last valid / default network.
+   */
+  networkLockUnresolved: boolean;
+  /** Mark the network as locked after a successful wallet chainChanged follow. */
+  lockNetworkFromWallet: () => void;
 }
 
 const EmbedContext = createContext<EmbedContextType>({
   isEmbed: false,
   parentOrigin: null,
-  postToHost: () => { },
+  postToHost: () => {},
+  isNetworkLocked: false,
+  networkLockUnresolved: false,
+  lockNetworkFromWallet: () => {},
 });
 
-export function EmbedProvider({ children }: { children: ReactNode }) {
+function EmbedProviderContent({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const isEmbed = isEmbedPath(pathname);
   const [parentOrigin, setParentOrigin] = useState<string | null>(null);
+  const [walletNetworkLocked, setWalletNetworkLocked] = useState(false);
+
+  const urlLockRequested = isEmbed && hasEmbedNetworkLockParams(searchParams);
+  const urlResolvedNetwork = useMemo(
+    () =>
+      isEmbed && urlLockRequested
+        ? resolveNetworkFromEmbedParams(searchParams)
+        : null,
+    [isEmbed, urlLockRequested, searchParams],
+  );
+
+  const networkLockUnresolved =
+    urlLockRequested && urlResolvedNetwork === null;
+  const isNetworkLocked =
+    isEmbed && (urlLockRequested || walletNetworkLocked);
+
+  const lockNetworkFromWallet = useCallback(() => {
+    if (!isEmbed) return;
+    setWalletNetworkLocked(true);
+  }, [isEmbed]);
 
   useEffect(() => {
     if (!isEmbed || window.self === window.top) return;
@@ -86,12 +130,34 @@ export function EmbedProvider({ children }: { children: ReactNode }) {
   }, [isEmbed, parentOrigin, postToHost]);
 
   const value = useMemo(
-    () => ({ isEmbed, parentOrigin, postToHost }),
-    [isEmbed, parentOrigin, postToHost],
+    () => ({
+      isEmbed,
+      parentOrigin,
+      postToHost,
+      isNetworkLocked,
+      networkLockUnresolved,
+      lockNetworkFromWallet,
+    }),
+    [
+      isEmbed,
+      parentOrigin,
+      postToHost,
+      isNetworkLocked,
+      networkLockUnresolved,
+      lockNetworkFromWallet,
+    ],
   );
 
   return (
     <EmbedContext.Provider value={value}>{children}</EmbedContext.Provider>
+  );
+}
+
+export function EmbedProvider({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={null}>
+      <EmbedProviderContent>{children}</EmbedProviderContent>
+    </Suspense>
   );
 }
 

--- a/app/context/NetworksContext.tsx
+++ b/app/context/NetworksContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useContext, useEffect } from "react";
 import { networks } from "../mocks";
 import type { Network } from "../types";
 import { isStarknetChain, isTronChain } from "../utils";
+import { useEmbed } from "./EmbedContext";
 import { useInjectedWallet } from "./InjectedWalletContext";
 
 type NetworkContextType = {
@@ -47,6 +48,7 @@ export function NetworkProvider({ children }: { children: React.ReactNode }) {
   const [selectedNetwork, setSelectedNetworkState] = useState<Network>(
     networks[0],
   );
+  const { isEmbed, isNetworkLocked } = useEmbed();
   const { isInjectedWallet, injectedReady } = useInjectedWallet();
 
   const handleNetworkChange = async (network: Network) => {
@@ -72,6 +74,10 @@ export function NetworkProvider({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
+    // Host-locked embed network is applied by EmbedNetworkLockApplier /
+    // injected chainChanged — do not overwrite from localStorage.
+    if (isEmbed && isNetworkLocked) return;
+
     const initNetwork = async () => {
       const preferredNetwork = getStoredNetwork();
       await handleNetworkChange(preferredNetwork);
@@ -81,10 +87,11 @@ export function NetworkProvider({ children }: { children: React.ReactNode }) {
       initNetwork();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isInjectedWallet, injectedReady]);
+  }, [isInjectedWallet, injectedReady, isEmbed, isNetworkLocked]);
 
   // cross-tab synchronization
   const onStorageUpdate = () => {
+    if (isEmbed && isNetworkLocked) return;
     const storedNetwork = getStoredNetwork();
     handleNetworkChange(storedNetwork);
   };
@@ -95,7 +102,7 @@ export function NetworkProvider({ children }: { children: React.ReactNode }) {
       window.removeEventListener("storage", onStorageUpdate);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isEmbed, isNetworkLocked]);
 
   return (
     <NetworkContext.Provider

--- a/app/hooks/useCNGNRate.ts
+++ b/app/hooks/useCNGNRate.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { fetchRate } from "../api/aggregator";
 import { getPreferredRateToken, normalizeNetworkForRateFetch } from "../utils";
+import { toAggregatorToken } from "../lib/token-symbol";
 import { ERROR_MESSAGES } from "../lib/errorMessages";
 
 // Constants for rate fetching configuration
@@ -95,7 +96,7 @@ async function fetchRateWithTimeout(
   try {
     const preferredToken = await getPreferredRateToken(network);
     const rateResponse = await fetchRate({
-      token: preferredToken,
+      token: toAggregatorToken(preferredToken),
       amount: 100,
       currency: "NGN",
       network: normalizeNetworkForRateFetch(network),

--- a/app/lib/embed-config.ts
+++ b/app/lib/embed-config.ts
@@ -1,0 +1,132 @@
+import {
+  parseCsvParam,
+  parseEmbedNetworkConfig,
+  type EmbedNetworkConfig,
+} from "./embed-network";
+import { canonicalTokenSymbol, tokensEqual } from "./token-symbol";
+
+type SearchParamsLike = { get: (key: string) => string | null };
+
+/**
+ * Parse a CSV allowlist param.
+ * - Key absent (`null`) → unrestricted (`null`)
+ * - Key present → list (possibly empty); symbols canonicalized for tokens
+ */
+export function parseTokenAllowlist(
+  raw: string | null,
+): string[] | null {
+  if (raw == null) return null;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const part of parseCsvParam(raw)) {
+    const symbol = canonicalTokenSymbol(part);
+    if (!symbol) continue;
+    const key = symbol.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(symbol);
+  }
+  return result;
+}
+
+export function parseCurrencyAllowlist(
+  raw: string | null,
+): string[] | null {
+  if (raw == null) return null;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const part of parseCsvParam(raw)) {
+    const code = part.toUpperCase();
+    if (!code || seen.has(code)) continue;
+    seen.add(code);
+    result.push(code);
+  }
+  return result;
+}
+
+export function isTokenInAllowlist(
+  token: string | null | undefined,
+  allowlist: string[] | null,
+): boolean {
+  if (allowlist == null) return true;
+  if (!token) return false;
+  return allowlist.some((item) => tokensEqual(item, token));
+}
+
+export function isCurrencyInAllowlist(
+  currency: string | null | undefined,
+  allowlist: string[] | null,
+): boolean {
+  if (allowlist == null) return true;
+  if (!currency) return false;
+  const upper = currency.trim().toUpperCase();
+  return allowlist.some((item) => item === upper);
+}
+
+export type HostSetConfigPayload = {
+  network?: string;
+  side?: string;
+  token?: string;
+  currency?: string;
+};
+
+export type EmbedParsedConfig = {
+  tokenAllowlist: string[] | null;
+  currencyAllowlist: string[] | null;
+  networkConfig: EmbedNetworkConfig;
+  /** Default token from `?token=` (canonicalized), if any. */
+  defaultToken: string | null;
+  /** Default currency from `?currency=`, if any. */
+  defaultCurrency: string | null;
+  hideSideToggle: boolean;
+  /** True when URL/`set_config` fixed a buy/sell side. */
+  sideLockedFromUrl: boolean;
+};
+
+function parseHideSideToggle(raw: string | null): boolean {
+  if (raw == null) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export function parseEmbedConfig(
+  searchParams: SearchParamsLike,
+): EmbedParsedConfig {
+  const tokenAllowlist = parseTokenAllowlist(searchParams.get("tokens"));
+  const currencyAllowlist = parseCurrencyAllowlist(
+    searchParams.get("currencies"),
+  );
+  const networkConfig = parseEmbedNetworkConfig(searchParams);
+
+  const tokenRaw = searchParams.get("token");
+  const parsedToken =
+    tokenRaw != null && tokenRaw.trim() !== ""
+      ? canonicalTokenSymbol(tokenRaw)
+      : null;
+
+  const currencyRaw = searchParams.get("currency");
+  const parsedCurrency =
+    currencyRaw != null && currencyRaw.trim() !== ""
+      ? currencyRaw.trim().toUpperCase()
+      : null;
+
+  const sideRaw = searchParams.get("side")?.trim().toLowerCase();
+  const sideLockedFromUrl = sideRaw === "buy" || sideRaw === "sell";
+
+  return {
+    tokenAllowlist,
+    currencyAllowlist,
+    networkConfig,
+    defaultToken:
+      parsedToken && isTokenInAllowlist(parsedToken, tokenAllowlist)
+        ? parsedToken
+        : null,
+    defaultCurrency:
+      parsedCurrency &&
+      isCurrencyInAllowlist(parsedCurrency, currencyAllowlist)
+        ? parsedCurrency
+        : null,
+    hideSideToggle: parseHideSideToggle(searchParams.get("hideSideToggle")),
+    sideLockedFromUrl,
+  };
+}

--- a/app/lib/embed-network.ts
+++ b/app/lib/embed-network.ts
@@ -4,11 +4,17 @@ import type { Network } from "../types";
 /**
  * Resolve embed URL / wallet chain IDs to a Noblocks `Network`.
  *
- * `?chainId=` is for EVM numeric (or hex) IDs. Starknet / Tron should use
- * `?network=` (by chain name) — their chain.id values are not EVM chainIds.
+ * Allowlists and `?network=` use **slugs** from chain display names
+ * (e.g. `base`, `arbitrum-one`, `starknet`). `?chainId=` remains an EVM
+ * convenience for the **default** only.
  */
 
 type SearchParamsLike = { get: (key: string) => string | null };
+
+/** Same as `normalizeNetworkForRateFetch` — kept local to avoid utils cycles. */
+function toNetworkSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "-");
+}
 
 /** Parse decimal or `0x`-prefixed hex chainId. Returns null if missing/invalid. */
 export function parseChainIdParam(
@@ -26,6 +32,11 @@ export function parseChainIdParam(
   const n = Number(trimmed);
   if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
   return n;
+}
+
+/** Slug used in allowlists and rate paths (e.g. `base`, `starknet`). */
+export function networkSlug(network: Network): string {
+  return toNetworkSlug(network.chain.name);
 }
 
 /** Match an EVM chainId (number or hex/decimal string) against `networks`. */
@@ -48,16 +59,75 @@ export function resolveNetworkByChainId(
   );
 }
 
-/** Case-insensitive match on `chain.name` (e.g. "Base", "Starknet"). */
+/**
+ * Resolve by slug (`base`, `arbitrum-one`, `starknet`) or chain display name.
+ * Accepts legacy `starknet-mainnet` as an alias for Starknet.
+ */
+export function resolveNetworkBySlug(
+  slug: string | null | undefined,
+): Network | null {
+  if (slug == null) return null;
+  const lower = slug.trim().toLowerCase();
+  if (!lower) return null;
+
+  if (lower === "starknet-mainnet") {
+    return networks.find((n) => n.chain.name === "Starknet") ?? null;
+  }
+
+  return (
+    networks.find((n) => networkSlug(n) === lower) ??
+    networks.find((n) => n.chain.name.toLowerCase() === lower) ??
+    null
+  );
+}
+
+/** @deprecated Prefer `resolveNetworkBySlug` — kept for existing call sites. */
 export function resolveNetworkByName(
   name: string | null | undefined,
 ): Network | null {
-  if (name == null) return null;
-  const lower = name.trim().toLowerCase();
-  if (!lower) return null;
-  return (
-    networks.find((n) => n.chain.name.toLowerCase() === lower) ?? null
-  );
+  return resolveNetworkBySlug(name);
+}
+
+/** Split a CSV query param into trimmed non-empty parts. */
+export function parseCsvParam(
+  raw: string | null | undefined,
+): string[] {
+  if (raw == null) return [];
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve `?networks=` CSV of slugs to Network[].
+ * Unknown slugs are dropped. Empty / missing CSV → empty array.
+ */
+export function resolveNetworksAllowlist(
+  raw: string | null | undefined,
+): Network[] {
+  const parts = parseCsvParam(raw);
+  const seen = new Set<string>();
+  const result: Network[] = [];
+  for (const part of parts) {
+    const network = resolveNetworkBySlug(part);
+    if (!network) continue;
+    const key = network.chain.name;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(network);
+  }
+  return result;
+}
+
+/** True when `network` is in an allowlist of Networks (by chain name). */
+export function isNetworkInAllowlist(
+  network: Network,
+  allowlist: Network[] | null | undefined,
+): boolean {
+  if (allowlist == null) return true;
+  if (allowlist.length === 0) return false;
+  return allowlist.some((n) => n.chain.name === network.chain.name);
 }
 
 /** True when the host passed `chainId` and/or `network` (even if empty/invalid). */
@@ -69,9 +139,16 @@ export function hasEmbedNetworkLockParams(
   );
 }
 
+/** True when `networks` query key is present (multi-network allowlist). */
+export function hasEmbedNetworksAllowlistParam(
+  searchParams: SearchParamsLike,
+): boolean {
+  return searchParams.get("networks") != null;
+}
+
 /**
- * Resolve locked network from embed URL params.
- * Prefers `chainId` when present (non-empty); otherwise uses `network`.
+ * Resolve default network from embed URL params.
+ * Prefers `chainId` when present (non-empty); otherwise uses `network` slug/name.
  * Returns null when params are missing, empty, or do not match a supported chain.
  */
 export function resolveNetworkFromEmbedParams(
@@ -86,8 +163,68 @@ export function resolveNetworkFromEmbedParams(
 
   const networkName = searchParams.get("network");
   if (networkName != null && networkName.trim() !== "") {
-    return resolveNetworkByName(networkName);
+    return resolveNetworkBySlug(networkName);
   }
 
   return null;
+}
+
+export type EmbedNetworkConfig = {
+  /** null = unrestricted; otherwise only these networks in the switcher. */
+  allowlist: Network[] | null;
+  /** Default network from URL (`network` / `chainId` / first allowlist entry). */
+  defaultNetwork: Network | null;
+  /**
+   * True when the picker is read-only: single allowlist entry, or legacy
+   * `network`/`chainId` lock without a multi-value `networks=` list.
+   */
+  isLocked: boolean;
+  /** URL requested a lock/default but nothing resolved. */
+  unresolved: boolean;
+};
+
+/**
+ * Parse embed network allowlist + default + lock from URL search params.
+ *
+ * - `networks=` CSV → allowlist (omit key = unrestricted)
+ * - `network=` / `chainId=` → default; without `networks=` also locks (legacy)
+ * - Single-entry `networks=` → locked read-only chip
+ */
+export function parseEmbedNetworkConfig(
+  searchParams: SearchParamsLike,
+): EmbedNetworkConfig {
+  const hasNetworksKey = hasEmbedNetworksAllowlistParam(searchParams);
+  const fromDefaultParams = resolveNetworkFromEmbedParams(searchParams);
+  const hadDefaultKeys = hasEmbedNetworkLockParams(searchParams);
+
+  if (hasNetworksKey) {
+    const allowlist = resolveNetworksAllowlist(searchParams.get("networks"));
+    const defaultNetwork =
+      fromDefaultParams && isNetworkInAllowlist(fromDefaultParams, allowlist)
+        ? fromDefaultParams
+        : (allowlist[0] ?? null);
+    return {
+      allowlist: allowlist.length > 0 ? allowlist : [],
+      defaultNetwork,
+      isLocked: allowlist.length === 1,
+      unresolved: allowlist.length === 0,
+    };
+  }
+
+  // Legacy: `network` / `chainId` without `networks=` → lock to that chain.
+  if (hadDefaultKeys) {
+    return {
+      allowlist: fromDefaultParams ? [fromDefaultParams] : [],
+      defaultNetwork: fromDefaultParams,
+      isLocked: true,
+      unresolved: fromDefaultParams == null,
+    };
+  }
+
+  return {
+    allowlist: null,
+    defaultNetwork: null,
+    isLocked: false,
+    unresolved: false,
+  };
 }

--- a/app/lib/embed-network.ts
+++ b/app/lib/embed-network.ts
@@ -1,0 +1,93 @@
+import { networks } from "../mocks";
+import type { Network } from "../types";
+
+/**
+ * Resolve embed URL / wallet chain IDs to a Noblocks `Network`.
+ *
+ * `?chainId=` is for EVM numeric (or hex) IDs. Starknet / Tron should use
+ * `?network=` (by chain name) — their chain.id values are not EVM chainIds.
+ */
+
+type SearchParamsLike = { get: (key: string) => string | null };
+
+/** Parse decimal or `0x`-prefixed hex chainId. Returns null if missing/invalid. */
+export function parseChainIdParam(
+  raw: string | null | undefined,
+): number | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("0x") || trimmed.startsWith("0X")) {
+    const n = Number.parseInt(trimmed, 16);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
+  return n;
+}
+
+/** Match an EVM chainId (number or hex/decimal string) against `networks`. */
+export function resolveNetworkByChainId(
+  chainId: number | string,
+): Network | null {
+  let numeric: number;
+  if (typeof chainId === "string") {
+    const parsed = parseChainIdParam(chainId);
+    if (parsed == null) return null;
+    numeric = parsed;
+  } else {
+    numeric = chainId;
+  }
+
+  return (
+    networks.find(
+      (n) => typeof n.chain.id === "number" && n.chain.id === numeric,
+    ) ?? null
+  );
+}
+
+/** Case-insensitive match on `chain.name` (e.g. "Base", "Starknet"). */
+export function resolveNetworkByName(
+  name: string | null | undefined,
+): Network | null {
+  if (name == null) return null;
+  const lower = name.trim().toLowerCase();
+  if (!lower) return null;
+  return (
+    networks.find((n) => n.chain.name.toLowerCase() === lower) ?? null
+  );
+}
+
+/** True when the host passed `chainId` and/or `network` (even if empty/invalid). */
+export function hasEmbedNetworkLockParams(
+  searchParams: SearchParamsLike,
+): boolean {
+  return (
+    searchParams.get("chainId") != null || searchParams.get("network") != null
+  );
+}
+
+/**
+ * Resolve locked network from embed URL params.
+ * Prefers `chainId` when present (non-empty); otherwise uses `network`.
+ * Returns null when params are missing, empty, or do not match a supported chain.
+ */
+export function resolveNetworkFromEmbedParams(
+  searchParams: SearchParamsLike,
+): Network | null {
+  const chainIdRaw = searchParams.get("chainId");
+  if (chainIdRaw != null && chainIdRaw.trim() !== "") {
+    const parsed = parseChainIdParam(chainIdRaw);
+    if (parsed == null) return null;
+    return resolveNetworkByChainId(parsed);
+  }
+
+  const networkName = searchParams.get("network");
+  if (networkName != null && networkName.trim() !== "") {
+    return resolveNetworkByName(networkName);
+  }
+
+  return null;
+}

--- a/app/lib/token-symbol.ts
+++ b/app/lib/token-symbol.ts
@@ -1,0 +1,31 @@
+/**
+ * Token symbol helpers for display vs aggregator wire format.
+ *
+ * UI / form state use `cNGN`. Aggregator rates and order APIs expect `CNGN`.
+ */
+
+/** Display form: `cNGN` for any cngn/CNGN/cNGN; otherwise pass-through. */
+export function canonicalTokenSymbol(symbol: string | null | undefined): string {
+  if (symbol == null) return "";
+  const trimmed = symbol.trim();
+  if (!trimmed) return "";
+  if (trimmed.toLowerCase() === "cngn") return "cNGN";
+  return trimmed;
+}
+
+/** Case-insensitive equality (cNGN === CNGN === cngn). */
+export function tokensEqual(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  if (a == null || b == null) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Aggregator wire form: `CNGN` when canonical is `cNGN`; else unchanged. */
+export function toAggregatorToken(symbol: string | null | undefined): string {
+  const canonical = canonicalTokenSymbol(symbol);
+  if (!canonical) return "";
+  if (canonical === "cNGN") return "CNGN";
+  return canonical;
+}

--- a/app/mocks.ts
+++ b/app/mocks.ts
@@ -14,7 +14,7 @@ import config from "./lib/config";
 export const starknetMainnet = {
   id: BigInt(toHex('SN_MAIN')).toString(), // Starknet Mainnet chain ID (SN_MAIN encoded)
   name: "Starknet",
-  network: "starknet-mainnet",
+  network: "starknet",
   nativeCurrency: {
     decimals: 18,
     name: "Ether",

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -165,7 +165,6 @@ export const TransactionForm = ({
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
   const [formattedSentAmount, setFormattedSentAmount] = useState("");
   const [formattedReceivedAmount, setFormattedReceivedAmount] = useState("");
-  const isFirstRender = useRef(true);
   const hasRestoredStateRef = useRef(false);
   const [rateError, setRateError] = useState<string | null>(null);
   const [isLimitModalOpen, setIsLimitModalOpen] = useState(false);
@@ -371,7 +370,7 @@ export const TransactionForm = ({
         formMethods.setValue("token", canonicalTokenSymbol(matched), {
           shouldDirty: true,
         });
-      } else if (!isFirstRender.current) {
+      } else {
         toast.error("Unsupported Token", {
           description: String(
             `${tokenParam} token is not supported on the current network.`,
@@ -402,8 +401,6 @@ export const TransactionForm = ({
       formMethods.setValue("amountReceived", fiatAmount, { shouldDirty: true });
       setIsReceiveInputActive(true);
     }
-    // Setting first render to false
-    isFirstRender.current = false;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -458,7 +455,7 @@ export const TransactionForm = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedNetwork.chain.name, tokenAllowlist],
+    [selectedNetwork.chain.name, tokenAllowlist, fetchedTokens],
   );
 
   useEffect(

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -40,6 +40,7 @@ import {
   getCurrencySymbol,
   getOnrampFiatMaxAmount,
   isOnrampFiatCurrencyCode,
+  swapModeFromSideParam,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -58,6 +59,14 @@ import {
   useEmbed,
 } from "../context";
 import { validateWalletAddress } from "../lib/validation";
+import {
+  canonicalTokenSymbol,
+  tokensEqual,
+} from "../lib/token-symbol";
+import {
+  isCurrencyInAllowlist,
+  isTokenInAllowlist,
+} from "../lib/embed-config";
 
 /**
  * Monthly KYC limits are in USD. Offramp `amountSent` is token (stable ≈ USD).
@@ -72,7 +81,7 @@ function kycUsdNotionalForLimitCheck(params: {
 }): number {
   const { isOnramp, amountSent, amountReceived, token, cngnRate } = params;
   const rate = cngnRate ?? undefined;
-  const isCngn = token === "cNGN" || token === "CNGN";
+  const isCngn = tokensEqual(token, "cNGN");
   if (isOnramp) {
     const recv = Number(amountReceived) || 0;
     if (isCngn && rate && rate > 0) return recv / rate;
@@ -114,7 +123,16 @@ export const TransactionForm = ({
   const { smartWalletBalance, externalWalletBalance, injectedWalletBalance, starknetWalletBalance, tronWalletBalance, isLoading } = useBalance();
   const shouldUseEOA = useShouldUseEOA();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
-  const { isEmbed } = useEmbed();
+  const {
+    isEmbed,
+    tokenAllowlist,
+    currencyAllowlist,
+    isTokenLocked,
+    isCurrencyLocked,
+    hideSideToggle,
+    isSideLocked,
+    hostFormConfig,
+  } = useEmbed();
   const { allTokens } = useTokens();
   // Network-aware "My wallet" / recipient address: Starknet wallet on Starknet,
   // EVM embedded EOA / smart wallet on EVM (mirrors activeWallet for EVM).
@@ -196,13 +214,19 @@ export const TransactionForm = ({
         disabled:
           item.disabled ||
           (swapMode === "onramp" && !isOnrampFiatCurrencyCode(item.name)) ||
-          (token?.toUpperCase() === "CNGN" && item.name !== "NGN"),
+          (tokensEqual(token, "cNGN") && item.name !== "NGN") ||
+          !isCurrencyInAllowlist(item.name, currencyAllowlist),
       }))
+      .filter(
+        (item) =>
+          currencyAllowlist == null ||
+          isCurrencyInAllowlist(item.name, currencyAllowlist),
+      )
       .sort((a, b) => {
         if (a.disabled === b.disabled) return 0;
         return a.disabled ? 1 : -1;
       });
-  }, [currencies, swapMode, token]);
+  }, [currencies, swapMode, token, currencyAllowlist]);
 
   // state for reordered currencies
   const [orderedCurrencies, setOrderedCurrencies] =
@@ -255,9 +279,12 @@ export const TransactionForm = ({
 
   // For CNGN, use raw balance instead of USD equivalent. If rawBalances doesn't contain
   // the token, treat as zero rather than falling back to USD-denominated balance.
-  const balance =
-    token === "CNGN" || token === "cNGN"
-      ? (activeBalance?.rawBalances?.[token] ?? activeBalance?.balances[token] ?? 0)
+  const balance = tokensEqual(token, "cNGN")
+      ? (activeBalance?.rawBalances?.[token] ??
+        activeBalance?.rawBalances?.cNGN ??
+        activeBalance?.rawBalances?.CNGN ??
+        activeBalance?.balances[token] ??
+        0)
       : (activeBalance?.balances[token] ?? 0);
 
   const fetchedTokens: Token[] = allTokens[selectedNetwork.chain.name] || [];
@@ -279,10 +306,12 @@ export const TransactionForm = ({
     );
   };
 
-  const tokens = fetchedTokens.map((token) => ({
-    name: token.symbol,
-    imageUrl: token.imageUrl,
-  }));
+  const tokens = fetchedTokens
+    .filter((t) => isTokenInAllowlist(t.symbol, tokenAllowlist))
+    .map((t) => ({
+      name: t.symbol,
+      imageUrl: t.imageUrl,
+    }));
 
   const handleBalanceMaxClick = () => {
     if (balance > 0) {
@@ -324,8 +353,8 @@ export const TransactionForm = ({
   };
 
   useEffect(function setDefaultValueOnPageLoad() {
-    const token = searchParams.get("token");
-    const currency = searchParams.get("currency");
+    const tokenParam = searchParams.get("token");
+    const currencyParam = searchParams.get("currency");
     const tokenAmount = +parseFloat(
       searchParams.get("tokenAmount") || "0",
     ).toFixed(2);
@@ -334,25 +363,31 @@ export const TransactionForm = ({
     ).toFixed(4);
 
     const supportedTokens = tokens.map((tokenElement) => tokenElement.name);
-    if (token && supportedTokens.includes(token)) {
-      formMethods.setValue("token", token, { shouldDirty: true });
+    if (tokenParam) {
+      const matched = supportedTokens.find((name) =>
+        tokensEqual(name, tokenParam),
+      );
+      if (matched) {
+        formMethods.setValue("token", canonicalTokenSymbol(matched), {
+          shouldDirty: true,
+        });
+      } else if (!isFirstRender.current) {
+        toast.error("Unsupported Token", {
+          description: String(
+            `${tokenParam} token is not supported on the current network.`,
+          ),
+        });
+      }
     }
-
-    // Check's if not first render to prevent display of error 2nd time
-    if (!isFirstRender.current && token && !supportedTokens.includes(token)) {
-      toast.error("Unsupported Token", {
-        description: String(
-          `${token} token is not supported on the current network.`,
-        ),
-      });
-    }
-    if (currency) {
+    if (currencyParam) {
       const supported = selectableCurrencies.find(
-        (c: CurrencyOption) => c.name === currency && !c.disabled,
+        (c: CurrencyOption) =>
+          c.name.toUpperCase() === currencyParam.trim().toUpperCase() &&
+          !c.disabled,
       );
 
       if (supported) {
-        formMethods.setValue("currency", currency, { shouldDirty: true });
+        formMethods.setValue("currency", supported.name, { shouldDirty: true });
         formMethods.setValue("receiveDestinationExplicitlySelected", true, {
           shouldDirty: true,
         });
@@ -374,17 +409,56 @@ export const TransactionForm = ({
   }, []);
 
   useEffect(
-    function initSelectedToken() {
-      if (getValues("isSwapped")) return;
-      if (
-        !fetchedTokens.find((t) => t.symbol === token) &&
-        fetchedTokens.length > 0
-      ) {
-        setValue("token", fetchedTokens[0].symbol, { shouldDirty: true });
+    function applyHostFormConfig() {
+      if (!isEmbed || hostFormConfig.version === 0) return;
+
+      if (hostFormConfig.token) {
+        const matched = tokens.find((t) =>
+          tokensEqual(t.name, hostFormConfig.token),
+        );
+        if (matched) {
+          setValue("token", matched.name, { shouldDirty: true });
+        }
+      }
+      if (hostFormConfig.currency) {
+        const matched = selectableCurrencies.find(
+          (c) =>
+            c.name.toUpperCase() === hostFormConfig.currency && !c.disabled,
+        );
+        if (matched) {
+          setValue("currency", matched.name, { shouldDirty: true });
+          setValue("receiveDestinationExplicitlySelected", true, {
+            shouldDirty: true,
+          });
+        }
+      }
+      if (hostFormConfig.side) {
+        const mode = swapModeFromSideParam(hostFormConfig.side);
+        if (mode) {
+          setValue("swapMode", mode, { shouldDirty: true });
+          setValue("isSwapped", mode === "onramp", { shouldDirty: true });
+        }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedNetwork.chain.name],
+    [hostFormConfig.version],
+  );
+
+  useEffect(
+    function initSelectedToken() {
+      if (getValues("isSwapped")) return;
+      const allowedFetched = fetchedTokens.filter((t) =>
+        isTokenInAllowlist(t.symbol, tokenAllowlist),
+      );
+      if (
+        !allowedFetched.find((t) => tokensEqual(t.symbol, token)) &&
+        allowedFetched.length > 0
+      ) {
+        setValue("token", allowedFetched[0].symbol, { shouldDirty: true });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedNetwork.chain.name, tokenAllowlist],
   );
 
   useEffect(
@@ -508,12 +582,10 @@ export const TransactionForm = ({
         let maxAmountSentValue = 10000;
         let minAmountSentValue = 0.5;
 
-        const normalizedToken = token?.toUpperCase();
-
         if (swapMode === "onramp") {
           maxAmountSentValue = getOnrampFiatMaxAmount(currency || "NGN");
           setRateError(null);
-        } else if (normalizedToken === "CNGN") {
+        } else if (tokensEqual(token, "cNGN")) {
           if (cngnRate && cngnRate > 0) {
             // Valid rate available - calculate limits and clear errors
             maxAmountSentValue = 50000000;
@@ -594,7 +666,7 @@ export const TransactionForm = ({
               );
             }
           }
-        } else if (normalizedToken === "CNGN") {
+        } else if (tokensEqual(token, "cNGN")) {
           const ngnEnabled = selectableCurrencies.some(
             (item) => item.name === "NGN" && !item.disabled,
           );
@@ -795,6 +867,7 @@ export const TransactionForm = ({
 
   // Handle swap button click to switch between token/currency dropdowns
   const handleSwapFields = () => {
+    if (isSideLocked) return;
     const willBeSwapped = !isSwapped;
     if (willBeSwapped && !onrampSupported) {
       toast.error("Buy is not available on Tron yet", {
@@ -1006,60 +1079,62 @@ export const TransactionForm = ({
         noValidate
       >
         <div className="grid gap-2 rounded-[20px] bg-background-neutral p-2 dark:bg-white/5">
-          <div className="flex items-center justify-between px-2 py-1">
-            <h3 className="text-base font-medium">Swap</h3>
+          {!hideSideToggle && (
+            <div className="flex items-center justify-between px-2 py-1">
+              <h3 className="text-base font-medium">Swap</h3>
 
-            <div className="flex items-center gap-1">
-              {/* On-ramp button */}
-              <button
-                type="button"
-                aria-disabled={!onrampSupported}
-                onClick={() => {
-                  if (!onrampSupported) {
-                    toast.error("Buy is not available on Tron yet", {
-                      description:
-                        "Switch to another network to buy crypto, or use Sell on Tron.",
-                    });
-                    return;
-                  }
-                  if (!isSwapped) {
-                    void handleSwapFields();
-                  }
-                }}
-                className={[
-                  "px-4 h-8 text-sm font-medium rounded-full transition-colors",
-                  "bg-neutral-100 dark:bg-[#141414]",
-                  !onrampSupported
-                    ? "cursor-not-allowed opacity-40"
-                    : "",
-                  isSwapped
-                    ? "border border-neutral-400 text-neutral-900 dark:border-[#FFFFFF1A] dark:text-white"
-                    : "border border-transparent text-neutral-400 dark:text-[#bdbdbd80]",
-                ].join(" ")}
-              >
-                Buy
-              </button>
+              <div className="flex items-center gap-1">
+                {/* On-ramp button */}
+                <button
+                  type="button"
+                  aria-disabled={!onrampSupported}
+                  onClick={() => {
+                    if (!onrampSupported) {
+                      toast.error("Buy is not available on Tron yet", {
+                        description:
+                          "Switch to another network to buy crypto, or use Sell on Tron.",
+                      });
+                      return;
+                    }
+                    if (!isSwapped) {
+                      void handleSwapFields();
+                    }
+                  }}
+                  className={[
+                    "px-4 h-8 text-sm font-medium rounded-full transition-colors",
+                    "bg-neutral-100 dark:bg-[#141414]",
+                    !onrampSupported
+                      ? "cursor-not-allowed opacity-40"
+                      : "",
+                    isSwapped
+                      ? "border border-neutral-400 text-neutral-900 dark:border-[#FFFFFF1A] dark:text-white"
+                      : "border border-transparent text-neutral-400 dark:text-[#bdbdbd80]",
+                  ].join(" ")}
+                >
+                  Buy
+                </button>
 
-              {/* Off-ramp button */}
-              <button
-                type="button"
-                onClick={() => {
-                  if (isSwapped) {
-                    void handleSwapFields();
-                  }
-                }}
-                className={[
-                  "px-4 h-8 text-sm font-medium rounded-full transition-colors",
-                  "bg-neutral-100 dark:bg-[#141414]",
-                  !isSwapped
-                    ? "border border-neutral-400 text-neutral-900 dark:border-[#FFFFFF1A] dark:text-white"
-                    : "border border-transparent text-neutral-400 dark:text-[#bdbdbd80]",
-                ].join(" ")}
-              >
-                Sell
-              </button>
+                {/* Off-ramp button */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (isSwapped) {
+                      void handleSwapFields();
+                    }
+                  }}
+                  className={[
+                    "px-4 h-8 text-sm font-medium rounded-full transition-colors",
+                    "bg-neutral-100 dark:bg-[#141414]",
+                    !isSwapped
+                      ? "border border-neutral-400 text-neutral-900 dark:border-[#FFFFFF1A] dark:text-white"
+                      : "border border-transparent text-neutral-400 dark:text-[#bdbdbd80]",
+                  ].join(" ")}
+                >
+                  Sell
+                </button>
+              </div>
             </div>
-          </div>
+          )}
 
           <motion.div
             layout
@@ -1161,6 +1236,7 @@ export const TransactionForm = ({
                   className="min-w-80"
                   dropdownWidth={320}
                   isCTA={!currency}
+                  disabled={isCurrencyLocked}
                 />
               ) : (
                 <FormDropdown
@@ -1173,6 +1249,7 @@ export const TransactionForm = ({
                   }
                   className="min-w-32"
                   dropdownWidth={160}
+                  disabled={isTokenLocked}
                 />
               )}
             </div>
@@ -1190,21 +1267,23 @@ export const TransactionForm = ({
               )}
 
             {/* Arrow showing swap direction */}
-            <button
-              type="button"
-              onClick={handleSwapFields}
-              className="absolute -bottom-5 left-1/2 z-10 w-fit -translate-x-1/2 rounded-xl border-4 border-background-neutral bg-background-neutral dark:border-white/5 dark:bg-surface-canvas"
-            >
-              <div className="rounded-lg bg-white p-0.5 dark:bg-surface-canvas">
-                {isFetchingRate ? (
-                  <span className="animate-spin text-xl text-outline-gray dark:text-white/50">
-                    <ImSpinner3 />
-                  </span>
-                ) : (
-                  <ArrowUpDownIcon className="text-xl text-outline-gray dark:text-white/40" />
-                )}
-              </div>
-            </button>
+            {!isSideLocked && (
+              <button
+                type="button"
+                onClick={handleSwapFields}
+                className="absolute -bottom-5 left-1/2 z-10 w-fit -translate-x-1/2 rounded-xl border-4 border-background-neutral bg-background-neutral dark:border-white/5 dark:bg-surface-canvas"
+              >
+                <div className="rounded-lg bg-white p-0.5 dark:bg-surface-canvas">
+                  {isFetchingRate ? (
+                    <span className="animate-spin text-xl text-outline-gray dark:text-white/50">
+                      <ImSpinner3 />
+                    </span>
+                  ) : (
+                    <ArrowUpDownIcon className="text-xl text-outline-gray dark:text-white/40" />
+                  )}
+                </div>
+              </button>
+            )}
           </motion.div>
 
           {/* Amount to receive & currency */}
@@ -1262,6 +1341,7 @@ export const TransactionForm = ({
                   }}
                   className="min-w-32"
                   dropdownWidth={160}
+                  disabled={isTokenLocked}
                 />
               ) : (
                 <FormDropdown
@@ -1283,6 +1363,7 @@ export const TransactionForm = ({
                       (authenticated && !(totalRequired > balance)))
                   }
                   dropdownWidth={320}
+                  disabled={isCurrencyLocked}
                 />
               )}
             </div>

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -19,6 +19,7 @@ import {
   publicKeyEncrypt,
   shortenAddress,
 } from "../utils";
+import { tokensEqual, toAggregatorToken } from "../lib/token-symbol";
 import { useNetwork, useTokens } from "../context";
 import config, { getDelegationContractAddress } from "../lib/config";
 import { appendBaseBuilderCode } from "../lib/baseBuilderCode";
@@ -222,10 +223,13 @@ export const TransactionPreview = ({
       : smartWalletBalance;
 
   // For CNGN, use raw balance (token units) instead of USD equivalent
-  const balance =
-    token === "CNGN" || token === "cNGN"
-      ? (activeBalance?.rawBalances?.[token] ?? activeBalance?.balances[token] ?? 0)
-      : (activeBalance?.balances[token] ?? 0);
+  const balance = tokensEqual(token, "cNGN")
+    ? (activeBalance?.rawBalances?.[token] ??
+      activeBalance?.rawBalances?.cNGN ??
+      activeBalance?.rawBalances?.CNGN ??
+      activeBalance?.balances[token] ??
+      0)
+    : (activeBalance?.balances[token] ?? 0);
 
   // Rendered tsx info
   const renderedInfo = isOnramp
@@ -690,7 +694,7 @@ export const TransactionPreview = ({
             walletAddress: activeWallet.address,
             transactionType: "onramp",
             fromCurrency: currency,
-            toCurrency: token,
+            toCurrency: toAggregatorToken(token),
             amountSent: Number(amountSent),
             amountReceived: Number(amountReceived),
             fee: Number(rate),
@@ -717,7 +721,7 @@ export const TransactionPreview = ({
           },
           destination: {
             type: "crypto" as const,
-            currency: token,
+            currency: toAggregatorToken(token),
             network: aggregatorNetwork,
             ...(providerId ? { providerId } : {}),
             recipient: {
@@ -806,7 +810,7 @@ export const TransactionPreview = ({
       await precheckSwapTransaction(
         {
           walletAddress: activeWallet.address,
-          fromCurrency: token,
+          fromCurrency: toAggregatorToken(token),
           toCurrency: currency,
           amountSent: Number(amountSent),
           amountReceived: Number(amountReceived),

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -28,6 +28,7 @@ import {
   EmbedProvider,
   isEmbedPath,
 } from "./context";
+import { EmbedNetworkLockApplier } from "./components/EmbedNetworkLockApplier";
 import { useActualTheme } from "./hooks/useActualTheme";
 import { useMixpanel } from "./hooks/analytics/client";
 import { BlockFestClaimProvider } from "./context/BlockFestClaimContext";
@@ -113,6 +114,7 @@ function ContextProviders({ children }: { children: ReactNode }) {
       <NetworkProvider>
       <HomeTransactionFormModeProvider>
         <InjectedWalletProvider>
+          <EmbedNetworkLockApplier />
           <MigrationStatusProvider>
             <StarknetProvider>
               <StarknetExportModalProvider>

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -18,6 +18,7 @@ import { erc20Abi, createPublicClient, http, keccak256, stringToBytes } from "vi
 import { mainnet } from "viem/chains";
 import { getEnsName } from "viem/actions";
 import { isValidEvmAddressCaseInsensitive } from "./lib/validation";
+import { canonicalTokenSymbol } from "./lib/token-symbol";
 import { colors } from "./mocks";
 import { fetchTokens } from "./api/aggregator";
 import { toast } from "sonner";
@@ -602,12 +603,13 @@ export function normalizeNetworkName(networkId: string): string {
  * @returns Formatted token for application use
  */
 export function transformToken(apiToken: APIToken): Token {
+  const symbol = canonicalTokenSymbol(apiToken.symbol);
   return {
-    name: apiToken.symbol,
-    symbol: apiToken.symbol,
+    name: symbol,
+    symbol,
     decimals: apiToken.decimals,
     address: apiToken.contractAddress,
-    imageUrl: `/logos/${apiToken.symbol.toLowerCase()}-logo.svg`,
+    imageUrl: `/logos/${symbol.toLowerCase()}-logo.svg`,
   };
 }
 
@@ -1578,7 +1580,10 @@ export function isStarknetChain(chain: {
 } | null | undefined): boolean {
   if (!chain) return false;
   if (chain.name === "Starknet") return true;
-  return chain.network === "starknet-mainnet";
+  // Accept both `starknet` (canonical) and legacy `starknet-mainnet`.
+  return (
+    chain.network === "starknet" || chain.network === "starknet-mainnet"
+  );
 }
 
 /** True for Tron mainnet (mock chain + viem-style `network` slug). */

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -72,6 +72,35 @@ Notes:
 | `provider`    | liquidity provider ID    | Pin a specific liquidity provider                         |
 | `ref`         | referral code            | Attribute transactions to your referral code              |
 | `injected`    | `true` \| `bridge`       | Wallet mode — see below                                   |
+| `chainId`     | decimal or `0x` hex      | Lock to an EVM network (e.g. `8453` or `0x2105` for Base) |
+| `network`     | chain name               | Lock by Noblocks name (e.g. `Base`, `Starknet`) — case-insensitive |
+
+### Network lock / follow
+
+Pass `chainId` and/or `network` to **lock** the widget to that chain:
+
+- The wallet drawer shows a read-only chain chip (no network switcher).
+- Balance-based auto network hopping is disabled.
+- Prefer **`chainId`** for EVM hosts. Use **`network`** for Starknet / Tron (and as an alternate for EVM by name). If both are present, `chainId` wins when non-empty.
+- An unsupported or unknown value toasts once, keeps the picker locked, and leaves the last valid network (or the widget default). A short inline note appears in the header on first paint failure.
+
+With `injected=true` or `injected=bridge`, the widget also **follows** the host wallet:
+
+- EIP-1193 `chainChanged` (extension or bridge) updates the displayed network when the new chain is supported, and keeps the lock on that chain.
+- Unsupported wallet chains toast once and do **not** unlock the picker.
+
+Closing / dismissing the iframe remains the host page’s responsibility (unchanged).
+
+```html
+<!-- Lock to Base -->
+<iframe src="https://noblocks.xyz/widget?chainId=8453&currency=NGN" ...></iframe>
+
+<!-- Lock to Starknet by name -->
+<iframe src="https://noblocks.xyz/widget?network=Starknet" ...></iframe>
+
+<!-- Bridge wallet + lock; follow host chain switches -->
+<iframe src="https://noblocks.xyz/widget?injected=bridge&chainId=8453" ...></iframe>
+```
 
 ## Widget → host events (postMessage)
 

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -61,33 +61,71 @@ Notes:
 
 ## URL parameters
 
-| Param         | Values                   | Effect                                                    |
-| ------------- | ------------------------ | --------------------------------------------------------- |
-| `theme`       | `dark` \| `light`        | Force the widget theme (default: visitor system theme)    |
-| `side`        | `buy` \| `sell`          | Start in on-ramp (buy) or off-ramp (sell) mode            |
-| `token`       | e.g. `USDC`, `USDT`      | Preselect token                                           |
-| `currency`    | e.g. `NGN`, `KES`        | Preselect fiat currency                                   |
-| `tokenAmount` | number                   | Prefill token amount                                      |
-| `fiatAmount`  | number                   | Prefill fiat amount                                       |
-| `provider`    | liquidity provider ID    | Pin a specific liquidity provider                         |
-| `ref`         | referral code            | Attribute transactions to your referral code              |
-| `injected`    | `true` \| `bridge`       | Wallet mode — see below                                   |
-| `chainId`     | decimal or `0x` hex      | Lock to an EVM network (e.g. `8453` or `0x2105` for Base) |
-| `network`     | chain name               | Lock by Noblocks name (e.g. `Base`, `Starknet`) — case-insensitive |
+| Param            | Values                              | Effect                                                                 |
+| ---------------- | ----------------------------------- | ---------------------------------------------------------------------- |
+| `theme`          | `dark` \| `light`                   | Force the widget theme (default: visitor system theme)                 |
+| `side`           | `buy` \| `sell`                     | Start in on-ramp (buy) or off-ramp (sell) mode; locks the center flip  |
+| `token`          | e.g. `USDC`, `cNGN`, `CNGN`         | Preselect token (case-insensitive; `CNGN`/`cNGN` both display as cNGN) |
+| `tokens`         | CSV of symbols                      | Allowlist for the token dropdown (omit = all; one entry = read-only)   |
+| `currency`       | e.g. `NGN`, `KES`                   | Preselect fiat currency                                                |
+| `currencies`     | CSV of codes                        | Allowlist for the currency dropdown (omit = all; one entry = read-only)|
+| `tokenAmount`    | number                              | Prefill token amount                                                   |
+| `fiatAmount`     | number                              | Prefill fiat amount                                                    |
+| `provider`       | liquidity provider ID               | Pin a specific liquidity provider                                      |
+| `ref`            | referral code                       | Attribute transactions to your referral code                           |
+| `injected`       | `true` \| `bridge`                  | Wallet mode — see below                                                |
+| `chainId`        | decimal or `0x` hex                 | Default EVM network only (e.g. `8453` / `0x2105` for Base)             |
+| `network`        | slug                                | Default network by slug (e.g. `base`, `starknet`, `arbitrum-one`)      |
+| `networks`       | CSV of slugs                        | Allowlist for the network switcher (omit = all; one entry = locked)    |
+| `hideSideToggle` | `1` \| `true`                       | Hide the “Swap” title and Buy/Sell pills (also locks the center flip)  |
+
+`cNGN` / `CNGN` are accepted interchangeably in URL and host config; the UI
+shows **cNGN**. Aggregator rate/order calls still use the wire form `CNGN`.
+
+### Token / currency / network allowlists
+
+```
+/widget?
+  side=sell
+  &token=cNGN&tokens=cNGN
+  &currency=NGN&currencies=NGN
+  &network=base&networks=base,arbitrum-one
+  &hideSideToggle=1
+  &injected=bridge
+```
+
+- Omit an allowlist param (`tokens`, `currencies`, `networks`) to leave that
+  selector unrestricted.
+- A single-item allowlist renders a read-only chip (dropdown disabled).
+- Multi-item `networks=` filters the wallet network switcher only — balance
+  lists and history stay **unfiltered**.
+- Without `networks=`, a lone `network=` / `chainId=` keeps the previous
+  **lock** behaviour (read-only chip + no balance auto-hop).
+- Supported network slugs match rate paths: `base`, `arbitrum-one`,
+  `bnb-smart-chain`, `polygon`, `lisk`, `celo`, `scroll`, `ethereum`,
+  `starknet`, `tron`. Legacy `starknet-mainnet` is accepted as an alias.
 
 ### Network lock / follow
 
-Pass `chainId` and/or `network` to **lock** the widget to that chain:
+Pass `chainId` and/or `network` to set the **default** chain (and lock when
+`networks=` is not a multi-value list):
 
-- The wallet drawer shows a read-only chain chip (no network switcher).
-- Balance-based auto network hopping is disabled.
-- Prefer **`chainId`** for EVM hosts. Use **`network`** for Starknet / Tron (and as an alternate for EVM by name). If both are present, `chainId` wins when non-empty.
-- An unsupported or unknown value toasts once, keeps the picker locked, and leaves the last valid network (or the widget default). A short inline note appears in the header on first paint failure.
+- The wallet drawer shows a read-only chain chip when locked (no switcher).
+- Balance-based auto network hopping is disabled whenever a network allowlist
+  or lock is set.
+- Prefer **`chainId`** for EVM default. Use **`network`** (slug) for Starknet /
+  Tron and for allowlists. If both default params are present, `chainId` wins
+  when non-empty.
+- An unsupported or unknown value toasts once and leaves the last valid
+  network (or the widget default).
 
 With `injected=true` or `injected=bridge`, the widget also **follows** the host wallet:
 
-- EIP-1193 `chainChanged` (extension or bridge) updates the displayed network when the new chain is supported, and keeps the lock on that chain.
-- Unsupported wallet chains toast once and do **not** unlock the picker.
+- EIP-1193 `chainChanged` (extension or bridge) updates the displayed network
+  when the new chain is supported **and** within the network allowlist (if set),
+  and keeps the lock on that chain.
+- Unsupported / out-of-allowlist wallet chains toast once and do **not** unlock
+  the picker.
 
 Closing / dismissing the iframe remains the host page’s responsibility (unchanged).
 
@@ -95,8 +133,11 @@ Closing / dismissing the iframe remains the host page’s responsibility (unchan
 <!-- Lock to Base -->
 <iframe src="https://noblocks.xyz/widget?chainId=8453&currency=NGN" ...></iframe>
 
-<!-- Lock to Starknet by name -->
-<iframe src="https://noblocks.xyz/widget?network=Starknet" ...></iframe>
+<!-- Lock to Starknet by slug -->
+<iframe src="https://noblocks.xyz/widget?network=starknet" ...></iframe>
+
+<!-- Allow Base + Arbitrum; default Base -->
+<iframe src="https://noblocks.xyz/widget?networks=base,arbitrum-one&network=base" ...></iframe>
 
 <!-- Bridge wallet + lock; follow host chain switches -->
 <iframe src="https://noblocks.xyz/widget?injected=bridge&chainId=8453" ...></iframe>
@@ -126,6 +167,34 @@ window.addEventListener("message", (e) => {
   // ...
 });
 ```
+
+## Host → widget: `noblocks:set_config`
+
+After the widget is ready, the host can push live updates (same origin /
+`event.source` checks as the wallet bridge):
+
+```js
+iframe.contentWindow.postMessage(
+  {
+    source: "noblocks-host",
+    event: "noblocks:set_config",
+    payload: {
+      network: "arbitrum-one", // slug
+      side: "sell",            // buy | sell
+      token: "cNGN",           // or CNGN
+      currency: "NGN",
+    },
+  },
+  "https://noblocks.xyz",
+);
+```
+
+Values outside the URL allowlists (or unsupported chains/tokens) are ignored
+and toasted. Omit fields you do not want to change.
+
+`NoblocksEmbed.bindWallet` (see below) already posts `noblocks-host` messages
+for the wallet bridge; you can reuse the same `postMessage` pattern for
+`set_config`, or call `iframe.contentWindow.postMessage` directly as above.
 
 ## Wallet modes
 

--- a/public/embed.js
+++ b/public/embed.js
@@ -20,6 +20,17 @@
  *     );
  *   </script>
  *
+ * Live config (optional): after noblocks:ready, post to the iframe:
+ *   iframe.contentWindow.postMessage(
+ *     {
+ *       source: "noblocks-host",
+ *       event: "noblocks:set_config",
+ *       payload: { network: "base", side: "sell", token: "cNGN", currency: "NGN" },
+ *     },
+ *     widgetOrigin
+ *   );
+ * Values are validated against URL allowlists (?tokens=, ?currencies=, ?networks=).
+ *
  * Call bindWallet before (or immediately after) adding the iframe so no
  * request from the widget is missed. Signing prompts appear in the host
  * wallet's own UI; the widget never sees keys. Dismissing the iframe


### PR DESCRIPTION
### Description

Partner embed improvements for `/widget`, building on the existing iframe embed.

**Auth chrome**
- Navbar-style **Sign in** in `WidgetShell` when logged out (form CTA stays **Swap**, matching non-embed)
- Sticky wallet pill when connected

**Network + allowlists**
- `token` / `tokens`, `currency` / `currencies`, `network` / `networks` (CSV allowlists; omit = all; length 1 = read-only chip)
- Network params use **slugs** (`base`, `arbitrum-one`, `bnb-smart-chain`, `starknet`)
- `chainId` still supported as an EVM default convenience
- Wallet balances/history stay unfiltered; only swap selectors and the network switcher respect allowlists
- Balance auto-hop skipped when a network allowlist/lock is active
- Injected/bridge `chainChanged` follows the wallet when the new chain is allowed

**Host live config**
- `noblocks:set_config` postMessage for `network` / `side` / `token` / `currency` (allowlist-validated)

**Chrome**
- `hideSideToggle=1` hides the in-widget Buy/Sell pills and the Swap title (host tabs + `?side=` drive mode)

**cNGN**
- Display and matching use **cNGN**; `CNGN` / `cNGN` both accepted in URL/params
- Aggregator requests still send **CNGN**
- Internal Starknet `chain.network` is `starknet` (legacy `starknet-mainnet` still accepted)

Docs: `docs/embed-widget.md`. Unit tests for allowlists, slugs, and token symbols.

### References

- Follow-up to embeddable widget (#609 / #611) and sticky header / host-owned dismiss (#612)
- Partner feedback: missing Sign in, chain lock/follow, asset/corridor allowlists, hide duplicate Buy/Sell

### Testing

- Unit: `__tests__/embed-network.test.ts`, `__tests__/embed-config.test.ts`, `__tests__/token-symbol.test.ts`
- Manual (embed, flag on):
  - Logged-out `/widget` shows Sign in; after login shows wallet pill; form CTA still says Swap
  - `?token=cNGN` and `?token=CNGN` both select cNGN; UI shows cNGN
  - `?tokens=USDC,USDT&token=USDC` filters picker; single `tokens=cNGN` is read-only
  - `?networks=base,arbitrum-one&network=base` filters network switcher; balances still show other assets
  - `?hideSideToggle=1&side=sell` hides Swap/Buy/Sell header
  - Host `noblocks:set_config` updates side/network within allowlist
  - Bridge `chainChanged` within allowlist updates network
- Environment: Next.js app, Chrome; `NEXT_PUBLIC_EMBED_ENABLED=true`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embed-mode network locking that applies host-driven constraints at runtime, including “unsupported network” and “unsupported configuration” warnings.
  * Widget now supports allowlists for tokens, currencies, and networks, plus host live updates via configuration messages.
  * Embedded UI can disable/hide selectors when locked.
* **Bug Fixes**
  * Improved cNGN token handling and normalization across balances and transaction flows.
  * Refined embed parameter validation and matching for tokens/currencies and network selection.
* **Documentation**
  * Expanded embed URL parameters and live configuration messaging guidance.
* **Tests**
  * Added coverage for embed config/network parsing and token symbol helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->