### PR TITLE
fix(embed): use injected SIWE auth on swap confirm

### DIFF
--- a/__tests__/erc20Allowance.test.ts
+++ b/__tests__/erc20Allowance.test.ts
@@ -1,0 +1,48 @@
+import {
+  GATEWAY_APPROVAL_MULTIPLIER,
+  gatewayApprovalAmount,
+  needsApproval,
+} from "../app/lib/erc20Allowance";
+
+describe("gatewayApprovalAmount", () => {
+  it("approves a multiple of the spend so the next same-size swap needs no approval", () => {
+    const required = BigInt(1_000_000);
+    expect(gatewayApprovalAmount(required)).toBe(
+      required * GATEWAY_APPROVAL_MULTIPLIER,
+    );
+  });
+
+  it("handles a zero spend without throwing", () => {
+    expect(gatewayApprovalAmount(BigInt(0))).toBe(BigInt(0));
+  });
+});
+
+describe("needsApproval", () => {
+  const required = BigInt(1_000_000);
+
+  it("fails open when the allowance could not be read", () => {
+    // A null allowance means the RPC read failed or was skipped. Skipping a required approve here
+    // would make the order revert, so an unknown allowance must always approve.
+    expect(needsApproval(null, required)).toBe(true);
+  });
+
+  it("approves when there is no allowance yet", () => {
+    expect(needsApproval(BigInt(0), required)).toBe(true);
+  });
+
+  it("approves when the standing allowance is short of the spend", () => {
+    expect(needsApproval(required - BigInt(1), required)).toBe(true);
+  });
+
+  it("skips when the allowance exactly covers the spend", () => {
+    expect(needsApproval(required, required)).toBe(false);
+  });
+
+  it("skips when the allowance exceeds the spend", () => {
+    expect(needsApproval(gatewayApprovalAmount(required), required)).toBe(false);
+  });
+
+  it("skips a zero spend against a zero allowance", () => {
+    expect(needsApproval(BigInt(0), BigInt(0))).toBe(false);
+  });
+});

--- a/__tests__/erc20Allowance.test.ts
+++ b/__tests__/erc20Allowance.test.ts
@@ -1,8 +1,42 @@
+import { createPublicClient, type Chain } from "viem";
 import {
   GATEWAY_APPROVAL_MULTIPLIER,
   gatewayApprovalAmount,
   needsApproval,
+  needsGatewayApproval,
+  readErc20Allowance,
 } from "../app/lib/erc20Allowance";
