### PR TITLE
feat(widget): lazy Connect wallet CTA for injected mode + chainIds allowlist

### DIFF
--- a/__tests__/embed-network.test.ts
+++ b/__tests__/embed-network.test.ts
@@ -160,6 +160,51 @@ describe("embed-network", () => {
       expect(config.allowlist).toBeNull();
       expect(config.isLocked).toBe(false);
     });
+
+    it("uses chainIds CSV as a multi-chain allowlist", () => {
+      const config = parseEmbedNetworkConfig(
+        params({ chainIds: "8453,42161" }),
+      );
+      expect(config.isLocked).toBe(false);
+      expect(config.allowlist?.map((n) => n.chain.name)).toEqual([
+        "Base",
+        "Arbitrum One",
+      ]);
+      expect(config.defaultNetwork?.chain.name).toBe("Base");
+    });
+
+    it("locks on a single-entry chainIds allowlist", () => {
+      const config = parseEmbedNetworkConfig(params({ chainIds: "0x2105" }));
+      expect(config.isLocked).toBe(true);
+      expect(config.allowlist?.map((n) => n.chain.name)).toEqual(["Base"]);
+      expect(config.defaultNetwork?.chain.name).toBe("Base");
+    });
+
+    it("unions networks and chainIds, deduping by chain", () => {
+      const config = parseEmbedNetworkConfig(
+        params({ networks: "base", chainIds: "42161,8453" }),
+      );
+      expect(config.allowlist?.map((n) => n.chain.name)).toEqual([
+        "Base",
+        "Arbitrum One",
+      ]);
+      expect(config.isLocked).toBe(false);
+    });
+
+    it("drops unknown chainIds and keeps the valid remainder", () => {
+      const config = parseEmbedNetworkConfig(
+        params({ chainIds: "999999,8453" }),
+      );
+      expect(config.allowlist?.map((n) => n.chain.name)).toEqual(["Base"]);
+      expect(config.isLocked).toBe(true);
+    });
+
+    it("marks all-invalid chainIds unresolved, matching networks= behavior", () => {
+      const config = parseEmbedNetworkConfig(params({ chainIds: "999999" }));
+      expect(config.allowlist).toEqual([]);
+      expect(config.unresolved).toBe(true);
+      expect(config.isLocked).toBe(false);
+    });
   });
 
   describe("hasEmbedNetworkLockParams", () => {
@@ -176,10 +221,13 @@ describe("embed-network", () => {
   });
 
   describe("hasEmbedNetworksAllowlistParam", () => {
-    it("detects the networks key", () => {
+    it("detects the networks and chainIds keys", () => {
       expect(hasEmbedNetworksAllowlistParam(params({ networks: "base" }))).toBe(
         true,
       );
+      expect(
+        hasEmbedNetworksAllowlistParam(params({ chainIds: "8453" })),
+      ).toBe(true);
       expect(hasEmbedNetworksAllowlistParam(params({}))).toBe(false);
     });
   });

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -46,6 +46,7 @@ export const Navbar = () => {
   const {
     isInjectedWallet,
     injectedAddress,
+    injectedReady,
     injectedRequested,
     injectedStatus,
   } = useInjectedWallet();
@@ -363,7 +364,7 @@ export const Navbar = () => {
         </div>
 
         <div className="flex gap-3 text-sm font-medium *:flex-shrink-0 sm:gap-4">
-          {(ready && authenticated) || isInjectedWallet ? (
+          {(ready && authenticated) || (isInjectedWallet && injectedReady) ? (
             <>
               <div className="hidden sm:block">
                 <WalletDetails />

--- a/app/components/WidgetShell.tsx
+++ b/app/components/WidgetShell.tsx
@@ -35,14 +35,18 @@ export function WidgetShell({ children }: { children: React.ReactNode }) {
   const { ready, authenticated } = usePrivy();
   const { login } = useLogin();
   const loginWithScrollPin = useLoginWithScrollPin(login);
-  const { isInjectedWallet, injectedRequested, injectedStatus } =
+  const { isInjectedWallet, injectedReady, injectedRequested, injectedStatus } =
     useInjectedWallet();
   const { networkLockUnresolved } = useEmbed();
   const [isWalletDrawerOpen, setIsWalletDrawerOpen] = useState(false);
 
-  const isConnected = (ready && authenticated) || isInjectedWallet;
+  // Injected mode counts as connected only once an account is actually in
+  // hand; while awaiting the host wallet the header shows neither the pill
+  // nor Sign in (the primary CTA reads "Connect wallet" instead).
+  const isConnected =
+    (ready && authenticated) || (isInjectedWallet && injectedReady);
   // The host asked us to use its wallet, so never offer our own login while
-  // that connection is still being established — only once it has failed.
+  // that connection is still possible — only once it has definitively failed.
   const injectedPendingOrActive =
     injectedRequested && injectedStatus !== "unavailable";
 

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   Suspense,
 } from "react";
-import { createWalletClient, custom, toHex } from "viem";
+import { toHex } from "viem";
 import { createSiweMessage, generateSiweNonce } from "viem/siwe";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
@@ -21,14 +21,18 @@ import {
 import { useEmbed } from "./EmbedContext";
 
 /**
- * "pending" covers the whole connect handshake (bridge origin resolution, the
- * host ACK wait, eth_requestAccounts). "unavailable" means the connection was
- * requested but definitively failed — only then should the widget offer its
- * own login as a fallback.
+ * "pending" covers in-flight work (bridge origin resolution, the host ACK
+ * wait, an eth_requestAccounts prompt). "awaiting_connection" means injected
+ * mode is viable (bridge answered / extension present) but no account is
+ * connected yet — the CTA reads "Connect wallet" and we follow the host's
+ * accountsChanged. "unavailable" means the connection was requested but
+ * definitively failed — only then should the widget offer its own login as a
+ * fallback.
  */
 export type InjectedWalletStatus =
   | "idle"
   | "pending"
+  | "awaiting_connection"
   | "connected"
   | "unavailable";
 
@@ -50,6 +54,12 @@ interface InjectedWalletContextType {
   injectedRequested: boolean;
   injectedStatus: InjectedWalletStatus;
   /**
+   * Gesture-driven connect for the "Connect wallet" CTA: prompts the injected
+   * provider via eth_requestAccounts. Resolves true once an account is
+   * connected. No-op unless status is "awaiting_connection".
+   */
+  connectInjectedWallet: () => Promise<boolean>;
+  /**
    * Session JWT for authenticating API requests (middleware `x-injected-token`).
    * A connected wallet alone does NOT authenticate API calls — the wallet must
    * sign a SIWE challenge once, exchanged server-side for this token. Returns
@@ -69,6 +79,7 @@ const InjectedWalletContext = createContext<InjectedWalletContextType>({
   injectedReady: false,
   injectedRequested: false,
   injectedStatus: "idle",
+  connectInjectedWallet: async () => false,
   getInjectedToken: async () => null,
   getInjectedAuthHeaders: async () => null,
 });
@@ -250,7 +261,7 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Committed to a handshake: claim a run id and mark this param handled so
+      // Committed to a probe: claim a run id and mark this param handled so
       // only genuinely new attempts (not dep re-runs) supersede this one.
       if (!useBridge) handledNonBridgeParamRef.current = injectedParam;
       const runId = ++runIdRef.current;
@@ -260,27 +271,29 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       setInjectedStatus("pending");
 
       try {
-        const client = createWalletClient({
-          transport: custom(provider as any),
-        });
-
-        await (provider as any).request({ method: "eth_requestAccounts" });
-        const [address] = await client.getAddresses();
+        // Silent probe only — no wallet prompt on load. eth_accounts returns
+        // the already-authorized accounts (and, over the bridge, doubles as
+        // the "is a host bridge listening" check via the ACK timeout).
+        // Connecting is a user gesture: the "Connect wallet" CTA calls
+        // connectInjectedWallet(), and managed hosts (wagmi/AppKit) connect
+        // through their own UI, which reaches us as accountsChanged.
+        const accounts = (await (provider as any).request({
+          method: "eth_accounts",
+        })) as string[] | undefined;
+        const [address] = accounts ?? [];
 
         if (isStale()) return;
 
+        // Keep the provider either way: awaiting mode needs it for the
+        // accountsChanged subscription and the CTA-driven connect.
+        setInjectedProvider(provider);
+
         if (address) {
-          setInjectedProvider(provider);
           setInjectedAddress(address);
           setInjectedReady(true);
           setInjectedStatus("connected");
         } else {
-          console.warn("No address returned from injected wallet.");
-          toast.error(
-            "Couldn't connect to your wallet. Please check your wallet connection.",
-          );
-          setIsInjectedWallet(false);
-          setInjectedStatus("unavailable");
+          setInjectedStatus("awaiting_connection");
         }
       } catch (error) {
         if (isStale()) return;
@@ -301,24 +314,12 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
           return;
         }
 
-        console.error("Failed to initialize injected wallet:", error);
-
-        if ((error as any)?.code === 4001) {
-          toast.error("Connection to wallet was rejected.", {
-            description: "Proceeding without wallet connection.",
-          });
-          // Reset injected wallet state on rejection
-          setIsInjectedWallet(false);
-          setInjectedProvider(null);
-          setInjectedAddress(null);
-          setInjectedReady(false);
-        } else {
-          toast.error(
-            "Failed to connect to wallet. Please refresh and try again.",
-          );
-          setIsInjectedWallet(false);
-        }
-        setInjectedStatus("unavailable");
+        // A failed silent probe isn't terminal: the provider exists, so let
+        // the user drive connection from the CTA instead of falling back to
+        // the widget's own login.
+        console.error("Injected wallet probe failed:", error);
+        setInjectedProvider(provider);
+        setInjectedStatus("awaiting_connection");
       }
     };
 
@@ -327,7 +328,8 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   }, [searchParams, parentOrigin, parentOriginResolved]);
 
   // Track host-side account switches (extension wallets and the embed bridge
-  // both emit standard EIP-1193 events).
+  // both emit standard EIP-1193 events). While awaiting_connection this is
+  // also how a managed host's own "Connect wallet" flow reaches us.
   useEffect(() => {
     if (!injectedProvider?.on) return;
     const handleAccountsChanged = (accounts: unknown) => {
@@ -337,16 +339,15 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       sessionRef.current = null;
       if (address) {
         setInjectedAddress(address);
+        setInjectedReady(true);
         setInjectedStatus("connected");
       } else {
-        // Host disconnected the wallet. Clear the injected flags too, not just
-        // the status — WidgetShell/Navbar treat isInjectedWallet as "connected"
-        // and would otherwise never fall through to the widget's own login.
+        // Host disconnected the wallet. The bridge/extension is still alive,
+        // so go back to awaiting — the CTA reads "Connect wallet" again —
+        // rather than falling back to the widget's own login.
         setInjectedAddress(null);
         setInjectedReady(false);
-        setInjectedProvider(null);
-        setIsInjectedWallet(false);
-        setInjectedStatus("unavailable");
+        setInjectedStatus("awaiting_connection");
       }
     };
     injectedProvider.on("accountsChanged", handleAccountsChanged);
@@ -358,6 +359,63 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
     };
   }, [injectedProvider]);
 
+  // Single-flight guard: concurrent CTA taps share one wallet prompt.
+  const connectInFlightRef = useRef<Promise<boolean> | null>(null);
+
+  /** Gesture-driven connect for the "Connect wallet" CTA. */
+  const connectInjectedWallet = useCallback(async (): Promise<boolean> => {
+    if (injectedStatus !== "awaiting_connection" || !injectedProvider) {
+      return injectedStatus === "connected";
+    }
+    if (connectInFlightRef.current) return connectInFlightRef.current;
+
+    const attempt = (async () => {
+      setInjectedStatus("pending");
+      try {
+        const accounts = (await injectedProvider.request({
+          method: "eth_requestAccounts",
+        })) as string[] | undefined;
+        const [address] = accounts ?? [];
+
+        if (address) {
+          setInjectedAddress(address);
+          setInjectedReady(true);
+          setInjectedStatus("connected");
+          return true;
+        }
+
+        // Managed hosts (wagmi/AppKit behind the bridge) can't prompt from
+        // here — connection happens through the host page's own button and
+        // arrives via accountsChanged.
+        toast.info("Connect your wallet on this site to continue.");
+        setInjectedStatus("awaiting_connection");
+        return false;
+      } catch (error) {
+        if ((error as any)?.code === BRIDGE_UNAVAILABLE_CODE) {
+          // Host bridge went away mid-session.
+          setIsInjectedWallet(false);
+          setInjectedProvider(null);
+          setInjectedStatus("unavailable");
+          return false;
+        }
+        if ((error as any)?.code === 4001) {
+          toast.error("Connection request was rejected.");
+        } else {
+          console.error("Injected wallet connect failed:", error);
+          toast.error("Couldn't connect the wallet. Please try again.");
+        }
+        // Retryable: stay in awaiting so the CTA keeps offering Connect.
+        setInjectedStatus("awaiting_connection");
+        return false;
+      } finally {
+        connectInFlightRef.current = null;
+      }
+    })();
+
+    connectInFlightRef.current = attempt;
+    return attempt;
+  }, [injectedStatus, injectedProvider]);
+
   return (
     <InjectedWalletContext.Provider
       value={{
@@ -367,6 +425,7 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
         injectedReady,
         injectedRequested,
         injectedStatus,
+        connectInjectedWallet,
         getInjectedToken,
         getInjectedAuthHeaders,
       }}

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -359,6 +359,35 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
     };
   }, [injectedProvider]);
 
+  // Close the subscription gap: the accountsChanged listener above only
+  // attaches after the provider lands in state, so a host connection made
+  // between the initial silent probe and that subscription would be missed.
+  // Re-probe (silently) whenever we enter awaiting_connection — this effect
+  // is declared after the subscription effect, so within a commit the
+  // listener is attached before the re-probe runs and no window remains.
+  useEffect(() => {
+    if (injectedStatus !== "awaiting_connection" || !injectedProvider) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const accounts = (await injectedProvider.request({
+          method: "eth_accounts",
+        })) as string[] | undefined;
+        const [address] = accounts ?? [];
+        if (!cancelled && address) {
+          setInjectedAddress(address);
+          setInjectedReady(true);
+          setInjectedStatus("connected");
+        }
+      } catch {
+        // Silent probe; stay in awaiting_connection.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [injectedStatus, injectedProvider]);
+
   // Single-flight guard: concurrent CTA taps share one wallet prompt.
   const connectInFlightRef = useRef<Promise<boolean> | null>(null);
 

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -43,7 +43,8 @@ export function useSwapButton({
   networkName = "",
 }: UseSwapButtonProps) {
   const { authenticated } = usePrivy();
-  const { isInjectedWallet } = useInjectedWallet();
+  const { isInjectedWallet, injectedReady, injectedStatus } =
+    useInjectedWallet();
   const {
     amountSent,
     currency,
@@ -52,6 +53,17 @@ export function useSwapButton({
     receiveDestinationExplicitlySelected,
     token,
   } = watch();
+
+  // Injected mode with no account yet: the CTA becomes "Connect wallet"
+  // (enabled even on an empty form) and everything balance/KYC-related below
+  // must not run — a disconnected wallet's balance is 0, which would
+  // otherwise misread as "Insufficient balance".
+  const isInjectedAwaiting =
+    isInjectedWallet &&
+    !injectedReady &&
+    injectedStatus === "awaiting_connection";
+  const isInjectedConnecting =
+    isInjectedWallet && !injectedReady && injectedStatus === "pending";
 
   // Off-ramp: min 0.5 token. On-ramp: min fiat 0.5×rate only after receive token + rate (same as onrampFiatMin).
   const isAmountValid = isSwapped
@@ -75,6 +87,10 @@ export function useSwapButton({
     : Boolean(recipientName);
 
   const isEnabled = (() => {
+    // Connecting needs no amount: the CTA is live as soon as the form renders.
+    if (isInjectedAwaiting) return true;
+    if (isInjectedConnecting) return false;
+
     // Phone / next-tier KYC from the main CTA must work before the user picks a
     // recipient; otherwise the verify label appears on a permanently disabled button.
     const rateReady = Boolean(rate) && Number(rate) > 0;
@@ -131,6 +147,9 @@ export function useSwapButton({
   })();
 
   const buttonText = (() => {
+    if (isInjectedAwaiting) return "Connect wallet";
+    if (isInjectedConnecting) return "Connecting...";
+
     if (isInjectedWallet && hasInsufficientBalance) {
       return "Insufficient balance";
     }
@@ -169,7 +188,11 @@ export function useSwapButton({
     openLimitModal: () => void,
     isPhoneVerified: boolean,
     isUserVerified: boolean,
+    connectWallet?: () => void,
   ) => {
+    if ((isInjectedAwaiting || isInjectedConnecting) && connectWallet) {
+      return connectWallet;
+    }
     if (!authenticated && !isInjectedWallet) {
       return login;
     }

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -43,7 +43,7 @@ export function useSwapButton({
   networkName = "",
 }: UseSwapButtonProps) {
   const { authenticated } = usePrivy();
-  const { isInjectedWallet, injectedReady, injectedStatus } =
+  const { isInjectedWallet, injectedReady, injectedRequested, injectedStatus } =
     useInjectedWallet();
   const {
     amountSent,
@@ -57,13 +57,16 @@ export function useSwapButton({
   // Injected mode with no account yet: the CTA becomes "Connect wallet"
   // (enabled even on an empty form) and everything balance/KYC-related below
   // must not run — a disconnected wallet's balance is 0, which would
-  // otherwise misread as "Insufficient balance".
+  // otherwise misread as "Insufficient balance". Anchored on injectedRequested
+  // (synchronous, from the URL) rather than isInjectedWallet: during bridge
+  // initialization the status is "pending" before isInjectedWallet flips true,
+  // and the CTA must not route to Privy login in that window.
   const isInjectedAwaiting =
-    isInjectedWallet &&
+    injectedRequested &&
     !injectedReady &&
     injectedStatus === "awaiting_connection";
   const isInjectedConnecting =
-    isInjectedWallet && !injectedReady && injectedStatus === "pending";
+    injectedRequested && !injectedReady && injectedStatus === "pending";
 
   // Off-ramp: min 0.5 token. On-ramp: min fiat 0.5×rate only after receive token + rate (same as onrampFiatMin).
   const isAmountValid = isSwapped

--- a/app/lib/embed-network.ts
+++ b/app/lib/embed-network.ts
@@ -120,6 +120,29 @@ export function resolveNetworksAllowlist(
   return result;
 }
 
+/**
+ * Resolve `?chainIds=` CSV of EVM chain IDs (decimal or 0x hex) to Network[].
+ * The allowlist counterpart of `?chainId=`, the way `?networks=` pairs with
+ * `?network=`. Unknown/invalid IDs are dropped. Empty / missing CSV → empty
+ * array.
+ */
+export function resolveChainIdsAllowlist(
+  raw: string | null | undefined,
+): Network[] {
+  const parts = parseCsvParam(raw);
+  const seen = new Set<string>();
+  const result: Network[] = [];
+  for (const part of parts) {
+    const network = resolveNetworkByChainId(part);
+    if (!network) continue;
+    const key = network.chain.name;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(network);
+  }
+  return result;
+}
+
 /** True when `network` is in an allowlist of Networks (by chain name). */
 export function isNetworkInAllowlist(
   network: Network,
@@ -139,11 +162,14 @@ export function hasEmbedNetworkLockParams(
   );
 }
 
-/** True when `networks` query key is present (multi-network allowlist). */
+/** True when a network allowlist key (`networks` / `chainIds`) is present. */
 export function hasEmbedNetworksAllowlistParam(
   searchParams: SearchParamsLike,
 ): boolean {
-  return searchParams.get("networks") != null;
+  return (
+    searchParams.get("networks") != null ||
+    searchParams.get("chainIds") != null
+  );
 }
 
 /**
@@ -186,9 +212,11 @@ export type EmbedNetworkConfig = {
 /**
  * Parse embed network allowlist + default + lock from URL search params.
  *
- * - `networks=` CSV → allowlist (omit key = unrestricted)
- * - `network=` / `chainId=` → default; without `networks=` also locks (legacy)
- * - Single-entry `networks=` → locked read-only chip
+ * - `networks=` CSV of slugs and/or `chainIds=` CSV of EVM chain IDs →
+ *   allowlist (the union when both are present; omit both = unrestricted)
+ * - `network=` / `chainId=` → default; without an allowlist key also locks
+ *   (legacy)
+ * - Single-entry allowlist → locked read-only chip
  */
 export function parseEmbedNetworkConfig(
   searchParams: SearchParamsLike,
@@ -198,7 +226,15 @@ export function parseEmbedNetworkConfig(
   const hadDefaultKeys = hasEmbedNetworkLockParams(searchParams);
 
   if (hasNetworksKey) {
-    const allowlist = resolveNetworksAllowlist(searchParams.get("networks"));
+    const bySlug = resolveNetworksAllowlist(searchParams.get("networks"));
+    const byChainId = resolveChainIdsAllowlist(searchParams.get("chainIds"));
+    const seen = new Set<string>();
+    const allowlist: Network[] = [];
+    for (const network of [...bySlug, ...byChainId]) {
+      if (seen.has(network.chain.name)) continue;
+      seen.add(network.chain.name);
+      allowlist.push(network);
+    }
     const defaultNetwork =
       fromDefaultParams && isNetworkInAllowlist(fromDefaultParams, allowlist)
         ? fromDefaultParams

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -124,8 +124,12 @@ export const TransactionForm = ({
     isLoading,
   } = useBalance();
   const shouldUseEOA = useShouldUseEOA();
-  const { isInjectedWallet, injectedAddress, injectedReady } =
-    useInjectedWallet();
+  const {
+    isInjectedWallet,
+    injectedAddress,
+    injectedReady,
+    connectInjectedWallet,
+  } = useInjectedWallet();
   // Privy `authenticated` is false in injected mode (extension or embed
   // bridge) — balance display and over-balance validation must treat a ready
   // injected wallet as connected too.
@@ -1614,6 +1618,7 @@ export const TransactionForm = ({
                 () => setIsLimitModalOpen(true),
                 isPhoneVerified,
                 isUserVerified,
+                () => void connectInjectedWallet(),
               )}
             >
               {buttonText}

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -37,12 +37,13 @@ inside your iframe. Non-whitelisted origins are blocked by the browser.
 
 Notes:
 
-- The widget **fills the iframe**: it has no margins, shadow, or fixed size of
-  its own. You control the size, corner radius, shadow, and positioning by
-  styling the `<iframe>` element (as above). The example's rounded corners +
-  shadow give the floating-card look; drop them for a flush embed. The widget
-  keeps `background: transparent`, so its rounded corners reveal your page
-  behind them. Set the iframe's `border-radius` to match (24px).
+- The widget **fills the iframe**: a single card with no outer margins, shadow,
+  or fixed size of its own. You control the size, shadow, and positioning by
+  styling the `<iframe>` element (as above). The card itself has 24px rounded
+  corners and its own internal padding; the page behind the card is
+  transparent, so your page shows through the corner cut-outs. Set the
+  iframe's `border-radius` to 24px to match (as in the example), or clip
+  harder for a flush embed.
 - Recommended width **360–420px**. The widget renders its mobile UI below
   ~640px wide (a comfortable compact layout); above that it would switch to
   the desktop layout, so keep it narrow. Height is flexible: size it to fit

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -37,15 +37,15 @@ inside your iframe. Non-whitelisted origins are blocked by the browser.
 
 Notes:
 
-- The widget **fills the iframe** — it has no margins, shadow, or fixed size of
+- The widget **fills the iframe**: it has no margins, shadow, or fixed size of
   its own. You control the size, corner radius, shadow, and positioning by
   styling the `<iframe>` element (as above). The example's rounded corners +
   shadow give the floating-card look; drop them for a flush embed. The widget
   keeps `background: transparent`, so its rounded corners reveal your page
-  behind them — set the iframe's `border-radius` to match (24px).
+  behind them. Set the iframe's `border-radius` to match (24px).
 - Recommended width **360–420px**. The widget renders its mobile UI below
   ~640px wide (a comfortable compact layout); above that it would switch to
-  the desktop layout, so keep it narrow. Height is flexible — size it to fit
+  the desktop layout, so keep it narrow. Height is flexible: size it to fit
   the flow (≈670–750px works well); the footer pins to the bottom edge, and
   the wallet control stays visible while the form scrolls.
 - **Dismissing the widget is your responsibility.** Provide whatever close
@@ -72,13 +72,13 @@ Notes:
 | `tokenAmount`    | number                              | Prefill token amount                                                   |
 | `fiatAmount`     | number                              | Prefill fiat amount                                                    |
 | `provider`       | liquidity provider ID               | Pin a specific liquidity provider                                      |
-| `ref`            | referral code                       | Attribute transactions to your referral code                           |
-| `injected`       | `true` \| `bridge`                  | Wallet mode — see below                                                |
+| `injected`       | `true` \| `bridge`                  | Wallet mode (see below)                                                |
 | `chainId`        | decimal or `0x` hex                 | Default EVM network only (e.g. `8453` / `0x2105` for Base)             |
+| `chainIds`       | CSV of decimal or `0x` hex          | Allowlist for the network switcher by EVM chain ID; unioned with `networks` |
 | `network`        | slug                                | Default network by slug (e.g. `base`, `starknet`, `arbitrum-one`)      |
 | `networks`       | CSV of slugs                        | Allowlist for the network switcher (omit = all; one entry = locked)    |
 | `hideSideToggle` | `1` \| `true`                       | Hide the “Swap” title and Buy/Sell pills (also locks the center flip)  |
-| `hideSupport`    | `1` \| `true`                       | Hide the in-widget support chat (default: shown) — see below           |
+| `hideSupport`    | `1` \| `true`                       | Hide the in-widget support chat, default shown (see below)             |
 
 `cNGN` / `CNGN` are accepted interchangeably in URL and host config; the UI
 shows **cNGN**. Aggregator rate/order calls still use the wire form `CNGN`.
@@ -95,12 +95,14 @@ shows **cNGN**. Aggregator rate/order calls still use the wire form `CNGN`.
   &injected=bridge
 ```
 
-- Omit an allowlist param (`tokens`, `currencies`, `networks`) to leave that
-  selector unrestricted.
+- Omit an allowlist param (`tokens`, `currencies`, `networks`, `chainIds`) to
+  leave that selector unrestricted.
 - A single-item allowlist renders a read-only chip (dropdown disabled).
-- Multi-item `networks=` filters the wallet network switcher only — balance
-  lists and history stay **unfiltered**.
-- Without `networks=`, a lone `network=` / `chainId=` keeps the previous
+- `networks=` takes slugs; `chainIds=` takes EVM chain IDs (decimal or `0x`
+  hex). Passing both unions the two lists.
+- A multi-item network allowlist filters the wallet network switcher only;
+  balance lists and history stay **unfiltered**.
+- Without an allowlist key, a lone `network=` / `chainId=` keeps the previous
   **lock** behaviour (read-only chip + no balance auto-hop).
 - Supported network slugs match rate paths: `base`, `arbitrum-one`,
   `bnb-smart-chain`, `polygon`, `lisk`, `celo`, `scroll`, `ethereum`,
@@ -109,13 +111,14 @@ shows **cNGN**. Aggregator rate/order calls still use the wire form `CNGN`.
 ### Network lock / follow
 
 Pass `chainId` and/or `network` to set the **default** chain (and lock when
-`networks=` is not a multi-value list):
+no multi-value allowlist is present):
 
 - The wallet drawer shows a read-only chain chip when locked (no switcher).
 - Balance-based auto network hopping is disabled whenever a network allowlist
   or lock is set.
 - Prefer **`chainId`** for EVM default. Use **`network`** (slug) for Starknet /
-  Tron and for allowlists. If both default params are present, `chainId` wins
+  Tron. For allowlists, use `networks=` (slugs, covers Starknet/Tron) or
+  `chainIds=` (EVM IDs). If both default params are present, `chainId` wins
   when non-empty.
 - An unsupported or unknown value toasts once and leaves the last valid
   network (or the widget default).
@@ -153,6 +156,9 @@ interactive), so hiding it also trims that download from the embed.
 
 <!-- Allow Base + Arbitrum; default Base -->
 <iframe src="https://noblocks.xyz/widget?networks=base,arbitrum-one&network=base" ...></iframe>
+
+<!-- Same allowlist by EVM chain id -->
+<iframe src="https://noblocks.xyz/widget?chainIds=8453,42161&chainId=8453" ...></iframe>
 
 <!-- Bridge wallet + lock; follow host chain switches -->
 <iframe src="https://noblocks.xyz/widget?injected=bridge&chainId=8453" ...></iframe>
@@ -215,17 +221,39 @@ for the wallet bridge; you can reuse the same `postMessage` pattern for
 
 ### Default: Privy login in the widget
 
-Users sign in with email (Privy) inside the widget — no host integration
+Users sign in with email (Privy) inside the widget, with no host integration
 needed. Note: in Safari/Firefox, storage partitioning means the session may
 not persist across page reloads, and OAuth popups must not be blocked.
+
+### Connection flow in injected modes
+
+In both injected modes the widget never prompts the wallet on load. It checks
+silently (`eth_accounts`) for an already-authorized account:
+
+- Already connected: the widget shows the wallet pill and behaves as signed in.
+- Not connected yet: the header shows neither Sign in nor the pill, and the
+  primary button reads **"Connect wallet"**. Tapping it requests connection
+  (`eth_requestAccounts`). The widget also listens for `accountsChanged`, so a
+  connection made through **your page's own connect button** is picked up
+  automatically. This matters for managed connector stacks (wagmi, AppKit,
+  WalletConnect): those providers usually cannot open a connect prompt from
+  inside the iframe, so your own connect flow is the reliable path and the
+  widget follows it.
+- The Privy sign-in fallback appears only when injected mode is genuinely
+  unavailable: no host bridge responded, or `injected=true` without an
+  extension wallet.
+
+The first authenticated action (e.g. submitting a swap) additionally asks the
+wallet for a one-time SIWE signature to authenticate API calls. It is a plain
+message signature: no transaction, no gas.
 
 ### `injected=true` — extension wallet inside the iframe
 
 Browser-extension wallets (MetaMask, Rabby, ...) inject `window.ethereum`
 into iframes too, so the user transacts with the same extension they use on
-your page. The wallet prompts them once to connect the noblocks.xyz origin
-(auto-connects on return visits). This does **not** cover WalletConnect /
-mobile-QR sessions — use the bridge for those.
+your page. The "Connect wallet" button prompts the extension once for the
+noblocks.xyz origin (auto-connects on return visits). This does **not** cover
+WalletConnect / mobile-QR sessions; use the bridge for those.
 
 ### `injected=bridge` — hand off your page's connected wallet
 
@@ -233,15 +261,15 @@ Your page proxies the widget's wallet requests to **your** connected provider
 (WalletConnect, AppKit, wagmi, `window.ethereum`, ...). All signing prompts
 appear in your wallet UI; the widget never sees keys.
 
-`bindWallet` is **required** for `injected=bridge` — don't pass the param on a
-plain iframe with no host script. (If no bridge responds within ~4 seconds,
-the widget automatically falls back to the standard sign-in flow rather than
-hanging, but users see a loading state for those seconds.)
+`bindWallet` is **required** for `injected=bridge`. Don't pass the param on a
+plain iframe with no host script: if no bridge responds within ~4 seconds,
+the widget falls back to the standard sign-in flow rather than hanging, but
+users see a loading state for those seconds.
 
-Bind the wallet **before** the iframe loads — create the iframe without a
+Bind the wallet **before** the iframe loads: create the iframe without a
 `src`, call `bindWallet` (which installs the message listener), then set `src`.
-Otherwise a fast widget load can fire `eth_requestAccounts` before the listener
-exists and the request hangs until timeout.
+Otherwise a fast widget load can probe the wallet before the listener exists
+and the request hangs until timeout.
 
 ```html
 <script src="https://noblocks.xyz/embed.js"></script>
@@ -269,22 +297,27 @@ NoblocksEmbed.bindWallet(iframe, client.transport, { onEvent });
 iframe.src = "https://noblocks.xyz/widget?injected=bridge";
 ```
 
+If your users may open the widget before connecting a wallet on your page,
+bind the provider anyway; when they later connect through your UI, the
+provider's `accountsChanged` event flows through the bridge and the widget
+picks the wallet up without a reload.
+
 The returned `unbind()` removes all listeners.
 
 ## Configuration (Noblocks operators)
 
-- `NEXT_PUBLIC_EMBED_ENABLED` — feature flag; when not `"true"`, `/widget`
+- `NEXT_PUBLIC_EMBED_ENABLED`: feature flag; when not `"true"`, `/widget`
   returns 404.
-- `EMBED_ALLOWED_ORIGINS` — comma-separated base allowlist (env-only, needs a
+- `EMBED_ALLOWED_ORIGINS`: comma-separated base allowlist (env-only, needs a
   redeploy to change). Origins must be `https://` (only `http://localhost` is
   accepted, for local dev).
-- `INTERNAL_API_BASE_URL` — trusted absolute base URL (e.g. `https://noblocks.xyz`)
+- `INTERNAL_API_BASE_URL`: trusted absolute base URL (e.g. `https://noblocks.xyz`)
   the middleware uses to fetch the DB-backed allowlist. **Required to consult the
-  `embed_allowed_origins` table** — if unset, only `EMBED_ALLOWED_ORIGINS` is
+  `embed_allowed_origins` table**; if unset, only `EMBED_ALLOWED_ORIGINS` is
   used. Never derived from the request Host header, so a poisoned host can't
   redirect the authenticated fetch. On a failed/non-OK refresh the DB-backed
   origins are dropped (fail closed) until the next successful fetch.
-- `embed_allowed_origins` table (Supabase) — runtime allowlist, merged with the
+- `embed_allowed_origins` table (Supabase): runtime allowlist, merged with the
   env var by `middleware.ts` (cached ~5 min). Managed via the secret-gated
   internal API:
 
@@ -306,5 +339,5 @@ Also add partner origins to the **Privy dashboard allowed origins** so Privy
 login works inside their frames.
 
 Widget loads are attributed server-side (cookieless) via the middleware
-analytics event `Embed Widget Loaded` with the embedding `referrer_origin` —
+analytics event `Embed Widget Loaded` with the embedding `referrer_origin`;
 no client trackers or cookie banner run inside the widget.


### PR DESCRIPTION
### Description

Follow-up to #627. On a real partner embed (managed connector stack with its own Connect button), `?injected=bridge` showed the widget's Privy **"Sign in"** button whenever the host wallet wasn't connected yet. The widget eagerly called `eth_requestAccounts` on load; managed providers (wagmi/AppKit) can't open a connect prompt from inside an iframe, so the call returned no accounts and the widget misread that as a terminal failure, falling back to Sign in — wrong, since the host explicitly requested wallet mode.

**Connection flow (both `injected=true` and `injected=bridge`):**

- New `awaiting_connection` status in `InjectedWalletContext`: wallet mode is viable (bridge ACKed / extension present) but no account is connected. In this state the header shows neither Sign in nor the wallet pill (its space is preserved), and the **primary CTA reads "Connect wallet"**, enabled even on an empty form (Uniswap pattern).
- Load now probes silently with `eth_accounts` — no wallet prompt on load. `eth_requestAccounts` fires only from the CTA (a user gesture) via the new `connectInjectedWallet()`. Managed hosts that can't prompt get an info toast pointing at the host page's own connect flow; a connection made there reaches the widget via `accountsChanged` and flips it to connected automatically.
- Host disconnect returns to `awaiting_connection` (CTA offers Connect again) instead of the Privy fallback. Sign in still appears only when injected mode is genuinely unavailable: no host bridge answered (4900 ACK timeout), `injected=true` without an extension, stripped referrer.
- `useSwapButton` short-circuits awaiting/pending ahead of the balance/KYC branches, so a disconnected wallet's zero balance can't misread as "Insufficient balance". Rejection (4001) is retryable and stays on the Connect CTA.
- SIWE (from #626) is unchanged: the one-time signature still happens lazily at the first authenticated action, not at connect.

**Embed params:**

- New `?chainIds=` CSV allowlist (decimal or `0x` hex EVM ids) — the allowlist counterpart of `?chainId=` the way `?networks=` pairs with `?network=`. Unioned with `?networks=` when both are present; same single-entry-locks / all-invalid-unresolved semantics.

**Docs (`docs/embed-widget.md`):**

- New "Connection flow in injected modes" section; `chainIds` row and examples; removed the partner-facing `ref` row (it is a Noblocks-user referral param, not an embed option — it keeps working); reduced em-dash usage throughout for readability.

### References

Follow-up to #627 (merged) and builds on the SIWE session auth from #626.

### Testing

Automated: `npx tsc --noEmit` clean; `npm test` — 16 suites, 187 tests pass (5 new `chainIds` cases in `__tests__/embed-network.test.ts`).

Manual (dev server + mock bridge host with a provider that starts disconnected, served from an allowlisted origin):

- Load with wallet not connected: no Sign in, header space intact, CTA reads "Connect wallet" enabled on an empty form; host log shows only the silent `eth_accounts` probe.
- Clicking the CTA sends `eth_requestAccounts` through the bridge (verified in the host log).
- Managed-host path: connecting via the **host page's** own button emits `accountsChanged` → widget flips to connected (wallet pill, balance row, CTA becomes "Swap" with normal gating) with no widget-side action.
- Host disconnect (`accountsChanged []`) returns the widget to the Connect CTA, not Sign in.
- Regression: host without `bindWallet` → 4900 fallback still shows Sign in; `?chainIds=999999` shows the same "Unsupported network — using default" notice as an invalid `networks=`.

Environment: Next.js 15 dev server, Chromium.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `chainIds` support for embedding network allowlists (CSV parsing for decimal and `0x` hex chain IDs).
  * Enhanced injected-wallet embedding flow with explicit “Connect wallet” and “Connecting...” connection phases.
* **Bug Fixes**
  * Wallet and authenticated UI now wait for injected-wallet readiness before showing controls.
  * Improved injected-wallet connection state handling, including silent account probing and safer disconnect behavior.
* **Documentation**
  * Updated embed widget guidance with `chainIds` vs `networks` rules, new allowlist examples, and detailed injected-mode connection steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->