+
+// Stub the three viem exports the helper uses. Declaring them here (rather than pulling in the real
+// module) keeps these tests off the network and lets us assert exactly which contract call is made.
+jest.mock("viem", () => ({
+  createPublicClient: jest.fn(),
+  http: jest.fn((url?: string) => ({ transport: url })),
+  erc20Abi: [{ type: "function", name: "allowance" }],
+}));
+
+const mockedCreatePublicClient = createPublicClient as unknown as jest.Mock;
+
+const VALID_READ = {
+  chain: { id: 8453, name: "Base" } as unknown as Chain,
+  rpcUrl: "https://rpc.example/key",
+  token: "0x1111111111111111111111111111111111111111",
+  owner: "0x2222222222222222222222222222222222222222",
+  spender: "0x3333333333333333333333333333333333333333",
+};
+
+/** Point createPublicClient at a readContract that resolves to `value` (or rejects with it). */
+function stubReadContract(value: bigint | Error) {
+  const readContract = jest.fn(() =>
+    value instanceof Error ? Promise.reject(value) : Promise.resolve(value),
+  );
+  mockedCreatePublicClient.mockReturnValue({ readContract });
+  return readContract;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("gatewayApprovalAmount", () => {
   it("approves a multiple of the spend so the next same-size swap needs no approval", () => {
@@ -44,5 +78,85 @@ describe("needsApproval", () => {
 
   it("skips a zero spend against a zero allowance", () => {
     expect(needsApproval(BigInt(0), BigInt(0))).toBe(false);
+  });
+});
+
+describe("readErc20Allowance", () => {
+  it("returns the on-chain allowance for the owner/spender pair", async () => {
+    const readContract = stubReadContract(BigInt(42));
+
+    await expect(readErc20Allowance(VALID_READ)).resolves.toBe(BigInt(42));
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: VALID_READ.token,
+        functionName: "allowance",
+        args: [VALID_READ.owner, VALID_READ.spender],
+      }),
+    );
+  });
+
+  it("returns null without building a client when the RPC URL is missing", async () => {
+    // viem would otherwise fall back to the chain's default transport — we'd rather report
+    // "unknown" than read from an RPC we didn't choose.
+    stubReadContract(BigInt(42));
+
+    await expect(
+      readErc20Allowance({ ...VALID_READ, rpcUrl: undefined }),
+    ).resolves.toBeNull();
+    expect(mockedCreatePublicClient).not.toHaveBeenCalled();
+  });
+
+  it.each(["token", "owner", "spender"] as const)(
+    "returns null when %s is missing",
+    async (field) => {
+      stubReadContract(BigInt(42));
+
+      await expect(
+        readErc20Allowance({ ...VALID_READ, [field]: undefined }),
+      ).resolves.toBeNull();
+      expect(mockedCreatePublicClient).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns null when the RPC read throws", async () => {
+    stubReadContract(new Error("RPC unreachable"));
+
+    await expect(readErc20Allowance(VALID_READ)).resolves.toBeNull();
+  });
+});
+
+describe("needsGatewayApproval", () => {
+  const required = BigInt(1_000_000);
+
+  it("approves when the allowance cannot be read (fails open)", async () => {
+    // The whole point of the null sentinel: an unreadable allowance must never let us skip an
+    // approve the order depends on.
+    stubReadContract(new Error("RPC unreachable"));
+
+    await expect(
+      needsGatewayApproval({ ...VALID_READ, required }),
+    ).resolves.toBe(true);
+  });
+
+  it("approves when there is no RPC URL to read from", async () => {
+    await expect(
+      needsGatewayApproval({ ...VALID_READ, rpcUrl: undefined, required }),
+    ).resolves.toBe(true);
+  });
+
+  it("skips the approve when the standing allowance covers the spend", async () => {
+    stubReadContract(gatewayApprovalAmount(required));
+
+    await expect(
+      needsGatewayApproval({ ...VALID_READ, required }),
+    ).resolves.toBe(false);
+  });
+
+  it("approves when the standing allowance is short of the spend", async () => {
+    stubReadContract(required - BigInt(1));
+
+    await expect(
+      needsGatewayApproval({ ...VALID_READ, required }),
+    ).resolves.toBe(true);
   });
 });

--- a/__tests__/resolveInjectedTokenAction.test.ts
+++ b/__tests__/resolveInjectedTokenAction.test.ts
@@ -1,0 +1,106 @@
+import {
+  INJECTED_SESSION_EXPIRY_GRACE_MS,
+  resolveInjectedTokenAction,
+} from "../app/context/InjectedWalletContext";
+
+const NOW = 1_700_000_000_000;
+
+const liveSession = {
+  token: "jwt",
+  expiresAt: NOW + INJECTED_SESSION_EXPIRY_GRACE_MS + 1,
+};
+
+describe("resolveInjectedTokenAction", () => {
+  it("uses a live session regardless of interactivity", () => {
+    for (const interactive of [true, false]) {
+      expect(
+        resolveInjectedTokenAction({
+          session: liveSession,
+          hasSignInFlight: false,
+          interactive,
+          now: NOW,
+        }),
+      ).toBe("use-session");
+    }
+  });
+
+  it("does not use a session inside the expiry grace window", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: { token: "jwt", expiresAt: NOW + 1 },
+        hasSignInFlight: false,
+        interactive: true,
+        now: NOW,
+      }),
+    ).toBe("start-sign-in");
+  });
+
+  it("joins an in-flight sign-in for a passive caller", () => {
+    // The regression this guards: the preview's mount effect starts an interactive sign-in, and the
+    // refund-account effect reads passively in the same commit. Returning "no-session" there left
+    // the saved refund account unfetched, with no dependency change to trigger a retry.
+    expect(
+      resolveInjectedTokenAction({
+        session: null,
+        hasSignInFlight: true,
+        interactive: false,
+        now: NOW,
+      }),
+    ).toBe("join-flight");
+  });
+
+  it("joins an in-flight sign-in for an interactive caller rather than opening a second popup", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: null,
+        hasSignInFlight: true,
+        interactive: true,
+        now: NOW,
+      }),
+    ).toBe("join-flight");
+  });
+
+  it("prefers a live session over joining an in-flight sign-in", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: liveSession,
+        hasSignInFlight: true,
+        interactive: false,
+        now: NOW,
+      }),
+    ).toBe("use-session");
+  });
+
+  it("reports no session when nothing is in flight and the caller is passive", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: null,
+        hasSignInFlight: false,
+        interactive: false,
+        now: NOW,
+      }),
+    ).toBe("no-session");
+  });
+
+  it("starts a sign-in when nothing is in flight and the caller is interactive", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: null,
+        hasSignInFlight: false,
+        interactive: true,
+        now: NOW,
+      }),
+    ).toBe("start-sign-in");
+  });
+
+  it("re-signs an expired session for an interactive caller", () => {
+    expect(
+      resolveInjectedTokenAction({
+        session: { token: "stale", expiresAt: NOW - 1 },
+        hasSignInFlight: false,
+        interactive: true,
+        now: NOW,
+      }),
+    ).toBe("start-sign-in");
+  });
+});

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -846,19 +846,26 @@ export type SwapPrecheckPayload = Pick<
 /**
  * Server-side monthly KYC limit check (RPC dry run) before on-chain swap steps.
  * Throws Error with the API message when the swap would be rejected at save time.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
  */
 export async function precheckSwapTransaction(
   payload: SwapPrecheckPayload,
-  accessToken: string,
+  accessToken: string | null,
+  injectedToken: string | null = null,
 ): Promise<void> {
+  const headers: Record<string, string> = {
+    "x-wallet-address": String(payload.walletAddress).toLowerCase(),
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const res = await axios.post<{ success?: boolean; error?: string }>(
     "/api/v1/transactions/swap-precheck",
     payload,
     {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-wallet-address": String(payload.walletAddress).toLowerCase(),
-      },
+      headers,
       validateStatus: () => true,
     },
   );
@@ -1156,17 +1163,21 @@ type RefundAccountSaveEnvelope = {
 
 /**
  * Loads the saved refund account for the authenticated wallet, if any.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
  */
 export async function fetchRefundAccount(
-  accessToken: string,
+  accessToken: string | null,
+  injectedToken: string | null = null,
 ): Promise<RefundAccountDetails | null> {
+  const headers: Record<string, string> = {};
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const response = await axios.get<RefundAccountApiEnvelope>(
     "/api/v1/refund-account",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
+    { headers },
   );
 
   if (!response.data.success) {
@@ -1178,11 +1189,19 @@ export async function fetchRefundAccount(
 
 /**
  * Upserts refund account details for the authenticated wallet.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
  */
 export async function saveRefundAccount(
   detail: RefundAccountDetails,
-  accessToken: string,
+  accessToken: string | null,
+  injectedToken: string | null = null,
 ): Promise<RefundAccountDetails> {
+  const headers: Record<string, string> = {};
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   let response: { data: RefundAccountSaveEnvelope };
   try {
     response = await axios.put<RefundAccountSaveEnvelope>(
@@ -1193,11 +1212,7 @@ export async function saveRefundAccount(
         accountIdentifier: detail.accountNumber,
         accountName: detail.accountName,
       },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
+      { headers },
     );
   } catch (err) {
     // Surface the server's error message (e.g. the refund-account name policy rejection) instead of
@@ -1463,20 +1478,25 @@ export const submitSmileIDData = async (
  * Creates a v2 on-ramp payment order (fiat source) via the server proxy to aggregator.
  * POST /api/v1/payment-orders (on-ramp only) → aggregator POST /v2/sender/orders.
  * Off-ramp orders are created on-chain (gateway.createOrder), not through this proxy.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
  */
 export async function createV2SenderPaymentOrder(
   payload: V2CreatePaymentOrderPayload,
-  accessToken: string,
+  accessToken: string | null,
+  injectedToken: string | null = null,
 ): Promise<AggregatorEnvelope<V2PaymentOrderCreateData>> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const response = await axios.post<AggregatorEnvelope<V2PaymentOrderCreateData>>(
     "/api/v1/payment-orders",
     payload,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    },
+    { headers },
   );
   return response.data;
 }

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -556,8 +556,8 @@ export const fetchAccountName = async (
  */
 export const fetchOrderDetails = async (
   orderId: string,
-  accessToken?: string,
-  options?: { network?: string },
+  accessToken?: string | null,
+  options?: { network?: string; injectedToken?: string | null },
 ): Promise<OrderDetailsResponse> => {
   const id = orderId.trim();
   if (!id) {
@@ -580,13 +580,19 @@ export const fetchOrderDetails = async (
     data?: unknown;
   };
 
-  if (typeof window !== "undefined" && accessToken?.trim()) {
+  const injectedToken = options?.injectedToken?.trim();
+
+  if (typeof window !== "undefined" && (accessToken?.trim() || injectedToken)) {
+    const headers: Record<string, string> = {};
+    if (injectedToken) {
+      headers["x-injected-token"] = injectedToken;
+    } else {
+      headers.Authorization = `Bearer ${accessToken!.trim()}`;
+    }
     const response = await axios.get(
       `/api/v1/payment-orders/${encodeURIComponent(id)}`,
       {
-        headers: {
-          Authorization: `Bearer ${accessToken.trim()}`,
-        },
+        headers,
         params:
           gatewayLookup && network
             ? { network }
@@ -780,23 +786,28 @@ export const detectUserLocation = async (): Promise<string> => {
  * @param {string} accessToken - The access token for authentication
  * @param {number} [page=1] - The page number
  * @param {number} [limit=20] - The number of items per page
+ * @param {string | null} [injectedToken] - Injected wallet SIWE session token
  * @returns {Promise<TransactionResponse>} The transactions response
  * @throws {Error} If the API request fails
  */
 export async function fetchTransactions(
   address: string,
-  accessToken: string,
+  accessToken: string | null,
   page: number = 1,
   limit: number = 20,
+  injectedToken: string | null = null,
 ): Promise<TransactionResponse> {
+  const headers: Record<string, string> = {
+    "x-wallet-address": address.toLowerCase(),
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const response = await axios.get<TransactionResponse>(
     `/api/v1/transactions?page=${page}&limit=${limit}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-wallet-address": address.toLowerCase(),
-      },
-    },
+    { headers },
   );
   return response.data;
 }
@@ -919,18 +930,23 @@ export async function updateTransactionStatus({
   status,
   accessToken,
   walletAddress,
+  injectedToken = null,
 }: UpdateTransactionStatusPayload): Promise<SaveTransactionResponse> {
   const finalStatus = mapAggregatorStatusToDbStatus(status, { onramp: false });
+
+  const headers: Record<string, string> = {
+    "x-wallet-address": walletAddress.toLowerCase(),
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
 
   const response = await axios.put(
     `/api/v1/transactions/status/${transactionId}`,
     { status: finalStatus },
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-wallet-address": walletAddress.toLowerCase(),
-      },
-    },
+    { headers },
   );
   return response.data;
 }
@@ -944,6 +960,7 @@ export async function updateTransactionStatus({
  * @param {string} [params.timeSpent] - The time spent on the transaction (optional)
  * @param {string} params.accessToken - The access token for authentication
  * @param {string} params.walletAddress - The wallet address for authorization
+ * @param {string} [params.injectedToken] - Injected wallet SIWE session token
  * @returns {Promise<SaveTransactionResponse>} The update response
  * @throws {Error} If the API request fails
  */
@@ -954,6 +971,7 @@ export async function updateTransactionDetails({
   timeSpent,
   accessToken,
   walletAddress,
+  injectedToken = null,
   isOnramp,
 }: UpdateTransactionDetailsPayload): Promise<SaveTransactionResponse> {
   const finalStatus = mapAggregatorStatusToDbStatus(status, {
@@ -969,15 +987,19 @@ export async function updateTransactionDetails({
     data.timeSpent = timeSpent;
   }
 
+  const headers: Record<string, string> = {
+    "x-wallet-address": walletAddress.toLowerCase(),
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
   const response = await axios.put(
     `/api/v1/transactions/${transactionId}`,
     data,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-wallet-address": walletAddress.toLowerCase(),
-      },
-    },
+    { headers },
   );
   return response.data;
 }
@@ -1506,15 +1528,18 @@ export async function createV2SenderPaymentOrder(
  */
 export async function fetchV2SenderPaymentOrderById(
   orderId: string,
-  accessToken: string,
+  accessToken: string | null,
+  injectedToken: string | null = null,
 ): Promise<AggregatorEnvelope<V2PaymentOrderGetData>> {
+  const headers: Record<string, string> = {};
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
   const response = await axios.get<AggregatorEnvelope<V2PaymentOrderGetData>>(
     `/api/v1/payment-orders/${encodeURIComponent(orderId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
+    { headers },
   );
   return response.data;
 }

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -70,6 +70,7 @@ import { BridgeForm } from "./bridge/BridgeForm";
 import { EarnHubView, ReferralHubView } from "./wallet-mobile-modal";
 import { ReferralCTA } from "./ReferralCTA";
 import { useBridgeStatusTracker } from "../hooks/useBridgeStatusTracker";
+import { useApiAuth } from "../hooks/useApiAuth";
 
 const Divider = () => (
   <div className="w-full border border-dashed border-[#EBEBEF] dark:border-[#FFFFFF1A]" />
@@ -165,7 +166,8 @@ export const WalletDetails = () => {
     softRefresh,
   } = useBalance();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
-  const { user, getAccessToken } = usePrivy();
+  const { user } = usePrivy();
+  const { resolveAuth } = useApiAuth();
   const { isEmbed } = useEmbed();
   const { wallets } = useWallets();
   const { transactions, fetchTransactions } = useTransactions();
@@ -237,12 +239,15 @@ export const WalletDetails = () => {
   useEffect(() => {
     const addr = activeWallet?.address;
     if (!addr) return;
-    void getAccessToken().then((token) => {
-      if (token) {
-        void fetchTransactions(addr, token, 1, 30);
-      }
-    });
-  }, [activeWallet?.address, fetchTransactions, getAccessToken]);
+    // Passive: this is a background prefetch and must not pop a SIWE signature request.
+    void resolveAuth({ interactive: false }).then(
+      ({ accessToken, injectedToken }) => {
+        if (accessToken || injectedToken) {
+          void fetchTransactions(addr, accessToken, 1, 30, false, injectedToken);
+        }
+      },
+    );
+  }, [activeWallet?.address, fetchTransactions, resolveAuth]);
 
   const showEarnUi = isEarnUiVisible(selectedNetwork.chain.name);
 

--- a/app/components/transaction/TransactionList.tsx
+++ b/app/components/transaction/TransactionList.tsx
@@ -16,6 +16,8 @@ import { usePrivy } from "@privy-io/react-auth";
 import { PiSpinnerBold } from "react-icons/pi";
 import { useActualTheme } from "../../hooks/useActualTheme";
 import { useTransactions } from "../../context/TransactionsContext";
+import { useInjectedWallet } from "../../context/InjectedWalletContext";
+import { useApiAuth } from "../../hooks/useApiAuth";
 import {
   ArrowLeft02Icon,
   ArrowRight02Icon,
@@ -151,7 +153,14 @@ export const TransactionListItem = ({
 export default function TransactionList({
   onSelectTransaction,
 }: TransactionListProps) {
-  const { user, getAccessToken } = usePrivy();
+  const { user } = usePrivy();
+  const {
+    isInjectedWallet,
+    injectedAddress,
+    injectedReady,
+    getInjectedToken,
+  } = useInjectedWallet();
+  const { resolveAuth } = useApiAuth();
   const limit = 30;
   const isDark = useActualTheme();
 
@@ -161,7 +170,11 @@ export default function TransactionList({
       account.type === "wallet" && account.connectorType === "embedded",
   ) as { address: string } | undefined;
 
-  const walletAddress = embeddedWallet?.address;
+  // In embed mode the host/extension wallet owns the history, and its SIWE session is what
+  // authenticates the request.
+  const walletAddress = isInjectedWallet
+    ? (injectedAddress ?? undefined)
+    : embeddedWallet?.address;
 
   // Use the transactions context
   const {
@@ -185,18 +198,39 @@ export default function TransactionList({
   const isLoadingRef = useRef(isLoading);
   useEffect(() => { isLoadingRef.current = isLoading; }, [isLoading]);
 
+  // Opening the history view is an explicit user action, so establish the injected SIWE session here
+  // (one signature, cached ~1h) — same pattern as BridgeForm/KycModal. Without it an injected user
+  // who lands on history before any signing sees a permanently empty list: the fetch below reads
+  // passively and its deps never change once a session appears.
+  useEffect(() => {
+    if (isInjectedWallet && injectedReady) {
+      void getInjectedToken({ interactive: true });
+    }
+  }, [isInjectedWallet, injectedReady, getInjectedToken]);
+
   // Fetch transactions when wallet address or page changes.
   // Skips if another fetch is already in-flight.
   // Uses isLoading via ref (not reactive dep) to avoid ping-pong re-fetch cycles.
   useEffect(() => {
     if (walletAddress && !isLoadingRef.current) {
-      getAccessToken().then((accessToken) => {
-        if (accessToken) {
-          fetchTransactions(walletAddress, accessToken, currentPage, limit);
-        }
-      });
+      // Passive: opening the history list must not pop a SIWE signature request. Injected users who
+      // haven't signed yet get an empty list until a user action establishes the session.
+      void resolveAuth({ interactive: false }).then(
+        ({ accessToken, injectedToken }) => {
+          if (accessToken || injectedToken) {
+            fetchTransactions(
+              walletAddress,
+              accessToken,
+              currentPage,
+              limit,
+              false,
+              injectedToken,
+            );
+          }
+        },
+      );
     }
-  }, [walletAddress, currentPage, getAccessToken, fetchTransactions]);
+  }, [walletAddress, currentPage, resolveAuth, fetchTransactions]);
 
   // Group transactions by date
   const groupedTransactions = useMemo(() => {

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -45,6 +45,31 @@ export interface InjectedTokenOptions {
   interactive?: boolean;
 }
 
+/** A session is treated as expired this early so a token can't lapse mid-request. */
+export const INJECTED_SESSION_EXPIRY_GRACE_MS = 60_000;
+
+/**
+ * What a `getInjectedToken` call should do, given the current session state.
+ *
+ * Extracted as a pure function because the ordering here is subtle: joining an in-flight sign-in
+ * must be considered *before* the non-interactive bail-out, or a passive caller racing an
+ * interactive one (both fired from the same mount) reports "no session" and, if its effect never
+ * re-runs, never recovers.
+ */
+export function resolveInjectedTokenAction(params: {
+  session: { token: string; expiresAt: number } | null;
+  hasSignInFlight: boolean;
+  interactive: boolean;
+  now: number;
+}): "use-session" | "join-flight" | "start-sign-in" | "no-session" {
+  const { session, hasSignInFlight, interactive, now } = params;
+  if (session && now < session.expiresAt - INJECTED_SESSION_EXPIRY_GRACE_MS) {
+    return "use-session";
+  }
+  if (hasSignInFlight) return "join-flight";
+  return interactive ? "start-sign-in" : "no-session";
+}
+
 interface InjectedWalletContextType {
   isInjectedWallet: boolean;
   injectedAddress: string | null;
@@ -187,18 +212,23 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
       ) {
         return null;
       }
-      // Treat as expired 60s early so a token can't lapse mid-request.
       const session = sessionRef.current;
-      if (session && Date.now() < session.expiresAt - 60_000) {
-        return session.token;
-      }
-      if (!opts?.interactive) return null;
+      const action = resolveInjectedTokenAction({
+        session,
+        hasSignInFlight: signInFlightRef.current !== null,
+        interactive: opts?.interactive === true,
+        now: Date.now(),
+      });
+
+      if (action === "use-session") return session!.token;
+      // Awaiting a popup someone else already opened pops none of our own.
+      if (action === "join-flight") return signInFlightRef.current;
+      if (action === "no-session") return null;
+
       // Single-flight: concurrent interactive callers share one wallet popup.
-      if (!signInFlightRef.current) {
-        signInFlightRef.current = performSiweSignIn().finally(() => {
-          signInFlightRef.current = null;
-        });
-      }
+      signInFlightRef.current = performSiweSignIn().finally(() => {
+        signInFlightRef.current = null;
+      });
       return signInFlightRef.current;
     },
     [

--- a/app/context/TransactionsContext.tsx
+++ b/app/context/TransactionsContext.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
 } from "react";
 import axios from "axios";
@@ -22,6 +23,8 @@ import {
 } from "../api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { reindexSingleTransaction } from "../lib/reindex";
+import { useInjectedWallet } from "./InjectedWalletContext";
+import { useApiAuth } from "../hooks/useApiAuth";
 
 // Polling interval and reindex threshold (30 seconds)
 const POLLING_INTERVAL_MS = 30 * 1000;
@@ -34,10 +37,11 @@ interface TransactionsContextType {
   currentPage: number;
   fetchTransactions: (
     walletAddress: string,
-    accessToken: string,
+    accessToken: string | null,
     page: number,
     limit: number,
     forceRefresh?: boolean,
+    injectedToken?: string | null,
   ) => Promise<void>;
   refreshTransactions: () => Promise<void>;
   clearTransactions: () => void;
@@ -64,7 +68,9 @@ export function TransactionsProvider({
       { data: TransactionHistory[]; total: number; timestamp: number }
     >
   >({});
-  const { user, getAccessToken } = usePrivy();
+  const { user } = usePrivy();
+  const { isInjectedWallet, injectedAddress } = useInjectedWallet();
+  const { resolveAuth } = useApiAuth();
   const reindexedTxHashesRef = useRef<Set<string>>(new Set());
   const transactionsRef = useRef<TransactionHistory[]>([]);
   const pollingInFlightRef = useRef(false);
@@ -75,12 +81,24 @@ export function TransactionsProvider({
     transactionsRef.current = transactions;
   }, [transactions]);
 
+  // Whose history we show: the host/extension wallet in embed mode (its SIWE session is what
+  // authenticates the request), otherwise the Privy embedded wallet.
+  const historyWalletAddress = useMemo(() => {
+    if (isInjectedWallet) return injectedAddress ?? undefined;
+    const embeddedWallet = user?.linkedAccounts.find(
+      (account) =>
+        account.type === "wallet" && account.connectorType === "embedded",
+    ) as { address: string } | undefined;
+    return embeddedWallet?.address;
+  }, [isInjectedWallet, injectedAddress, user]);
+
   // Background reconciliation logic
   const reconcileTransactionStatuses = useCallback(
     async (
       txs: TransactionHistory[],
       walletAddress: string,
-      accessToken: string,
+      accessToken: string | null,
+      injectedToken: string | null = null,
     ) => {
       // Only onramp/offramp transactions are backed by an aggregator order that can be looked up.
       // transfer/swap/credit carry a tx hash (or no order) in `order_id`, so reconciling them hits
@@ -106,6 +124,7 @@ export function TransactionsProvider({
               const res = await fetchV2SenderPaymentOrderById(
                 tx.order_id!,
                 accessToken,
+                injectedToken,
               );
               const resolvedStatus = resolveOnrampOrderStatusFromV2Response(res);
               orderData =
@@ -119,7 +138,7 @@ export function TransactionsProvider({
               const res = await fetchOrderDetails(
                 tx.order_id!,
                 accessToken,
-                { network: tx.network },
+                { network: tx.network, injectedToken },
               );
               orderData = res.data;
             }
@@ -187,6 +206,7 @@ export function TransactionsProvider({
                 status: orderData.status,
                 txHash: newTxHash,
                 accessToken,
+                injectedToken,
                 walletAddress,
                 isOnramp: isOnrampTx,
               });
@@ -255,7 +275,9 @@ export function TransactionsProvider({
               : `/api/bridge/lifi/status?txHash=${encodeURIComponent(tx.order_id!)}`;
 
             const res = await fetch(url, {
-              headers: { Authorization: `Bearer ${accessToken}` },
+              headers: injectedToken
+                ? { "x-injected-token": injectedToken }
+                : { Authorization: `Bearer ${accessToken}` },
             });
             if (!res.ok) return;
             const data = await res.json();
@@ -268,7 +290,7 @@ export function TransactionsProvider({
 
             if (!nextStatus || nextStatus === tx.status) return;
 
-            await updateBridgeTransactionStatus(tx.id, nextStatus, accessToken, walletAddress);
+            await updateBridgeTransactionStatus(tx.id, nextStatus, accessToken, walletAddress, injectedToken);
 
             const updated = { ...tx, status: nextStatus };
             setTransactions((prev) =>
@@ -300,10 +322,11 @@ export function TransactionsProvider({
   const fetchTransactionData = useCallback(
     async (
       walletAddress: string,
-      accessToken: string,
+      accessToken: string | null,
       page: number,
       limit: number,
       forceRefresh?: boolean,
+      injectedToken: string | null = null,
     ) => {
       const cacheKey = `${walletAddress}-${page}-${limit}`;
       const cachedData = cacheRef.current[cacheKey];
@@ -324,6 +347,7 @@ export function TransactionsProvider({
           cachedData.data,
           walletAddress,
           accessToken,
+          injectedToken,
         );
         return;
       }
@@ -338,6 +362,7 @@ export function TransactionsProvider({
           accessToken,
           page,
           limit,
+          injectedToken,
         );
         if (data.success) {
           setTransactions(data.data.transactions);
@@ -357,6 +382,7 @@ export function TransactionsProvider({
             data.data.transactions,
             walletAddress,
             accessToken,
+            injectedToken,
           );
         }
       } catch (error) {
@@ -378,16 +404,15 @@ export function TransactionsProvider({
   );
 
   const refreshTransactions = useCallback(async () => {
-    const embeddedWallet = user?.linkedAccounts.find(
-      (account) =>
-        account.type === "wallet" && account.connectorType === "embedded",
-    ) as { address: string } | undefined;
-
-    const walletAddress = embeddedWallet?.address;
+    const walletAddress = historyWalletAddress;
     if (!walletAddress) return;
 
-    const accessToken = await getAccessToken();
-    if (!accessToken) return;
+    // Passive: a background refresh must never pop a SIWE signature request. Without a session we
+    // skip and pick it up on the next refresh a user action triggers.
+    const { accessToken, injectedToken } = await resolveAuth({
+      interactive: false,
+    });
+    if (!accessToken && !injectedToken) return;
 
     // Clear cache for this page so concurrent fetches also hit the network.
     // Must match the page size TransactionList fetches/paginates with (limit = 30),
@@ -414,8 +439,9 @@ export function TransactionsProvider({
       currentPage,
       PAGE_LIMIT,
       true,
+      injectedToken,
     );
-  }, [user, getAccessToken, currentPage, fetchTransactionData]);
+  }, [historyWalletAddress, resolveAuth, currentPage, fetchTransactionData]);
 
   const clearTransactions = useCallback(() => {
     setTransactions([]);
@@ -428,7 +454,8 @@ export function TransactionsProvider({
 
   // Polling mechanism for incomplete transactions
   useEffect(() => {
-    if (!user) {
+    // Injected wallets have no Privy user; their identity is the SIWE session instead.
+    if (!user && !isInjectedWallet) {
       return;
     }
 
@@ -445,13 +472,7 @@ export function TransactionsProvider({
       return;
     }
 
-    // Get wallet address from user
-    const embeddedWallet = user.linkedAccounts.find(
-      (account) =>
-        account.type === "wallet" && account.connectorType === "embedded",
-    ) as { address: string } | undefined;
-
-    const walletAddress = embeddedWallet?.address;
+    const walletAddress = historyWalletAddress;
     if (!walletAddress) {
       return;
     }
@@ -478,12 +499,16 @@ export function TransactionsProvider({
           return;
         }
 
-        const accessToken = await getAccessToken();
-        if (accessToken) {
+        // Passive: a poller must never pop a signature request.
+        const { accessToken, injectedToken } = await resolveAuth({
+          interactive: false,
+        });
+        if (accessToken || injectedToken) {
           await reconcileTransactionStatuses(
             currentIncomplete,
             walletAddress,
             accessToken,
+            injectedToken,
           );
         }
       } catch (error) {
@@ -496,7 +521,14 @@ export function TransactionsProvider({
     return () => {
       clearInterval(intervalId);
     };
-  }, [transactions, user, getAccessToken, reconcileTransactionStatuses]);
+  }, [
+    transactions,
+    user,
+    isInjectedWallet,
+    historyWalletAddress,
+    resolveAuth,
+    reconcileTransactionStatuses,
+  ]);
 
   return (
     <TransactionsContext.Provider

--- a/app/hooks/useApiAuth.ts
+++ b/app/hooks/useApiAuth.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useInjectedWallet } from "../context/InjectedWalletContext";
+
+export type ApiAuth = {
+  accessToken: string | null;
+  injectedToken: string | null;
+};
+
+/**
+ * Resolves the credential our API routes accept: a Privy Bearer token for Privy wallets, or the
+ * injected wallet's SIWE session token (`x-injected-token`) in embed/widget mode. The middleware
+ * accepts either; a connected injected wallet on its own is not authentication.
+ *
+ * Pass `interactive: false` from background work (pollers, hydration effects) so a missing session
+ * never pops a signature request — the caller should skip that cycle instead. Use
+ * `interactive: true` only on paths the user just triggered.
+ */
+export function useApiAuth() {
+  const { getAccessToken } = usePrivy();
+  const { isInjectedWallet, getInjectedToken } = useInjectedWallet();
+
+  const resolveAuth = useCallback(
+    async (opts?: { interactive?: boolean }): Promise<ApiAuth> => {
+      const interactive = opts?.interactive ?? true;
+      const accessToken = isInjectedWallet ? null : await getAccessToken();
+      const injectedToken = isInjectedWallet
+        ? await getInjectedToken({ interactive })
+        : null;
+      return { accessToken, injectedToken };
+    },
+    [isInjectedWallet, getAccessToken, getInjectedToken],
+  );
+
+  return { resolveAuth };
+}

--- a/app/lib/erc20Allowance.ts
+++ b/app/lib/erc20Allowance.ts
@@ -1,0 +1,72 @@
+import { createPublicClient, http, erc20Abi, type Chain } from "viem";
+
+/**
+ * Multiple of the spend we approve when an approve is needed at all. The gateway only ever
+ * transfers `amount + senderFee`; the headroom exists so the *next* swap of the same size finds
+ * enough allowance and needs no second approval prompt. The flip side is a standing allowance on
+ * the gateway after the order settles — that is the trade we are making for one less prompt.
+ */
+export const GATEWAY_APPROVAL_MULTIPLIER = BigInt(10);
+
+/** The amount to pass to `approve` for a spend of `required`. */
+export function gatewayApprovalAmount(required: bigint): bigint {
+  return required * GATEWAY_APPROVAL_MULTIPLIER;
+}
+
+/**
+ * Whether an `approve` must be sent before the order.
+ *
+ * Fails open: a null allowance means we could not read it (RPC error, missing RPC URL, unmapped
+ * token/spender), and an unknown allowance must never let us skip a required approval.
+ */
+export function needsApproval(
+  allowance: bigint | null,
+  required: bigint,
+): boolean {
+  return allowance === null || allowance < required;
+}
+
+/**
+ * Read `allowance(owner, spender)` fresh from RPC, or null when it cannot be read.
+ *
+ * Read on-chain rather than from any cached context because this gates money movement and must be
+ * authoritative and bigint-exact. Mirrors the public client setup in `readForwardBalanceWei`.
+ */
+export async function readErc20Allowance(params: {
+  chain: Chain;
+  rpcUrl: string | undefined;
+  token: string | undefined;
+  owner: string | undefined;
+  spender: string | undefined;
+}): Promise<bigint | null> {
+  const { chain, rpcUrl, token, owner, spender } = params;
+
+  // No RPC URL means viem would silently fall back to the chain's default transport; prefer an
+  // explicit "unknown" over a read against an RPC we did not choose.
+  if (!rpcUrl || !token || !owner || !spender) return null;
+
+  try {
+    const client = createPublicClient({ chain, transport: http(rpcUrl) });
+    return await client.readContract({
+      address: token as `0x${string}`,
+      abi: erc20Abi,
+      functionName: "allowance",
+      args: [owner as `0x${string}`, spender as `0x${string}`],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Convenience: read the allowance and decide, failing open on an unreadable allowance. */
+export async function needsGatewayApproval(params: {
+  chain: Chain;
+  rpcUrl: string | undefined;
+  token: string | undefined;
+  owner: string | undefined;
+  spender: string | undefined;
+  required: bigint;
+}): Promise<boolean> {
+  const allowance = await readErc20Allowance(params);
+  return needsApproval(allowance, params.required);
+}

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 
@@ -58,6 +58,11 @@ import {
   readBatchNonce,
   type BatchCall,
 } from "../lib/providerBatch";
+import {
+  gatewayApprovalAmount,
+  needsGatewayApproval,
+} from "../lib/erc20Allowance";
+import { useApiAuth } from "../hooks/useApiAuth";
 
 import {
   fetchAggregatorPublicKey,
@@ -102,6 +107,7 @@ export const TransactionPreview = ({
     injectedReady,
     getInjectedToken,
   } = useInjectedWallet();
+  const { resolveAuth } = useApiAuth();
   const { walletId: starknetWalletId, address: starknetWalletAddress, publicKey: starknetPublicKey } = useStarknet();
   const shouldUseEOA = useShouldUseEOA();
   const { isLoading: isMigrationLoading } = useMigrationStatus();
@@ -151,6 +157,11 @@ export const TransactionPreview = ({
   const [isOrderCreatedLogsFetched, setIsOrderCreatedLogsFetched] =
     useState<boolean>(false);
   const [isGatewayApproved, setIsGatewayApproved] = useState<boolean>(false);
+  // Whether the injected flow will need a gateway approval prompt, read once on mount so the step
+  // copy below promises the number of wallet prompts the user will actually see. Confirm time
+  // re-reads authoritatively — this value never decides whether an approve is sent. Starts true so
+  // we over-promise rather than under-promise while the read is in flight.
+  const [willNeedApproval, setWillNeedApproval] = useState<boolean>(true);
   const [isOrderCreated, setIsOrderCreated] = useState<boolean>(false);
   const [isSavingTransaction, setIsSavingTransaction] = useState(false);
   const [refundAccountModalOpen, setRefundAccountModalOpen] = useState(false);
@@ -176,19 +187,6 @@ export const TransactionPreview = ({
     }
   }, [isInjectedWallet, injectedReady, getInjectedToken]);
 
-  /** Resolve Privy Bearer or injected SIWE token for authenticated API calls. */
-  const resolveSwapAuth = useCallback(
-    async (opts?: { interactive?: boolean }) => {
-      const interactive = opts?.interactive ?? true;
-      const accessToken = isInjectedWallet ? null : await getAccessToken();
-      const injectedToken = isInjectedWallet
-        ? await getInjectedToken({ interactive })
-        : null;
-      return { accessToken, injectedToken };
-    },
-    [isInjectedWallet, getAccessToken, getInjectedToken],
-  );
-
   useEffect(() => {
     if (!isOnramp) return;
     // Reset on every currency change so a cached NGN account isn't submitted for KES/TZS/UGX orders.
@@ -197,7 +195,7 @@ export const TransactionPreview = ({
     void (async () => {
       try {
         // Passive: SIWE is established by the mount effect; don't re-prompt here.
-        const { accessToken, injectedToken } = await resolveSwapAuth({
+        const { accessToken, injectedToken } = await resolveAuth({
           interactive: false,
         });
         if ((!accessToken && !injectedToken) || cancelled) return;
@@ -212,7 +210,7 @@ export const TransactionPreview = ({
     return () => {
       cancelled = true;
     };
-  }, [isOnramp, currency, resolveSwapAuth]);
+  }, [isOnramp, currency, resolveAuth]);
 
   const fetchedTokens: Token[] = allTokens[selectedNetwork.chain.name] || [];
 
@@ -223,6 +221,18 @@ export const TransactionPreview = ({
   const tokenDecimals = fetchedTokens.find(
     (t) => t.symbol.toUpperCase() === token.toUpperCase(),
   )?.decimals;
+
+  // What the gateway will actually pull (senderFee is 0 today, see prepareCreateOrderParams).
+  // Lifted out of prepareCreateOrderParams so the allowance read can reuse it without that
+  // function's network round-trip for the aggregator public key.
+  const requiredSpendWei = parseUnits(
+    (amountSent ?? 0).toString(),
+    tokenDecimals ?? 18,
+  );
+
+  const gatewayAddress = getGatewayContractAddress(
+    selectedNetwork.chain.name,
+  ) as `0x${string}`;
 
   const injectedWallet = isInjectedWallet
     ? { address: injectedAddress, type: "injected_wallet" }
@@ -240,6 +250,47 @@ export const TransactionPreview = ({
 
   const isStarknetSelected = selectedNetwork.chain.name === "Starknet";
   const isTronSelected = selectedNetwork.chain.name === "Tron";
+
+  // Drives the approval-step copy for injected off-ramp only — that's the one flow that tells the
+  // user up front how many wallet prompts to expect. Skipped for Starknet/Tron, whose chain objects
+  // are not viem chains (see app/mocks.ts).
+  useEffect(() => {
+    if (
+      !isInjectedWallet ||
+      isOnramp ||
+      isStarknetSelected ||
+      isTronSelected ||
+      !injectedReady
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const mustApprove = await needsGatewayApproval({
+        chain: selectedNetwork.chain,
+        rpcUrl: getRpcUrl(selectedNetwork.chain.name),
+        token: tokenAddress,
+        owner: injectedAddress ?? undefined,
+        spender: gatewayAddress,
+        required: requiredSpendWei,
+      });
+      if (!cancelled) setWillNeedApproval(mustApprove);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isInjectedWallet,
+    isOnramp,
+    isStarknetSelected,
+    isTronSelected,
+    injectedReady,
+    injectedAddress,
+    selectedNetwork.chain,
+    tokenAddress,
+    gatewayAddress,
+    requiredSpendWei,
+  ]);
 
   const activeWallet = injectedWallet ||
     (isStarknetSelected
@@ -438,51 +489,58 @@ export const TransactionPreview = ({
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
 
-        // Approve 10× the spend (amount + senderFee) so subsequent swaps can
-        // reuse allowance; the contract still transfers only amount + senderFee.
-        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
+        const requiredSpend = params.amount + params.senderFee;
 
-        const approvalData = encodeFunctionData({
-          abi: erc20Abi,
-          functionName: "approve",
-          args: [
-            getGatewayContractAddress(
-              selectedNetwork.chain.name,
-            ) as `0x${string}`,
-            totalAmountToApprove,
-          ],
+        // Authoritative read at confirm time — the mount-time value only drives the step copy.
+        // A standing allowance from an earlier swap saves the user a whole wallet prompt here.
+        const mustApprove = await needsGatewayApproval({
+          chain: selectedNetwork.chain,
+          rpcUrl: getRpcUrl(selectedNetwork.chain.name),
+          token: tokenAddress,
+          owner: injectedAddress ?? undefined,
+          spender: gatewayAddress,
+          required: requiredSpend,
         });
 
-        // Send approval transaction
-        const approvalTx = await injectedProvider.request({
-          method: "eth_sendTransaction",
-          params: [
-            {
-              from: injectedAddress,
-              to: tokenAddress,
-              data: appendBaseBuilderCode(
-                selectedNetwork.chain.id,
-                approvalData,
-              ),
-            },
-          ],
-        });
-
-        try {
-          const publicClient = createPublicClient({
-            chain: selectedNetwork.chain,
-            transport: http(getRpcUrl(selectedNetwork.chain.name)),
+        if (mustApprove) {
+          const approvalData = encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [gatewayAddress, gatewayApprovalAmount(requiredSpend)],
           });
 
-          await publicClient.waitForTransactionReceipt({
-            hash: approvalTx as `0x${string}`,
+          // Send approval transaction
+          const approvalTx = await injectedProvider.request({
+            method: "eth_sendTransaction",
+            params: [
+              {
+                from: injectedAddress,
+                to: tokenAddress,
+                data: appendBaseBuilderCode(
+                  selectedNetwork.chain.id,
+                  approvalData,
+                ),
+              },
+            ],
           });
-          toast.success("Token spending approved");
-          setIsGatewayApproved(true);
-        } catch (error) {
-          toast.error("Approval failed");
-          throw new Error("Approval transaction failed");
+
+          try {
+            const publicClient = createPublicClient({
+              chain: selectedNetwork.chain,
+              transport: http(getRpcUrl(selectedNetwork.chain.name)),
+            });
+
+            await publicClient.waitForTransactionReceipt({
+              hash: approvalTx as `0x${string}`,
+            });
+            toast.success("Token spending approved");
+          } catch (error) {
+            toast.error("Approval failed");
+            throw new Error("Approval transaction failed");
+          }
         }
+
+        setIsGatewayApproved(true);
 
         const createOrderData = encodeFunctionData({
           abi: gatewayAbi,
@@ -505,9 +563,7 @@ export const TransactionPreview = ({
           params: [
             {
               from: injectedAddress,
-              to: getGatewayContractAddress(
-                selectedNetwork.chain.name,
-              ) as `0x${string}`,
+              to: gatewayAddress,
               data: appendBaseBuilderCode(
                 selectedNetwork.chain.id,
                 createOrderData,
@@ -527,9 +583,6 @@ export const TransactionPreview = ({
         const chain = selectedNetwork?.chain;
         if (!chain) throw new Error("Network not ready");
         const chainId = chain.id;
-        const gatewayAddress = getGatewayContractAddress(
-          selectedNetwork.chain.name,
-        ) as `0x${string}`;
 
         const delegationContractAddress = getDelegationContractAddress(chainId);
         if (!delegationContractAddress || delegationContractAddress === "") {
@@ -572,8 +625,16 @@ export const TransactionPreview = ({
 
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
-        // Approve 10× the spend (amount + senderFee) for allowance headroom.
-        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
+        const requiredSpend = params.amount + params.senderFee;
+
+        const mustApprove = await needsGatewayApproval({
+          chain,
+          rpcUrl,
+          token: tokenAddress,
+          owner: accountAddress,
+          spender: gatewayAddress,
+          required: requiredSpend,
+        });
 
         const approveCall: BatchCall = {
           to: tokenAddress as `0x${string}`,
@@ -581,7 +642,7 @@ export const TransactionPreview = ({
           data: encodeFunctionData({
             abi: erc20Abi,
             functionName: "approve",
-            args: [gatewayAddress, totalAmountToApprove],
+            args: [gatewayAddress, gatewayApprovalAmount(requiredSpend)],
           }),
         };
         const createOrderCall: BatchCall = {
@@ -602,15 +663,21 @@ export const TransactionPreview = ({
           }),
         };
 
+        // One array for both the digest and the encoded batch — the signature covers these exact
+        // calls, so dropping the approve from one and not the other would fail at the bundler.
+        const batchCalls: BatchCall[] = mustApprove
+          ? [approveCall, createOrderCall]
+          : [createOrderCall];
+
         const nonce = await readBatchNonce(publicClient, accountAddress).catch(() => BigInt(0));
-        const digest = buildBatchDigest(nonce, [approveCall, createOrderCall]);
+        const digest = buildBatchDigest(nonce, batchCalls);
         const rawSignature = (await provider.request({
           method: "personal_sign",
           params: [digest, accountAddress],
         })) as string;
         const signature = (rawSignature.startsWith("0x") ? rawSignature : `0x${rawSignature}`) as `0x${string}`;
 
-        const callData = encodeExecuteBatch([approveCall, createOrderCall], signature);
+        const callData = encodeExecuteBatch(batchCalls, signature);
         const payload = {
           chainId,
           rpcUrl,
@@ -678,31 +745,39 @@ export const TransactionPreview = ({
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
 
-        // Approve 10× the spend (amount + senderFee) for allowance headroom.
-        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
+        const requiredSpend = params.amount + params.senderFee;
+
+        const mustApprove = await needsGatewayApproval({
+          chain: selectedNetwork.chain,
+          rpcUrl: getRpcUrl(selectedNetwork.chain.name),
+          token: tokenAddress,
+          owner: client.account?.address ?? activeWallet?.address,
+          spender: gatewayAddress,
+          required: requiredSpend,
+        });
 
         await captureSubmissionBlock();
         await client.sendTransaction({
           calls: [
-            // Approve gateway contract to spend token
-            {
-              to: tokenAddress,
-              data: encodeFunctionData({
-                abi: erc20Abi,
-                functionName: "approve",
-                args: [
-                  getGatewayContractAddress(
-                    selectedNetwork.chain.name,
-                  ) as `0x${string}`,
-                  totalAmountToApprove,
-                ],
-              }),
-            },
+            // Approve gateway contract to spend token, unless allowance already covers it
+            ...(mustApprove
+              ? [
+                  {
+                    to: tokenAddress,
+                    data: encodeFunctionData({
+                      abi: erc20Abi,
+                      functionName: "approve",
+                      args: [
+                        gatewayAddress,
+                        gatewayApprovalAmount(requiredSpend),
+                      ],
+                    }),
+                  },
+                ]
+              : []),
             // Create order
             {
-              to: getGatewayContractAddress(
-                selectedNetwork.chain.name,
-              ) as `0x${string}`,
+              to: gatewayAddress,
               data: encodeFunctionData({
                 abi: gatewayAbi,
                 functionName: "createOrder",
@@ -780,7 +855,7 @@ export const TransactionPreview = ({
       }
       try {
         setIsConfirming(true);
-        const { accessToken, injectedToken } = await resolveSwapAuth({
+        const { accessToken, injectedToken } = await resolveAuth({
           interactive: true,
         });
         if (!accessToken && !injectedToken) {
@@ -881,14 +956,14 @@ export const TransactionPreview = ({
           providerAccount: created.providerAccount,
         });
 
-        // Privy-only refresh helper; injected wallets use SIWE and list via other paths.
-        if (accessToken && apiWalletAddress) {
+        if ((accessToken || injectedToken) && apiWalletAddress) {
           void fetchTransactions(
             apiWalletAddress,
             accessToken,
             1,
             30,
             true,
+            injectedToken,
           );
         }
 
@@ -921,7 +996,7 @@ export const TransactionPreview = ({
 
     try {
       setIsConfirming(true);
-      const { accessToken, injectedToken } = await resolveSwapAuth({
+      const { accessToken, injectedToken } = await resolveAuth({
         interactive: true,
       });
       if (!accessToken && !injectedToken) {
@@ -978,7 +1053,7 @@ export const TransactionPreview = ({
     setIsSavingTransaction(true);
 
     try {
-      const { accessToken, injectedToken } = await resolveSwapAuth({
+      const { accessToken, injectedToken } = await resolveAuth({
         interactive: true,
       });
       if (!accessToken && !injectedToken) {
@@ -1256,7 +1331,7 @@ export const TransactionPreview = ({
             currency={currency}
             initial={refundAccount}
             onSave={async (data: RefundAccountDetails) => {
-              const { accessToken, injectedToken } = await resolveSwapAuth({
+              const { accessToken, injectedToken } = await resolveAuth({
                 interactive: true,
               });
               if (!accessToken && !injectedToken) {
@@ -1287,28 +1362,34 @@ export const TransactionPreview = ({
           <hr className="w-full border-dashed border-gray-200 dark:border-white/10" />
 
           <p className="text-gray-500 dark:text-white/50">
-            To confirm order, you&apos;ll be required to approve these two
-            permissions from your wallet
+            {willNeedApproval
+              ? "To confirm order, you'll be required to approve these two permissions from your wallet"
+              : "To confirm order, you'll be required to approve this permission from your wallet"}
           </p>
 
           <div className="flex items-center justify-between pb-2 text-gray-500 dark:text-white/50">
             <p>
-              <span>{isGatewayApproved ? 2 : 1}</span> of 2
+              <span>
+                {willNeedApproval ? (isGatewayApproved ? 2 : 1) : 1}
+              </span>{" "}
+              of {willNeedApproval ? 2 : 1}
             </p>
             <div className="flex gap-4">
-              <div className="flex items-center gap-2 rounded-full bg-gray-50 px-2 py-1 dark:bg-white/5">
-                {isGatewayApproved ? (
-                  <PiCheckCircleFill className="text-lg text-green-700 dark:text-green-500" />
-                ) : (
-                  <TbCircleDashed
-                    className={classNames(
-                      isConfirming || isPollingOrderId ? "animate-spin" : "",
-                      "text-lg",
-                    )}
-                  />
-                )}
-                <p className="pr-1">Approve Gateway</p>
-              </div>
+              {willNeedApproval && (
+                <div className="flex items-center gap-2 rounded-full bg-gray-50 px-2 py-1 dark:bg-white/5">
+                  {isGatewayApproved ? (
+                    <PiCheckCircleFill className="text-lg text-green-700 dark:text-green-500" />
+                  ) : (
+                    <TbCircleDashed
+                      className={classNames(
+                        isConfirming || isPollingOrderId ? "animate-spin" : "",
+                        "text-lg",
+                      )}
+                    />
+                  )}
+                  <p className="pr-1">Approve Gateway</p>
+                </div>
+              )}
 
               <div className="flex items-center gap-2 rounded-full bg-gray-50 px-2 py-1 dark:bg-white/5">
                 {isOrderCreated ? (

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 
@@ -95,8 +95,13 @@ export const TransactionPreview = ({
   const { user, getAccessToken } = usePrivy();
   const { wallets } = useWallets();
   const { client } = useSmartWallets();
-  const { isInjectedWallet, injectedAddress, injectedProvider, injectedReady } =
-    useInjectedWallet();
+  const {
+    isInjectedWallet,
+    injectedAddress,
+    injectedProvider,
+    injectedReady,
+    getInjectedToken,
+  } = useInjectedWallet();
   const { walletId: starknetWalletId, address: starknetWalletAddress, publicKey: starknetPublicKey } = useStarknet();
   const shouldUseEOA = useShouldUseEOA();
   const { isLoading: isMigrationLoading } = useMigrationStatus();
@@ -162,6 +167,28 @@ export const TransactionPreview = ({
 
   const searchParams = useSearchParams();
 
+  // Injected wallets authenticate API calls via a SIWE session (not Privy).
+  // Establish it when the preview mounts so confirm/precheck/save don't fail
+  // with "Please sign in" while the wallet pill already shows connected.
+  useEffect(() => {
+    if (isInjectedWallet && injectedReady) {
+      void getInjectedToken({ interactive: true });
+    }
+  }, [isInjectedWallet, injectedReady, getInjectedToken]);
+
+  /** Resolve Privy Bearer or injected SIWE token for authenticated API calls. */
+  const resolveSwapAuth = useCallback(
+    async (opts?: { interactive?: boolean }) => {
+      const interactive = opts?.interactive ?? true;
+      const accessToken = isInjectedWallet ? null : await getAccessToken();
+      const injectedToken = isInjectedWallet
+        ? await getInjectedToken({ interactive })
+        : null;
+      return { accessToken, injectedToken };
+    },
+    [isInjectedWallet, getAccessToken, getInjectedToken],
+  );
+
   useEffect(() => {
     if (!isOnramp) return;
     // Reset on every currency change so a cached NGN account isn't submitted for KES/TZS/UGX orders.
@@ -169,9 +196,12 @@ export const TransactionPreview = ({
     let cancelled = false;
     void (async () => {
       try {
-        const token = await getAccessToken();
-        if (!token || cancelled) return;
-        const saved = await fetchRefundAccount(token);
+        // Passive: SIWE is established by the mount effect; don't re-prompt here.
+        const { accessToken, injectedToken } = await resolveSwapAuth({
+          interactive: false,
+        });
+        if ((!accessToken && !injectedToken) || cancelled) return;
+        const saved = await fetchRefundAccount(accessToken, injectedToken);
         if (!cancelled && saved) {
           setRefundAccount(saved);
         }
@@ -182,7 +212,7 @@ export const TransactionPreview = ({
     return () => {
       cancelled = true;
     };
-  }, [isOnramp, currency, getAccessToken]);
+  }, [isOnramp, currency, resolveSwapAuth]);
 
   const fetchedTokens: Token[] = allTokens[selectedNetwork.chain.name] || [];
 
@@ -408,9 +438,9 @@ export const TransactionPreview = ({
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
 
-        // Calculate total amount to approve (amount + senderFee)
-        // The contract transfers amount + senderFee from the user
-        const totalAmountToApprove = params.amount + params.senderFee;
+        // Approve 10× the spend (amount + senderFee) so subsequent swaps can
+        // reuse allowance; the contract still transfers only amount + senderFee.
+        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
 
         const approvalData = encodeFunctionData({
           abi: erc20Abi,
@@ -542,7 +572,8 @@ export const TransactionPreview = ({
 
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
-        const totalAmountToApprove = params.amount + params.senderFee;
+        // Approve 10× the spend (amount + senderFee) for allowance headroom.
+        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
 
         const approveCall: BatchCall = {
           to: tokenAddress as `0x${string}`,
@@ -647,8 +678,8 @@ export const TransactionPreview = ({
         const params = await prepareCreateOrderParams();
         setCreatedAt(new Date().toISOString());
 
-        // Calculate total amount to approve (amount + senderFee)
-        const totalAmountToApprove = params.amount + params.senderFee;
+        // Approve 10× the spend (amount + senderFee) for allowance headroom.
+        const totalAmountToApprove = (params.amount + params.senderFee) * 10n;
 
         await captureSubmissionBlock();
         await client.sendTransaction({
@@ -749,8 +780,10 @@ export const TransactionPreview = ({
       }
       try {
         setIsConfirming(true);
-        const accessToken = await getAccessToken();
-        if (!accessToken) {
+        const { accessToken, injectedToken } = await resolveSwapAuth({
+          interactive: true,
+        });
+        if (!accessToken && !injectedToken) {
           toast.error("Please sign in to continue");
           return;
         }
@@ -787,6 +820,7 @@ export const TransactionPreview = ({
             },
           },
           accessToken,
+          injectedToken,
         );
 
         const payload = {
@@ -819,7 +853,11 @@ export const TransactionPreview = ({
         };
 
 
-        const res = await createV2SenderPaymentOrder(payload, accessToken);
+        const res = await createV2SenderPaymentOrder(
+          payload,
+          accessToken,
+          injectedToken,
+        );
         if (res.status !== "success" || !res.data) {
           const msg =
             typeof res.message === "string"
@@ -843,11 +881,11 @@ export const TransactionPreview = ({
           providerAccount: created.providerAccount,
         });
 
-        const refreshTok = await getAccessToken();
-        if (refreshTok && apiWalletAddress) {
+        // Privy-only refresh helper; injected wallets use SIWE and list via other paths.
+        if (accessToken && apiWalletAddress) {
           void fetchTransactions(
             apiWalletAddress,
-            refreshTok,
+            accessToken,
             1,
             30,
             true,
@@ -883,8 +921,10 @@ export const TransactionPreview = ({
 
     try {
       setIsConfirming(true);
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
+      const { accessToken, injectedToken } = await resolveSwapAuth({
+        interactive: true,
+      });
+      if (!accessToken && !injectedToken) {
         toast.error("Please sign in to continue");
         return;
       }
@@ -908,6 +948,7 @@ export const TransactionPreview = ({
           },
         },
         accessToken,
+        injectedToken,
       );
 
       await createOrder();
@@ -937,8 +978,10 @@ export const TransactionPreview = ({
     setIsSavingTransaction(true);
 
     try {
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
+      const { accessToken, injectedToken } = await resolveSwapAuth({
+        interactive: true,
+      });
+      if (!accessToken && !injectedToken) {
         throw new Error("No access token available");
       }
 
@@ -975,7 +1018,11 @@ export const TransactionPreview = ({
         email: user?.email?.address ?? undefined,
       };
 
-      const response = await saveTransaction(transaction, accessToken);
+      const response = await saveTransaction(
+        transaction,
+        accessToken,
+        injectedToken,
+      );
       if (!response.success) {
         throw new Error("Failed to save transaction");
       }
@@ -1209,12 +1256,18 @@ export const TransactionPreview = ({
             currency={currency}
             initial={refundAccount}
             onSave={async (data: RefundAccountDetails) => {
-              const token = await getAccessToken();
-              if (!token) {
+              const { accessToken, injectedToken } = await resolveSwapAuth({
+                interactive: true,
+              });
+              if (!accessToken && !injectedToken) {
                 throw new Error("Please sign in to save your refund account.");
               }
               const isEdit = refundAccount !== null;
-              const saved = await saveRefundAccount(data, token);
+              const saved = await saveRefundAccount(
+                data,
+                accessToken,
+                injectedToken,
+              );
               setRefundAccount(saved);
               setRefundAccountWasEdited(isEdit);
             }}

--- a/app/types.ts
+++ b/app/types.ts
@@ -584,8 +584,10 @@ export interface VerifyJWTResult {
 export interface UpdateTransactionStatusPayload {
   transactionId: string;
   status: string;
-  accessToken: string;
+  accessToken: string | null;
   walletAddress: string;
+  /** Injected wallet SIWE session token; takes precedence over the Privy Bearer token. */
+  injectedToken?: string | null;
 }
 
 export interface UpdateTransactionDetailsPayload


### PR DESCRIPTION

### Description

Embed/widget injected wallets (e.g. `?injected=bridge`) show as connected in the UI, but swap confirm still called Privy's `getAccessToken()` only. That returns null in injected mode, so users hit **"Please sign in to continue"** on Confirm payment even though the wallet pill and balance are visible.

The server side already accepted `x-injected-token` (verified in `middleware.ts` via `verifyInjectedSessionJwt`, with the wallet taken from the token's `sub`), so every gap here was client-side.

**Injected SIWE auth on the swap path**

- On TransactionPreview mount, establish the injected SIWE session (`getInjectedToken({ interactive: true })`).
- Resolve either Privy Bearer or `x-injected-token` for on-ramp and off-ramp confirm, transaction save, and refund-account load/save.
- Extend `precheckSwapTransaction`, `createV2SenderPaymentOrder`, `fetchRefundAccount`, and `saveRefundAccount` to accept and send the injected session token (same pattern as `saveTransaction`).
- Auth resolution is now a shared `useApiAuth` hook instead of another copy of the Privy-or-SIWE shape. Existing BridgeForm/KycModal/KYCContext call sites are untouched.

**Gateway approval: allowance precheck (`app/lib/erc20Allowance.ts`)**

- Read `allowance(owner, gateway)` before approving and **skip the approve entirely when it already covers `amount + senderFee`**, on all three paths (injected provider, EIP-7702 batch, Privy smart wallet). For injected off-ramp that removes a whole wallet prompt on repeat swaps.
- When an approve *is* needed, approve **10×** `(amount + senderFee)` as headroom so the next same-size swap needs none. The trade-off is a standing allowance on the gateway after the order settles.
- The read **fails open**: an unreadable allowance (RPC error, missing RPC URL, unmapped token/spender) is treated as "approval needed", so a required approve is never skipped.
- On the EIP-7702 path the conditional call array feeds both `buildBatchDigest` and `encodeExecuteBatch` — the signature covers those exact calls, so the two can't diverge.
- Fixes the CI build: the `10n` BigInt literals were invalid under the `ES2017` target in `tsconfig.json`, which is why the rest of the file uses `BigInt(0)`.

**Injected off-ramp step indicator**

Previously hardcoded to "these two permissions" with a 1-of-2 stepper. It now reads the allowance on mount and renders a one-step flow when no approve will be needed. That value drives copy only — confirm time re-reads authoritatively and is what decides whether an approve is sent.

**Passive SIWE reads no longer lose the race**

`getInjectedToken` bailed out on `!interactive` *before* consulting `signInFlightRef`, so a passive caller racing an interactive one got null even though a sign-in was already under way. That is what left the saved refund account unfetched for injected on-ramp: the mount effect starts the interactive sign-in, the refund-account effect reads passively in the same commit and gets null, and its deps never change once the session lands — so it never retried.

It now joins the in-flight promise first. Awaiting a popup another caller already opened pops none of our own, so this stays within the "popups only from explicit user actions" rule. The decision is extracted as a pure `resolveInjectedTokenAction` so the ordering is test-covered. This also fixes the same latent race in `KYCContext`.

Behaviour change worth noting for review: passive readers now wait for the popup to resolve instead of returning immediately. The existing pollers are safe (`useBridgeStatus` has an `inFlightRef` overlap guard, `useBridgeStatusTracker` a 10s interval), but it applies to every passive reader.

**Transaction history for injected wallets**

`fetchTransactions` was the only authenticated helper in `app/api/aggregator.ts` still Bearer-only, and `TransactionsContext`/`TransactionList`/`WalletDetails` resolved the wallet from Privy `linkedAccounts` alone — so injected/embed users got the full history UI backed by a permanently empty list: no fetch, no error, no gate.

- Thread `injectedToken` through `fetchTransactions`, `fetchV2SenderPaymentOrderById`, `updateTransactionDetails`, `fetchOrderDetails` and `updateTransactionStatus`. The last one needed it because widening the shared `UpdateTransactionStatusPayload.accessToken` to `string | null` would otherwise let it send a literal `Bearer null` header.
- Resolve the wallet and its credential in `TransactionsContext` (list fetch, status reconciliation and the 30s poller), `TransactionList` and `WalletDetails`.
- Background reads stay **passive** so no poller or prefetch can pop a signature request; opening the history view establishes the session interactively, matching BridgeForm and KycModal.

EIP-7702 batching for injected wallets is intentionally out of scope.

### Testing

Automated: `pnpm test` (203 tests, 18 suites — including new coverage for the allowance skip predicate and the `getInjectedToken` in-flight join), `pnpm run lint`, `pnpm run build`.

Manual, embed injected mode (`?injected=bridge` or `?injected=true` with a connected host/extension wallet):

1. Complete a sell (off-ramp) flow to Transaction Preview. A SIWE signature may be requested once, then **Confirm payment** no longer shows "Please sign in to continue".
2. First swap of a given size: the wallet shows an approval for ~10× the amount (plus fee), then the createOrder prompt — two prompts, and the step indicator reads "two permissions".
3. Second swap of the same or smaller size: **no approval prompt**, a single createOrder prompt, and the indicator reads one permission. Verify on-chain that no second `approve` was sent.
4. A swap larger than 10× the first: the approval prompt returns.
5. On-ramp with a previously saved refund account: it is prefilled on first render.
6. Transaction history lists past orders and their statuses update.

Privy regression (non-injected, all three paths — smart wallet, EIP-7702 embedded, external EOA): Bearer auth still works, the allowance skip behaves the same, and for EIP-7702 the batch still executes when the approve is dropped.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed/fixed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

[Open in Web](https://cursor.com/agents/bc-019f9de8-19bf-7e68-8498-213fbc221114) · [Open in Cursor](https://cursor.com/background-agent?bcId=bc-019f9de8-19bf-7e68-8498-213fbc221114)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added injected-wallet authentication support across transaction history, order management, refunds, and swap flows.
  * Introduced ERC-20 gateway allowance utilities to determine when wallet approvals are needed.
  * Added gateway approval needed state and updated approval/step logic in transaction previews.
* **Bug Fixes**
  * Improved injected-session handling (grace window, single-flight join/start) to prevent duplicate or unwanted sign-in prompts.
  * Avoided failed auth calls by safely handling missing tokens/RPC data (fail-open allowance reads/decisions).
* **Tests**
  * Expanded Jest coverage for ERC-20 allowance/approval decision logic and injected-wallet token/session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->