### PR TITLE
feat(kyc): pool limits per identity, exempt injected wallets from uniqueness

### DIFF
--- a/__tests__/injectedIdentity.test.ts
+++ b/__tests__/injectedIdentity.test.ts
@@ -1,0 +1,31 @@
+import {
+  INJECTED_USER_ID_PREFIX,
+  isInjectedUserId,
+} from "@/app/lib/injected-identity";
+
+describe("isInjectedUserId", () => {
+  it("recognizes the subject middleware mints for injected sessions", () => {
+    expect(
+      isInjectedUserId("injected-0x1234567890abcdef1234567890abcdef12345678"),
+    ).toBe(true);
+  });
+
+  it("rejects Privy subjects", () => {
+    expect(isInjectedUserId("did:privy:clx0000000000000000000000")).toBe(false);
+  });
+
+  it("rejects missing or empty ids without throwing", () => {
+    expect(isInjectedUserId(null)).toBe(false);
+    expect(isInjectedUserId(undefined)).toBe(false);
+    expect(isInjectedUserId("")).toBe(false);
+  });
+
+  it("requires the prefix at the start, not merely somewhere in the id", () => {
+    expect(isInjectedUserId("did:privy:injected-0xabc")).toBe(false);
+  });
+
+  it("exports the prefix middleware builds the subject from", () => {
+    expect(INJECTED_USER_ID_PREFIX).toBe("injected-");
+    expect(isInjectedUserId(`${INJECTED_USER_ID_PREFIX}0xabc`)).toBe(true);
+  });
+});

--- a/__tests__/kycIdentity.test.ts
+++ b/__tests__/kycIdentity.test.ts
@@ -1,0 +1,211 @@
+import { resolveIdentityScope } from "../app/lib/kyc-identity";
+import { supabaseAdmin } from "../app/lib/supabase";
+
+// Stub Supabase entirely: these tests are about which wallets end up sharing a spend
+// pool, not about PostgREST. `from` is queued per call so each query in
+// resolveIdentityScope (profile, then phone siblings, then ID siblings) can return its
+// own fixture. Relative specifier: the "@/" alias resolves for imports but not for
+// jest.mock, whose moduleNameMapper target ("<rootDir>/app/$1") does not exist.
+jest.mock("../app/lib/supabase", () => ({
+  supabaseAdmin: { from: jest.fn() },
+}));
+
+const mockedFrom = supabaseAdmin.from as unknown as jest.Mock;
+
+type QueryResult = { data: unknown; error: unknown };
+
+/**
+ * A chainable stand-in for a PostgREST query builder. Every filter returns itself; the
+ * builder is awaitable directly (sibling queries) and via maybeSingle (profile lookup).
+ */
+function query(result: QueryResult) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ["select", "eq", "gte", "neq", "limit", "in"]) {
+    builder[method] = () => builder;
+  }
+  builder.maybeSingle = () => Promise.resolve(result);
+  builder.then = (onFulfilled: unknown, onRejected: unknown) =>
+    Promise.resolve(result).then(
+      onFulfilled as never,
+      onRejected as never,
+    );
+  return builder;
+}
+
+function queueQueries(...results: QueryResult[]) {
+  mockedFrom.mockReset();
+  for (const result of results) {
+    mockedFrom.mockImplementationOnce(() => query(result));
+  }
+}
+
+const ok = (data: unknown): QueryResult => ({ data, error: null });
+
+const CALLER = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SIBLING = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PHONE = "+2348001112222";
+
+beforeEach(() => {
+  mockedFrom.mockReset();
+});
+
+describe("resolveIdentityScope", () => {
+  it("scopes to the caller alone when no profile exists", async () => {
+    queueQueries(ok(null));
+
+    await expect(resolveIdentityScope(CALLER)).resolves.toEqual({
+      wallets: [CALLER],
+      effectiveTier: 0,
+      identityKeys: [`wallet:${CALLER}`],
+    });
+  });
+
+  it("scopes to the caller when the profile has no verified identity", async () => {
+    queueQueries(
+      ok({
+        tier: 0,
+        phone_number: null,
+        id_country: null,
+        id_type: null,
+        id_number: null,
+      }),
+    );
+
+    await expect(resolveIdentityScope(CALLER)).resolves.toEqual({
+      wallets: [CALLER],
+      effectiveTier: 0,
+      identityKeys: [`wallet:${CALLER}`],
+    });
+  });
+
+  it("pools wallets sharing a phone and inherits the group's highest tier", async () => {
+    queueQueries(
+      ok({
+        tier: 1,
+        phone_number: PHONE,
+        id_country: null,
+        id_type: null,
+        id_number: null,
+      }),
+      ok([
+        { wallet_address: CALLER, tier: 1 },
+        { wallet_address: SIBLING, tier: 2 },
+      ]),
+    );
+
+    const scope = await resolveIdentityScope(CALLER);
+
+    expect(scope.wallets).toEqual([CALLER, SIBLING].sort());
+    // The identity carries the tier: a tier-1 wallet inherits its sibling's tier 2.
+    expect(scope.effectiveTier).toBe(2);
+    expect(scope.identityKeys).toEqual([`phone:${PHONE}`]);
+  });
+
+  it("pools wallets sharing an ID document", async () => {
+    queueQueries(
+      ok({
+        tier: 2,
+        phone_number: null,
+        id_country: "NG",
+        id_type: "BVN",
+        id_number: "12345678901",
+      }),
+      ok([{ wallet_address: SIBLING, tier: 3 }]),
+    );
+
+    const scope = await resolveIdentityScope(CALLER);
+
+    expect(scope.wallets).toEqual([CALLER, SIBLING].sort());
+    expect(scope.effectiveTier).toBe(3);
+    expect(scope.identityKeys).toEqual(["id:NG:BVN:12345678901"]);
+  });
+
+  it("returns both identity keys sorted when phone and ID are present", async () => {
+    queueQueries(
+      ok({
+        tier: 2,
+        phone_number: PHONE,
+        id_country: "NG",
+        id_type: "BVN",
+        id_number: "12345678901",
+      }),
+      ok([]),
+      ok([]),
+    );
+
+    const scope = await resolveIdentityScope(CALLER);
+
+    // Sorted so two transactions can never take the two locks in opposite orders.
+    expect(scope.identityKeys).toEqual([
+      "id:NG:BVN:12345678901",
+      `phone:${PHONE}`,
+    ]);
+    expect([...scope.identityKeys].sort()).toEqual(scope.identityKeys);
+  });
+
+  it("lowercases and dedupes wallet addresses so the pool matches transactions rows", async () => {
+    queueQueries(
+      ok({
+        tier: 1,
+        phone_number: PHONE,
+        id_country: null,
+        id_type: null,
+        id_number: null,
+      }),
+      ok([
+        { wallet_address: CALLER.toUpperCase().replace("0X", "0x"), tier: 1 },
+        { wallet_address: SIBLING, tier: 1 },
+        { wallet_address: SIBLING, tier: 1 },
+        { wallet_address: null, tier: 1 },
+      ]),
+    );
+
+    const scope = await resolveIdentityScope(CALLER.toUpperCase().replace("0X", "0x"));
+
+    expect(scope.wallets).toEqual([CALLER, SIBLING].sort());
+  });
+
+  it("clamps an out-of-range tier to the highest tier the limit table defines", async () => {
+    queueQueries(
+      ok({
+        tier: 4,
+        phone_number: PHONE,
+        id_country: null,
+        id_type: null,
+        id_number: null,
+      }),
+      ok([]),
+    );
+
+    await expect(
+      resolveIdentityScope(CALLER).then((s) => s.effectiveTier),
+    ).resolves.toBe(3);
+  });
+
+  it("throws when the profile lookup fails rather than narrowing the pool", async () => {
+    queueQueries({ data: null, error: { message: "boom" } });
+
+    // Falling back to a per-wallet scope here would leave siblings' spend uncounted
+    // and make the monthly cap bypassable, so this must fail closed.
+    await expect(resolveIdentityScope(CALLER)).rejects.toEqual({
+      message: "boom",
+    });
+  });
+
+  it("throws when a sibling lookup fails rather than narrowing the pool", async () => {
+    queueQueries(
+      ok({
+        tier: 1,
+        phone_number: PHONE,
+        id_country: null,
+        id_type: null,
+        id_number: null,
+      }),
+      { data: null, error: { message: "sibling boom" } },
+    );
+
+    await expect(resolveIdentityScope(CALLER)).rejects.toEqual({
+      message: "sibling boom",
+    });
+  });
+});

--- a/__tests__/kycLimitCopy.test.ts
+++ b/__tests__/kycLimitCopy.test.ts
@@ -1,0 +1,55 @@
+import {
+  isPooledAllowance,
+  monthlyLimitReachedMessage,
+  sharedAllowanceNote,
+} from "../app/lib/kyc-limit-copy";
+
+// The copy shipped before identity pooling. Anyone whose allowance is not shared must
+// keep seeing exactly this — pooling should be invisible to the unaffected majority.
+const LEGACY_MESSAGE =
+  "Monthly transaction limit of $5,000 reached. Upgrade your verification tier to continue.";
+
+describe("isPooledAllowance", () => {
+  it("treats a single wallet, missing, and zero counts as not pooled", () => {
+    expect(isPooledAllowance(1)).toBe(false);
+    expect(isPooledAllowance(0)).toBe(false);
+    expect(isPooledAllowance(undefined)).toBe(false);
+  });
+
+  it("is pooled from two wallets up", () => {
+    expect(isPooledAllowance(2)).toBe(true);
+    expect(isPooledAllowance(7)).toBe(true);
+  });
+});
+
+describe("sharedAllowanceNote", () => {
+  it("is empty when the allowance is not shared", () => {
+    expect(sharedAllowanceNote(1)).toBe("");
+    expect(sharedAllowanceNote(undefined)).toBe("");
+  });
+
+  it("names the wallet count when shared", () => {
+    expect(sharedAllowanceNote(3)).toBe("shared across your 3 wallets");
+  });
+});
+
+describe("monthlyLimitReachedMessage", () => {
+  it("returns the pre-pooling copy verbatim for a single wallet", () => {
+    expect(monthlyLimitReachedMessage(5000, 1)).toBe(LEGACY_MESSAGE);
+  });
+
+  it("returns the pre-pooling copy when the count is missing", () => {
+    expect(monthlyLimitReachedMessage(5000, undefined)).toBe(LEGACY_MESSAGE);
+  });
+
+  it("names the linked wallets when the allowance is shared", () => {
+    expect(monthlyLimitReachedMessage(5000, 3)).toBe(
+      "Monthly transaction limit of $5,000 reached across your 3 linked wallets. Upgrade your verification tier to continue.",
+    );
+  });
+
+  it("keeps thousands separators on the limit", () => {
+    expect(monthlyLimitReachedMessage(1234567, 1)).toContain("$1,234,567");
+    expect(monthlyLimitReachedMessage(1234567, 2)).toContain("$1,234,567");
+  });
+});

--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -121,7 +121,9 @@ export async function POST(request: NextRequest) {
   // existing verified data that the sync response already wrote.
   const { data: existing, error: fetchError } = await supabaseAdmin
     .from("user_kyc_profiles")
-    .select("tier, verified, platform")
+    .select(
+      "tier, verified, platform, id_country, id_type, id_number, is_injected_wallet",
+    )
     .eq("wallet_address", walletAddress)
     .maybeSingle();
 
@@ -210,6 +212,53 @@ export async function POST(request: NextRequest) {
       : null) ||
     null;
 
+  // Raising tier to 2 can newly pull this row into uniq_user_kyc_profiles_verified_id
+  // (the index covers tier >= 2 only), even though no id_number is written here. If
+  // another non-injected wallet already holds this document, the promotion can never
+  // succeed — so refuse it deliberately instead of letting a 23505 surface as a 500
+  // that SmileID retries forever.
+  if (
+    newTier >= 2 &&
+    existing.id_number &&
+    existing.is_injected_wallet !== true
+  ) {
+    const { data: idOwner, error: idOwnerError } = await supabaseAdmin
+      .from("user_kyc_profiles")
+      .select("wallet_address")
+      .eq("id_country", existing.id_country)
+      .eq("id_type", existing.id_type)
+      .eq("id_number", existing.id_number)
+      .gte("tier", 2)
+      .eq("is_injected_wallet", false)
+      .neq("wallet_address", walletAddress)
+      .limit(1)
+      .maybeSingle();
+
+    if (idOwnerError) {
+      console.error("[smile-id/callback] ID ownership check failed", {
+        walletAddress,
+        idOwnerError,
+      });
+      // Transient: 500 so SmileID retries.
+      return NextResponse.json(
+        { status: "error", message: "Database error" },
+        { status: 500 },
+      );
+    }
+
+    if (idOwner) {
+      console.warn(
+        "[smile-id/callback] ID document already verified on another wallet — skipping tier promotion",
+        { walletAddress, jobId },
+      );
+      // 200: the conflict is permanent, so retrying would loop forever.
+      return NextResponse.json({
+        status: "ok",
+        action: "duplicate_id_conflict",
+      });
+    }
+  }
+
   const { error: updateError } = await supabaseAdmin
     .from("user_kyc_profiles")
     .update({
@@ -223,6 +272,18 @@ export async function POST(request: NextRequest) {
     .eq("wallet_address", walletAddress);
 
   if (updateError) {
+    // Same conflict, lost to a concurrent verification after the check above.
+    // Still permanent — do not ask SmileID to retry.
+    if (updateError.code === "23505") {
+      console.warn(
+        "[smile-id/callback] Tier promotion hit the verified-ID unique index",
+        { walletAddress, jobId },
+      );
+      return NextResponse.json({
+        status: "ok",
+        action: "duplicate_id_conflict",
+      });
+    }
     console.error("[smile-id/callback] Failed to update profile", { walletAddress, updateError });
     // Return 500 so SmileID retries.
     return NextResponse.json({ status: "error", message: "Database update failed" }, { status: 500 });

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest) {
     const { data: existingProfile, error: profileFetchError } =
       await supabaseAdmin
         .from("user_kyc_profiles")
-        .select("platform, tier")
+        .select("platform, tier, is_injected_wallet")
         .eq("wallet_address", walletAddress)
         .maybeSingle();
 
@@ -287,7 +287,12 @@ export async function POST(request: NextRequest) {
     // the update, preserving any previously stored id_number.
     const idNumberToStore: string | undefined =
       smileIdInfo.id_number || id_info.id_number || undefined;
-    if (idNumberToStore) {
+    // Injected/bridge wallets are exempt in both directions — neither checked nor
+    // counted as owners. Tier >= 1 is a precondition above, so the flag was already
+    // set by send-otp when the profile was created; no header read is needed here.
+    const isInjected = existingProfile.is_injected_wallet === true;
+
+    if (idNumberToStore && !isInjected) {
       const { data: idOwner, error: idOwnerError } = await supabaseAdmin
         .from("user_kyc_profiles")
         .select("wallet_address")
@@ -295,6 +300,7 @@ export async function POST(request: NextRequest) {
         .eq("id_type", id_info.id_type)
         .eq("id_number", idNumberToStore)
         .gte("tier", 2)
+        .eq("is_injected_wallet", false)
         .neq("wallet_address", walletAddress)
         .limit(1)
         .maybeSingle();
@@ -339,7 +345,7 @@ export async function POST(request: NextRequest) {
 
     if (supabaseError) {
       // 23505: partial unique index on verified ID documents (concurrent
-      // verification of the same document on another wallet).
+      // verification of the same document on another non-injected wallet).
       if (supabaseError.code === "23505") {
         return NextResponse.json(
           {

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -56,12 +56,13 @@ export async function GET(request: NextRequest) {
     // that person holds. Reported here so the UI shows the tier and cap that
     // enforcement will actually apply.
     let tier: 0 | 1 | 2 | 3;
+    let pooledWalletCount: number;
     try {
-      tier = (await resolveIdentityScope(walletAddress)).effectiveTier as
-        | 0
-        | 1
-        | 2
-        | 3;
+      const scope = await resolveIdentityScope(walletAddress);
+      tier = scope.effectiveTier as 0 | 1 | 2 | 3;
+      // How many wallets share this allowance. > 1 is what makes the UI explain the
+      // pool; at 1 every limit surface renders exactly as it did before pooling.
+      pooledWalletCount = scope.wallets.length;
     } catch (scopeError) {
       trackApiError(request, "/api/kyc/status", "GET", scopeError as Error, 500);
       return NextResponse.json(
@@ -82,6 +83,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       success: true,
       tier,
+      pooledWalletCount,
       isPhoneVerified: phoneVerified,
       phoneNumber,
       fullName: kycProfile?.full_name || null,

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
+import { resolveIdentityScope } from "@/app/lib/kyc-identity";
 import {
   trackApiRequest,
   trackApiResponse,
@@ -50,14 +51,29 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const rawTier = Number(kycProfile?.tier ?? 0);
-    const safeTier = Number.isFinite(rawTier) ? rawTier : 0;
-    const tier: 0 | 1 | 2 | 3 = Math.min(
-      Math.max(safeTier, 0),
-      3,
-    ) as 0 | 1 | 2 | 3;
+    // The identity carries the tier: a wallet inherits the highest tier reached by any
+    // wallet sharing its verified phone/ID, so verifying an ID once lifts every wallet
+    // that person holds. Reported here so the UI shows the tier and cap that
+    // enforcement will actually apply.
+    let tier: 0 | 1 | 2 | 3;
+    try {
+      tier = (await resolveIdentityScope(walletAddress)).effectiveTier as
+        | 0
+        | 1
+        | 2
+        | 3;
+    } catch (scopeError) {
+      trackApiError(request, "/api/kyc/status", "GET", scopeError as Error, 500);
+      return NextResponse.json(
+        { success: false, error: "Failed to load KYC profile" },
+        { status: 500 },
+      );
+    }
+
     const phoneNumber = kycProfile?.phone_number || null;
-    // tier >= 1 means phone OTP was verified; do not rely on the generic `verified` flag
+    // tier >= 1 means phone OTP was verified; do not rely on the generic `verified` flag.
+    // phone_number stays this wallet's own, so an inherited tier can never report a
+    // phone as verified on a wallet that never verified one.
     const phoneVerified = tier >= 1 && !!phoneNumber;
 
     const responseTime = Date.now() - startTime;

--- a/app/api/kyc/transaction-summary/route.ts
+++ b/app/api/kyc/transaction-summary/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
+import { resolveIdentityScope } from "@/app/lib/kyc-identity";
 import {
   trackApiRequest,
   trackApiResponse,
@@ -26,6 +27,26 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: "Unauthorized" },
         { status: 401 },
+      );
+    }
+
+    // Spend is pooled per verified identity, so the summary must count every wallet
+    // sharing it — mirroring insert_swap_transaction_if_within_limit. Counting only
+    // this wallet would show headroom that enforcement does not actually grant.
+    let scopeWallets: string[];
+    try {
+      scopeWallets = (await resolveIdentityScope(walletAddress)).wallets;
+    } catch (scopeError) {
+      trackApiError(
+        request,
+        "/api/kyc/transaction-summary",
+        "GET",
+        scopeError as Error,
+        500,
+      );
+      return NextResponse.json(
+        { success: false, error: "Failed to fetch transaction summary" },
+        { status: 500 },
       );
     }
 
@@ -73,7 +94,7 @@ export async function GET(request: NextRequest) {
     const { data: swapTransactions, error: swapError } = await supabaseAdmin
       .from("transactions")
       .select("amount_sent, from_currency, created_at")
-      .eq("wallet_address", walletAddress)
+      .in("wallet_address", scopeWallets)
       .eq("transaction_type", "offramp")
       .in("status", SPEND_STATUSES)
       .gte("created_at", monthStart.toISOString());
@@ -83,7 +104,7 @@ export async function GET(request: NextRequest) {
       .select(
         "amount_sent, amount_received, from_currency, to_currency, created_at",
       )
-      .eq("wallet_address", walletAddress)
+      .in("wallet_address", scopeWallets)
       .eq("transaction_type", "onramp")
       .in("status", SPEND_STATUSES)
       .gte("created_at", monthStart.toISOString());

--- a/app/api/phone/send-otp/route.ts
+++ b/app/api/phone/send-otp/route.ts
@@ -9,6 +9,7 @@ import {
   trackApiError,
 } from "../../../lib/server-analytics";
 import { rateLimit } from "@/app/lib/rate-limit";
+import { isInjectedUserId } from "@/app/lib/injected-identity";
 
 function hashOTP(otp: string): string {
   return createHash("sha256").update(otp).digest("hex");
@@ -131,7 +132,9 @@ export async function POST(request: NextRequest) {
     const { data: existingProfile, error: profileFetchError } =
       await supabaseAdmin
         .from("user_kyc_profiles")
-        .select("tier, id_country, id_type, platform, full_name")
+        .select(
+          "tier, id_country, id_type, platform, full_name, is_injected_wallet",
+        )
         .eq("wallet_address", walletAddress)
         .maybeSingle();
 
@@ -163,40 +166,53 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // One verified identity per phone number: refuse before spending an SMS.
-    const { data: phoneOwner, error: phoneOwnerError } = await supabaseAdmin
-      .from("user_kyc_profiles")
-      .select("wallet_address")
-      .eq("phone_number", validation.e164Format)
-      .gte("tier", 1)
-      .neq("wallet_address", walletAddress)
-      .limit(1)
-      .maybeSingle();
+    // Injected/bridge wallets are exempt from phone uniqueness: one person reaches the
+    // app on several self-custodied addresses, and identity-scoped limits
+    // (`app/lib/kyc-identity.ts`) already pool their spend, so extra wallets buy no
+    // extra allowance. Non-injected callers still get one verified identity per number,
+    // and injected rows are skipped when checking so they never block a Privy user.
+    const isInjected = isInjectedUserId(userId);
 
-    if (phoneOwnerError) {
-      logSupabaseError("Supabase phone uniqueness check failed", phoneOwnerError);
-      return NextResponse.json(
-        { success: false, error: "Failed to validate phone number" },
-        { status: 500 },
-      );
-    }
+    if (!isInjected) {
+      // Refuse before spending an SMS.
+      const { data: phoneOwner, error: phoneOwnerError } = await supabaseAdmin
+        .from("user_kyc_profiles")
+        .select("wallet_address")
+        .eq("phone_number", validation.e164Format)
+        .gte("tier", 1)
+        .eq("is_injected_wallet", false)
+        .neq("wallet_address", walletAddress)
+        .limit(1)
+        .maybeSingle();
 
-    if (phoneOwner) {
-      trackApiError(
-        request,
-        "/api/phone/send-otp",
-        "POST",
-        new Error("Phone number already verified on another account"),
-        409,
-      );
-      return NextResponse.json(
-        {
-          success: false,
-          error:
-            "This phone number is already verified on another account. Please use a different number.",
-        },
-        { status: 409 },
-      );
+      if (phoneOwnerError) {
+        logSupabaseError(
+          "Supabase phone uniqueness check failed",
+          phoneOwnerError,
+        );
+        return NextResponse.json(
+          { success: false, error: "Failed to validate phone number" },
+          { status: 500 },
+        );
+      }
+
+      if (phoneOwner) {
+        trackApiError(
+          request,
+          "/api/phone/send-otp",
+          "POST",
+          new Error("Phone number already verified on another account"),
+          409,
+        );
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "This phone number is already verified on another account. Please use a different number.",
+          },
+          { status: 409 },
+        );
+      }
     }
 
     const isNigerian = validation.isNigerian;
@@ -256,6 +272,11 @@ export async function POST(request: NextRequest) {
           platform: existingProfile?.platform || null,
           otp_attempts: 0, // reset OTP counter on each new OTP send; leave `attempts` (SmileID) untouched
           provider: validation.provider,
+          // Sticky: never downgrade true → false. A wallet that verified while injected
+          // and is later seen through Privy must keep the exemption — clearing it would
+          // pull the row back into the unique index and could fail a valid write (23505).
+          is_injected_wallet:
+            isInjected || existingProfile?.is_injected_wallet === true,
         },
         {
           onConflict: "wallet_address",

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -38,30 +38,38 @@ function notifyPhoneVerified(walletAddress: string, currentTier: number): void {
  * Promotes the pending number to the verified phone_number. Enforces one
  * verified identity per phone (friendly pre-check + 23505 from the partial
  * unique index for the concurrent case).
+ *
+ * Injected-wallet profiles are exempt in both directions: they are neither checked
+ * nor counted as owners. Their spend is pooled per identity instead
+ * (`app/lib/kyc-identity.ts`), so several wallets on one number share one allowance.
  */
 async function promoteVerifiedPhone(
   walletAddress: string,
   e164: string,
   currentTier: number,
+  isInjected: boolean,
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-  const { data: phoneOwner, error: ownerError } = await supabaseAdmin
-    .from("user_kyc_profiles")
-    .select("wallet_address")
-    .eq("phone_number", e164)
-    .gte("tier", 1)
-    .neq("wallet_address", walletAddress)
-    .limit(1)
-    .maybeSingle();
+  if (!isInjected) {
+    const { data: phoneOwner, error: ownerError } = await supabaseAdmin
+      .from("user_kyc_profiles")
+      .select("wallet_address")
+      .eq("phone_number", e164)
+      .gte("tier", 1)
+      .eq("is_injected_wallet", false)
+      .neq("wallet_address", walletAddress)
+      .limit(1)
+      .maybeSingle();
 
-  if (ownerError) {
-    return {
-      ok: false,
-      status: 500,
-      error: "Failed to update verification status",
-    };
-  }
-  if (phoneOwner) {
-    return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
+    if (ownerError) {
+      return {
+        ok: false,
+        status: 500,
+        error: "Failed to update verification status",
+      };
+    }
+    if (phoneOwner) {
+      return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
+    }
   }
 
   const updateData: Record<string, unknown> = {
@@ -87,6 +95,7 @@ async function promoteVerifiedPhone(
     .maybeSingle();
 
   if (updateError) {
+    // Still reachable: two non-injected wallets racing to verify the same number.
     if (updateError.code === "23505") {
       return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
     }
@@ -178,7 +187,7 @@ export async function POST(request: NextRequest) {
     const { data: verification, error: fetchError } = await supabaseAdmin
       .from("user_kyc_profiles")
       .select(
-        "verified, provider, tier, expires_at, otp_attempts, otp_code, phone_number, pending_phone_number",
+        "verified, provider, tier, expires_at, otp_attempts, otp_code, phone_number, pending_phone_number, is_injected_wallet",
       )
       .eq("wallet_address", walletAddress)
       .maybeSingle();
@@ -252,6 +261,7 @@ export async function POST(request: NextRequest) {
         walletAddress,
         validation.e164Format,
         Number(verification.tier) || 0,
+        verification.is_injected_wallet === true,
       );
       if (!promotion.ok) {
         trackApiError(
@@ -360,6 +370,7 @@ export async function POST(request: NextRequest) {
       walletAddress,
       validation.e164Format,
       Number(verification.tier) || 0,
+      verification.is_injected_wallet === true,
     );
     if (!promotion.ok) {
       trackApiError(

--- a/app/api/v1/transactions/route.ts
+++ b/app/api/v1/transactions/route.ts
@@ -18,6 +18,7 @@ import {
   assertTransactionWalletAuthorized,
   executeSwapTransactionLimitCheck,
 } from "@/app/lib/swap-transaction-limit-server";
+import { monthlyLimitReachedMessage } from "@/app/lib/kyc-limit-copy";
 
 // Route handler for GET requests
 export const GET = withRateLimit(async (request: NextRequest) => {
@@ -285,7 +286,10 @@ export const POST = withRateLimit(async (request: NextRequest) => {
         return NextResponse.json(
           {
             success: false,
-            error: `Monthly transaction limit of $${swapResult.monthlyLimit.toLocaleString()} reached. Upgrade your verification tier to continue.`,
+            error: monthlyLimitReachedMessage(
+              swapResult.monthlyLimit,
+              swapResult.pooledWalletCount,
+            ),
           },
           { status: 403 },
         );

--- a/app/api/v1/transactions/swap-precheck/route.ts
+++ b/app/api/v1/transactions/swap-precheck/route.ts
@@ -9,6 +9,7 @@ import {
   assertTransactionWalletAuthorized,
   executeSwapTransactionLimitCheck,
 } from "@/app/lib/swap-transaction-limit-server";
+import { monthlyLimitReachedMessage } from "@/app/lib/kyc-limit-copy";
 import {
   parseValidTransactionAmount,
   roundAmountForCurrency,
@@ -199,7 +200,10 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       return NextResponse.json(
         {
           success: false,
-          error: `Monthly transaction limit of $${swapResult.monthlyLimit.toLocaleString()} reached. Upgrade your verification tier to continue.`,
+          error: monthlyLimitReachedMessage(
+            swapResult.monthlyLimit,
+            swapResult.pooledWalletCount,
+          ),
         },
         { status: 403 },
       );

--- a/app/components/ProfileView.tsx
+++ b/app/components/ProfileView.tsx
@@ -32,6 +32,7 @@ import TransactionLimitModal from "./TransactionLimitModal";
 import { ReferralCTA } from "./ReferralCTA";
 import { ReferralHubView } from "./wallet-mobile-modal";
 import config from "../lib/config";
+import { isPooledAllowance } from "../lib/kyc-limit-copy";
 
 // Re-import usePrivy and useLinkAccount specifically from Privy
 import { usePrivy as usePrivyAuth, useLinkAccount as useLinkAccountAuth } from "@privy-io/react-auth";
@@ -48,6 +49,7 @@ export default function ProfileView({ layout, onBack, onClose }: ProfileViewProp
   const { isEmbed } = useEmbed();
   const {
     tier,
+    pooledWalletCount,
     transactionSummary,
     getCurrentLimits,
     refreshStatus,
@@ -405,6 +407,14 @@ export default function ProfileView({ layout, onBack, onClose }: ProfileViewProp
                     </span>
                     <InformationCircleIcon className="size-4 text-outline-gray dark:text-white/50" />
                   </div>
+
+                  {/* Explains spend this wallet did not make. Hidden at one wallet so
+                      users without a shared allowance see the original layout. */}
+                  {isPooledAllowance(pooledWalletCount) && (
+                    <p className="text-xs font-light text-text-secondary dark:text-white/50">
+                      Shared across your {pooledWalletCount} wallets
+                    </p>
+                  )}
 
                   <div className="text-2xl font-light text-text-body dark:text-white">
                     ${formatUsdAmount(transactionSummary.monthlySpent)}{" "}

--- a/app/components/TransactionLimitModal.tsx
+++ b/app/components/TransactionLimitModal.tsx
@@ -21,6 +21,7 @@ import {
   getKycUpgradeStep,
   hasAssignedKycTier,
 } from "@/app/lib/kyc-upgrade-path";
+import { isPooledAllowance } from "@/app/lib/kyc-limit-copy";
 
 interface TransactionLimitModalProps {
   isOpen: boolean;
@@ -35,6 +36,7 @@ export default function TransactionLimitModal({
 }: TransactionLimitModalProps) {
   const {
     tier,
+    pooledWalletCount,
     getCurrentLimits,
     refreshStatus,
     transactionSummary,
@@ -104,6 +106,9 @@ export default function TransactionLimitModal({
             <span className="font-medium text-black dark:text-white">
               ${formatUsdAmount(currentLimits.monthly)}
             </span>
+            {isPooledAllowance(pooledWalletCount) && (
+              <>, shared across your {pooledWalletCount} wallets</>
+            )}
             {transactionAmount > 0 ? (
               <>
                 . This transaction (${formatNumberWithCommas(transactionAmount)}
@@ -141,6 +146,13 @@ export default function TransactionLimitModal({
               </span>
               <InformationCircleIcon className="h-4 w-4 text-gray-400 dark:text-white/40" />
             </div>
+
+            {/* The spend below can exceed what this wallet alone has sent. */}
+            {isPooledAllowance(pooledWalletCount) && (
+              <p className="text-xs font-light text-text-secondary dark:text-white/50">
+                Shared across your {pooledWalletCount} wallets
+              </p>
+            )}
 
             <div className="w-full text-start">
               <div className="mb-2 text-2xl font-light text-text-body dark:text-white">

--- a/app/context/KYCContext.tsx
+++ b/app/context/KYCContext.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { getKycTierLimit } from "@/app/lib/kyc-tier-limits";
+import { sharedAllowanceNote } from "@/app/lib/kyc-limit-copy";
 import { useWalletAddress } from "../hooks/useWalletAddress";
 import { useInjectedWallet } from "./InjectedWalletContext";
 
@@ -63,6 +64,12 @@ interface UserTransactionSummary {
 /** Synchronous KYC view — updated as soon as status APIs return (before re-render). */
 export interface KYCStatusSnapshot {
   tier: KYCTierLevel;
+  /**
+   * Wallets sharing this identity's monthly allowance. Defaults to 1, so a failed or
+   * stale status fetch reads as "not pooled" and every limit surface renders the
+   * pre-pooling copy rather than inventing wallets the user does not have.
+   */
+  pooledWalletCount: number;
   isPhoneVerified: boolean;
   phoneNumber: string | null;
   fullName: string | null;
@@ -71,6 +78,7 @@ export interface KYCStatusSnapshot {
 
 interface KYCContextType {
   tier: KYCTierLevel;
+  pooledWalletCount: number;
   isPhoneVerified: boolean;
   phoneNumber: string | null;
   fullName: string | null;
@@ -94,6 +102,7 @@ const EMPTY_TX_SUMMARY: UserTransactionSummary = {
 function createEmptySnapshot(): KYCStatusSnapshot {
   return {
     tier: 0,
+    pooledWalletCount: 1,
     isPhoneVerified: false,
     phoneNumber: null,
     fullName: null,
@@ -137,6 +146,7 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
   const guardKey = walletAddress || "no_wallet";
 
   const [tier, setTier] = useState<KYCTierLevel>(0);
+  const [pooledWalletCount, setPooledWalletCount] = useState(1);
   const [isPhoneVerified, setIsPhoneVerified] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState<string | null>(null);
   const [fullName, setFullName] = useState<string | null>(null);
@@ -146,6 +156,8 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
   const applySnapshot = useCallback((partial: Partial<KYCStatusSnapshot>) => {
     const next: KYCStatusSnapshot = {
       tier: partial.tier ?? latestSnapshotRef.current.tier,
+      pooledWalletCount:
+        partial.pooledWalletCount ?? latestSnapshotRef.current.pooledWalletCount,
       isPhoneVerified:
         partial.isPhoneVerified ?? latestSnapshotRef.current.isPhoneVerified,
       phoneNumber:
@@ -161,6 +173,7 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
     };
     latestSnapshotRef.current = next;
     setTier(next.tier);
+    setPooledWalletCount(next.pooledWalletCount);
     setIsPhoneVerified(next.isPhoneVerified);
     setPhoneNumber(next.phoneNumber);
     setFullName(next.fullName);
@@ -192,9 +205,14 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
         return { allowed: true };
       }
       if (amount > remaining.monthly) {
+        // The remaining figure covers every wallet on this identity, so say so —
+        // otherwise the number looks wrong to anyone with more than one wallet.
+        const pooled = sharedAllowanceNote(
+          latestSnapshotRef.current.pooledWalletCount,
+        );
         return {
           allowed: false,
-          reason: `Transaction amount ($${amount}) exceeds remaining monthly limit ($${remaining.monthly})`,
+          reason: `Transaction amount ($${amount}) exceeds remaining monthly limit ($${remaining.monthly})${pooled ? ` ${pooled}` : ""}`,
         };
       }
       return { allowed: true };
@@ -291,6 +309,7 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
         ) as KYCTierLevel;
         applySnapshot({
           tier: safeTier,
+          pooledWalletCount: Math.max(1, Number(data.pooledWalletCount) || 1),
           isPhoneVerified: Boolean(data.isPhoneVerified),
           phoneNumber: data.phoneNumber ?? null,
           fullName: data.fullName ?? null,
@@ -356,6 +375,7 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
       const empty = createEmptySnapshot();
       latestSnapshotRef.current = empty;
       setTier(empty.tier);
+      setPooledWalletCount(empty.pooledWalletCount);
       setIsPhoneVerified(empty.isPhoneVerified);
       setPhoneNumber(empty.phoneNumber);
       setFullName(empty.fullName);
@@ -370,6 +390,7 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
     <KYCContext.Provider
       value={{
         tier,
+        pooledWalletCount,
         isPhoneVerified,
         phoneNumber,
         fullName,

--- a/app/lib/injected-identity.ts
+++ b/app/lib/injected-identity.ts
@@ -1,0 +1,19 @@
+/**
+ * Server-side detection of injected-wallet sessions.
+ *
+ * `?injected=true|bridge` is a client-only URL parameter — the widget renders with
+ * `ssr: false`, so no API route ever sees it. The only server-side signal is the SIWE
+ * session JWT: middleware verifies `x-injected-token` and derives the subject
+ * `injected-<address>` for `x-user-id`, where Privy sessions carry a `did:privy:…`.
+ *
+ * That signal cannot distinguish `true` from `bridge` — both mint the same token — so
+ * anything keyed off it necessarily covers both modes.
+ */
+
+/** Prefix middleware gives the `x-user-id` of an injected-wallet session. */
+export const INJECTED_USER_ID_PREFIX = "injected-";
+
+/** True when a user id came from an injected-wallet (SIWE) session. */
+export function isInjectedUserId(userId: string | null | undefined): boolean {
+  return !!userId && userId.startsWith(INJECTED_USER_ID_PREFIX);
+}

--- a/app/lib/kyc-identity.ts
+++ b/app/lib/kyc-identity.ts
@@ -1,4 +1,5 @@
 import { supabaseAdmin } from "@/app/lib/supabase";
+import { MAX_KYC_TIER } from "@/app/lib/kyc-tier-limits";
 
 /**
  * Identity-scoped KYC limits.
@@ -15,9 +16,6 @@ import { supabaseAdmin } from "@/app/lib/supabase";
  * `app/lib/injected-identity.ts`) — uniqueness is no longer what bounds spend.
  */
 
-/** Highest tier the limit table defines (`app/lib/kyc-tier-limits.ts`). The DB allows 4. */
-const MAX_LIMIT_TIER = 3;
-
 export interface IdentityScope {
   /** Caller + siblings, lowercased and deduped. Always contains the caller. */
   wallets: string[];
@@ -33,7 +31,7 @@ export interface IdentityScope {
 function clampTier(tier: unknown): number {
   const n = Number(tier ?? 0);
   if (!Number.isFinite(n)) return 0;
-  return Math.min(Math.max(Math.trunc(n), 0), MAX_LIMIT_TIER);
+  return Math.min(Math.max(Math.trunc(n), 0), MAX_KYC_TIER);
 }
 
 type SiblingRow = { wallet_address: string | null; tier: number | null };

--- a/app/lib/kyc-identity.ts
+++ b/app/lib/kyc-identity.ts
@@ -1,0 +1,136 @@
+import { supabaseAdmin } from "@/app/lib/supabase";
+
+/**
+ * Identity-scoped KYC limits.
+ *
+ * A monthly spend limit belongs to the verified *identity* (phone number and/or ID
+ * document), not to a single wallet. One person may legitimately hold several
+ * wallets — a Privy embedded wallet plus extension wallets connected through
+ * injected/bridge mode — and each must not get its own fresh allowance.
+ *
+ * Every wallet sharing an identity draws from one pool and is capped at the highest
+ * tier any of them reached, so the group's total monthly spend equals the cap of the
+ * identity's best tier no matter how many wallets it spans. This is what makes it
+ * safe to exempt injected wallets from the phone/ID uniqueness constraints (see
+ * `app/lib/injected-identity.ts`) — uniqueness is no longer what bounds spend.
+ */
+
+/** Highest tier the limit table defines (`app/lib/kyc-tier-limits.ts`). The DB allows 4. */
+const MAX_LIMIT_TIER = 3;
+
+export interface IdentityScope {
+  /** Caller + siblings, lowercased and deduped. Always contains the caller. */
+  wallets: string[];
+  /** MAX(tier) across the group — the identity carries the tier, not the wallet. */
+  effectiveTier: number;
+  /**
+   * Sorted advisory-lock keys for the identity. Sorted so two transactions holding
+   * both a phone and an ID key can never take them in opposite orders and deadlock.
+   */
+  identityKeys: string[];
+}
+
+function clampTier(tier: unknown): number {
+  const n = Number(tier ?? 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(Math.max(Math.trunc(n), 0), MAX_LIMIT_TIER);
+}
+
+type SiblingRow = { wallet_address: string | null; tier: number | null };
+
+/**
+ * Resolves the spend pool a wallet belongs to.
+ *
+ * Sibling matching is direct, not transitive: profiles sharing the caller's verified
+ * phone number, or its (country, type, number) ID triple. A wallet with neither
+ * scopes to itself — tier 0's cap is $0, so there is nothing to farm there.
+ *
+ * Throws on any Supabase error. Callers must not fall back to a per-wallet scope:
+ * silently narrowing the pool would let siblings' spend go uncounted and bypass the
+ * limit entirely.
+ */
+export async function resolveIdentityScope(
+  walletAddress: string,
+): Promise<IdentityScope> {
+  const caller = walletAddress.trim().toLowerCase();
+
+  const { data: profile, error: profileError } = await supabaseAdmin
+    .from("user_kyc_profiles")
+    .select("tier, phone_number, id_country, id_type, id_number")
+    .eq("wallet_address", caller)
+    .maybeSingle();
+
+  if (profileError) {
+    throw profileError;
+  }
+
+  const ownTier = clampTier(profile?.tier);
+
+  const phone = profile?.phone_number || null;
+  const hasId = !!(profile?.id_country && profile?.id_type && profile?.id_number);
+
+  if (!profile || (!phone && !hasId)) {
+    return {
+      wallets: [caller],
+      effectiveTier: ownTier,
+      identityKeys: [`wallet:${caller}`],
+    };
+  }
+
+  const identityKeys: string[] = [];
+  const siblingQueries: PromiseLike<{
+    data: SiblingRow[] | null;
+    error: { message?: string } | null;
+  }>[] = [];
+
+  if (phone) {
+    identityKeys.push(`phone:${phone}`);
+    // phone_number only ever holds an OTP-confirmed number (unverified ones stage in
+    // pending_phone_number), so tier >= 1 is implied — asserted here for clarity.
+    siblingQueries.push(
+      supabaseAdmin
+        .from("user_kyc_profiles")
+        .select("wallet_address, tier")
+        .eq("phone_number", phone)
+        .gte("tier", 1),
+    );
+  }
+
+  if (hasId) {
+    identityKeys.push(
+      `id:${profile.id_country}:${profile.id_type}:${profile.id_number}`,
+    );
+    siblingQueries.push(
+      supabaseAdmin
+        .from("user_kyc_profiles")
+        .select("wallet_address, tier")
+        .eq("id_country", profile.id_country)
+        .eq("id_type", profile.id_type)
+        .eq("id_number", profile.id_number)
+        .gte("tier", 2),
+    );
+  }
+
+  const results = await Promise.all(siblingQueries);
+
+  const wallets = new Set<string>([caller]);
+  let effectiveTier = ownTier;
+
+  for (const { data, error } of results) {
+    if (error) {
+      throw error;
+    }
+    for (const row of data ?? []) {
+      const address = row.wallet_address?.trim().toLowerCase();
+      if (!address) continue;
+      wallets.add(address);
+      effectiveTier = Math.max(effectiveTier, clampTier(row.tier));
+    }
+  }
+
+  return {
+    wallets: [...wallets].sort(),
+    effectiveTier,
+    identityKeys: identityKeys.sort(),
+  };
+}

--- a/app/lib/kyc-limit-copy.ts
+++ b/app/lib/kyc-limit-copy.ts
@@ -1,0 +1,37 @@
+/**
+ * Copy for the monthly spend limit.
+ *
+ * The limit belongs to a verified identity, so several wallets can draw from one
+ * allowance (see `app/lib/kyc-identity.ts`). Someone with more than one wallet would
+ * otherwise see spend their current wallet never made, so the pooled wording names the
+ * wallet count wherever a limit or a block is shown.
+ *
+ * Every helper here returns the pre-pooling string verbatim when the identity spans a
+ * single wallet: the majority of users are unaffected by pooling and must see no change.
+ */
+
+/** True when this identity's allowance is shared across more than one wallet. */
+export function isPooledAllowance(pooledWalletCount: number | undefined): boolean {
+  return (pooledWalletCount ?? 1) > 1;
+}
+
+/** e.g. "shared across your 3 wallets". Empty string when not pooled. */
+export function sharedAllowanceNote(pooledWalletCount: number | undefined): string {
+  return isPooledAllowance(pooledWalletCount)
+    ? `shared across your ${pooledWalletCount} wallets`
+    : "";
+}
+
+/**
+ * Error shown when a swap is refused for exceeding the monthly limit. Callers pass the
+ * resolved limit and the number of wallets sharing it.
+ */
+export function monthlyLimitReachedMessage(
+  monthlyLimit: number,
+  pooledWalletCount: number | undefined,
+): string {
+  const amount = `$${monthlyLimit.toLocaleString()}`;
+  return isPooledAllowance(pooledWalletCount)
+    ? `Monthly transaction limit of ${amount} reached across your ${pooledWalletCount} linked wallets. Upgrade your verification tier to continue.`
+    : `Monthly transaction limit of ${amount} reached. Upgrade your verification tier to continue.`;
+}

--- a/app/lib/kyc-tier-limits.ts
+++ b/app/lib/kyc-tier-limits.ts
@@ -13,6 +13,14 @@ const DEFAULT_KYC_MONTHLY_LIMITS: Record<number, number> = {
   3: 2,
 };
 
+/**
+ * Highest tier this table defines. Derived from the table rather than written out, so
+ * callers that clamp a tier (the DB allows 4) cannot drift from it when a tier is added.
+ */
+export const MAX_KYC_TIER = Math.max(
+  ...Object.keys(DEFAULT_KYC_MONTHLY_LIMITS).map(Number),
+);
+
 /** Resolved limit for a tier. When `unlimited` is true, `monthly` is 0 and must be ignored. */
 export interface KycTierLimit {
   monthly: number;

--- a/app/lib/swap-transaction-limit-server.ts
+++ b/app/lib/swap-transaction-limit-server.ts
@@ -86,9 +86,9 @@ export async function assertTransactionWalletAuthorized(
 }
 
 export type SwapLimitCheckResult =
-  | { kind: "success"; id?: string; monthlyLimit: number }
+  | { kind: "success"; id?: string; monthlyLimit: number; pooledWalletCount: number }
   | { kind: "rate_unavailable" }
-  | { kind: "limit_exceeded"; monthlyLimit: number }
+  | { kind: "limit_exceeded"; monthlyLimit: number; pooledWalletCount: number }
   | { kind: "kyc_required" }
   | { kind: "kyc_db_error" }
   | { kind: "rpc_failed"; error: unknown }
@@ -131,6 +131,8 @@ export async function executeSwapTransactionLimitCheck(
   // Sent to the RPC and echoed back in success/limit_exceeded results.
   // null signals "no cap" to the RPC; 0 is only reachable for capped tiers above.
   const monthlyLimit = tierLimit.unlimited ? 0 : tierLimit.monthly;
+  // Echoed back so the blocked-swap copy can name the wallets sharing the allowance.
+  const pooledWalletCount = scope.wallets.length;
 
   let cngnToUsdRate = 0;
   try {
@@ -190,12 +192,12 @@ export async function executeSwapTransactionLimitCheck(
   }
 
   if (rpcData.error === "limit_exceeded") {
-    return { kind: "limit_exceeded", monthlyLimit };
+    return { kind: "limit_exceeded", monthlyLimit, pooledWalletCount };
   }
 
   if (options.dryRun) {
     if (rpcData.ok === true) {
-      return { kind: "success", monthlyLimit };
+      return { kind: "success", monthlyLimit, pooledWalletCount };
     }
     return { kind: "unexpected_rpc" };
   }
@@ -204,5 +206,5 @@ export async function executeSwapTransactionLimitCheck(
     return { kind: "unexpected_rpc" };
   }
 
-  return { kind: "success", id: rpcData.id, monthlyLimit };
+  return { kind: "success", id: rpcData.id, monthlyLimit, pooledWalletCount };
 }

--- a/app/lib/swap-transaction-limit-server.ts
+++ b/app/lib/swap-transaction-limit-server.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
 import { getKycTierLimit } from "@/app/lib/kyc-tier-limits";
+import { resolveIdentityScope } from "@/app/lib/kyc-identity";
 import { collectLinkedEvmAddressesForPrivyUserId } from "@/app/lib/privy";
 
 export type SwapLimitRpcBody = {
@@ -108,18 +109,18 @@ export async function executeSwapTransactionLimitCheck(
 ): Promise<SwapLimitCheckResult> {
   const kycWalletAddress = normalizedBodyWalletAddress;
 
-  const { data: kycProfile, error: kycError } = await supabaseAdmin
-    .from("user_kyc_profiles")
-    .select("tier")
-    .eq("wallet_address", kycWalletAddress)
-    .maybeSingle();
-
-  if (kycError) {
+  // The limit belongs to the verified identity, not this wallet: every wallet sharing
+  // the caller's phone/ID draws from one pool and inherits the group's best tier.
+  // Never fall back to a per-wallet scope on failure — a narrower pool would leave
+  // siblings' spend uncounted and the cap bypassable.
+  let scope;
+  try {
+    scope = await resolveIdentityScope(kycWalletAddress);
+  } catch {
     return { kind: "kyc_db_error" };
   }
 
-  const tier = Math.min(Math.max(Number(kycProfile?.tier ?? 0), 0), 3);
-  const tierLimit = getKycTierLimit(tier);
+  const tierLimit = getKycTierLimit(scope.effectiveTier);
 
   // A capped limit of 0 means "no swaps until phone" (tier 0). An unlimited tier
   // must never hit this branch.
@@ -169,6 +170,8 @@ export async function executeSwapTransactionLimitCheck(
       p_email: options.normalizedEmail,
       p_explorer_link: options.explorerLink || null,
       p_dry_run: options.dryRun,
+      p_scope_wallets: scope.wallets,
+      p_identity_keys: scope.identityKeys,
     },
   );
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 import { verifyInjectedSessionJwt } from "./app/lib/injectedSessionAuth";
+import { INJECTED_USER_ID_PREFIX } from "./app/lib/injected-identity";
 
 // Inline lightweight edge-compatible helpers to avoid pulling in heavy SDKs
 
@@ -203,7 +204,8 @@ async function authorizationMiddleware(req: NextRequest) {
         { status: 401 },
       );
     }
-    privyUserId = `injected-${walletAddress}`;
+    // API routes detect injected sessions by this prefix (see isInjectedUserId).
+    privyUserId = `${INJECTED_USER_ID_PREFIX}${walletAddress}`;
   } else if (token) {
     // Privy JWT mode: verify and resolve wallet
     try {

--- a/supabase/migrations/20260726120000_identity_scoped_monthly_limit.sql
+++ b/supabase/migrations/20260726120000_identity_scoped_monthly_limit.sql
@@ -1,0 +1,211 @@
+-- Identity-scoped monthly limits.
+--
+-- The monthly spend cap previously belonged to a single wallet: spend was summed over
+-- `wallet_address = p_wallet_address` and the advisory lock was taken on that address.
+-- One person holding several wallets therefore got a full, independent allowance for
+-- each — and the phone/ID uniqueness indexes were the only thing keeping that from
+-- being farmed at will.
+--
+-- The pool now belongs to the verified *identity* (phone number and/or ID document).
+-- Callers pass the set of wallets sharing that identity (`p_scope_wallets`, resolved by
+-- `app/lib/kyc-identity.ts`) and the identity's lock keys (`p_identity_keys`); spend is
+-- aggregated across the whole set. Wallet count stops affecting total spend, which is
+-- what makes exempting injected wallets from the uniqueness indexes safe.
+--
+-- Both new parameters default to the previous per-wallet behavior, so any caller that
+-- has not been updated keeps working unchanged.
+
+-- The parameter list grows, so the old signature must be dropped rather than replaced:
+-- CREATE OR REPLACE with extra defaulted parameters registers a second overload, and
+-- an 18-argument call would then match both and fail as "function is not unique".
+DROP FUNCTION IF EXISTS public.insert_swap_transaction_if_within_limit(
+  TEXT, NUMERIC, NUMERIC, TEXT, TEXT, TEXT, NUMERIC, NUMERIC, NUMERIC, JSONB,
+  TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, BOOLEAN
+);
+
+CREATE FUNCTION public.insert_swap_transaction_if_within_limit(
+  p_wallet_address   TEXT,
+  p_monthly_limit    NUMERIC,
+  p_cngn_to_usd_rate NUMERIC,
+  p_transaction_type TEXT,
+  p_from_currency    TEXT,
+  p_to_currency      TEXT,
+  p_amount_sent      NUMERIC,
+  p_amount_received  NUMERIC,
+  p_fee              NUMERIC,
+  p_recipient        JSONB,
+  p_status           TEXT,
+  p_network          TEXT DEFAULT NULL,
+  p_time_spent       TEXT DEFAULT NULL,
+  p_tx_hash          TEXT DEFAULT NULL,
+  p_order_id         TEXT DEFAULT NULL,
+  p_email            TEXT DEFAULT NULL,
+  p_explorer_link    TEXT DEFAULT NULL,
+  p_dry_run          BOOLEAN DEFAULT FALSE,
+  -- Wallets sharing the caller's verified identity. NULL → just the caller.
+  p_scope_wallets    TEXT[] DEFAULT NULL,
+  -- Advisory-lock keys for that identity. NULL → the caller's own wallet key.
+  p_identity_keys    TEXT[] DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_monthly_spent       NUMERIC := 0;
+  v_offramp_spent       NUMERIC := 0;
+  v_onramp_spent        NUMERIC := 0;
+  v_this_tx_usd         NUMERIC;
+  v_new_id              UUID;
+  v_month_start         TIMESTAMPTZ;
+  v_has_cngn_history    BOOLEAN;
+  v_needs_fiat_rate     BOOLEAN;
+  v_stable_to           TEXT[] := ARRAY['USDC', 'USDT', 'CUSD'];
+  -- Statuses that consume the monthly limit: anything in-flight or settled.
+  -- 'fulfilling' is legacy-only (the app maps the aggregator's "fulfilling"
+  -- to 'pending') but is kept in case old rows carry it.
+  v_spend_statuses      TEXT[] := ARRAY['pending', 'fulfilling', 'fulfilled', 'completed'];
+  v_scope_wallets       TEXT[];
+  v_sorted_keys         TEXT[];
+  v_key                 TEXT;
+BEGIN
+  PERFORM set_config('search_path', 'public', true);
+
+  -- Always include the caller, and dedupe: a caller that passes a stale or partial
+  -- scope must never end up with a *narrower* pool than its own wallet.
+  SELECT COALESCE(array_agg(DISTINCT w), ARRAY[p_wallet_address])
+    INTO v_scope_wallets
+    FROM unnest(
+           COALESCE(p_scope_wallets, ARRAY[]::TEXT[]) || ARRAY[p_wallet_address]
+         ) AS w;
+
+  SELECT COALESCE(array_agg(DISTINCT k ORDER BY k), ARRAY['wallet:' || p_wallet_address])
+    INTO v_sorted_keys
+    FROM unnest(COALESCE(p_identity_keys, ARRAY[]::TEXT[])) AS k;
+
+  -- Lock the identity, not the wallet: sibling wallets sharing a pool must serialize
+  -- against each other, or two concurrent swaps that individually fit will both pass
+  -- the check and together exceed the cap. Keys are taken in sorted order so a
+  -- transaction holding the phone key and one holding the ID key cannot deadlock.
+  FOREACH v_key IN ARRAY v_sorted_keys LOOP
+    PERFORM pg_advisory_xact_lock(hashtext(v_key));
+  END LOOP;
+
+  -- Capped tiers run the full rate + spend + limit check. An unlimited tier
+  -- (p_monthly_limit IS NULL) skips straight to the insert/dry-run tail.
+  IF p_monthly_limit IS NOT NULL THEN
+    v_month_start := date_trunc('month', now() AT TIME ZONE 'UTC');
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM transactions
+      WHERE wallet_address   = ANY (v_scope_wallets)
+        AND transaction_type = 'offramp'
+        AND status           = ANY (v_spend_statuses)
+        AND upper(coalesce(from_currency, '')) = 'CNGN'
+        AND created_at       >= v_month_start
+    ) INTO v_has_cngn_history;
+
+    v_needs_fiat_rate := (
+      v_has_cngn_history
+      OR upper(coalesce(p_from_currency, '')) = 'CNGN'
+      OR upper(coalesce(p_to_currency, '')) = 'CNGN'
+      OR EXISTS (
+        SELECT 1
+        FROM transactions
+        WHERE wallet_address   = ANY (v_scope_wallets)
+          AND transaction_type = 'onramp'
+          AND status           = ANY (v_spend_statuses)
+          AND created_at       >= v_month_start
+          AND upper(coalesce(to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      )
+      OR (
+        p_transaction_type = 'onramp'
+        AND upper(coalesce(p_to_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      )
+    );
+
+    IF v_needs_fiat_rate AND (p_cngn_to_usd_rate IS NULL OR p_cngn_to_usd_rate <= 0) THEN
+      RETURN jsonb_build_object('error', 'rate_unavailable');
+    END IF;
+
+    SELECT COALESCE(SUM(
+      CASE
+        WHEN upper(coalesce(from_currency, '')) = 'CNGN' THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+        ELSE amount_sent::NUMERIC
+      END
+    ), 0)
+    INTO v_offramp_spent
+    FROM transactions
+    WHERE wallet_address   = ANY (v_scope_wallets)
+      AND transaction_type = 'offramp'
+      AND status           = ANY (v_spend_statuses)
+      AND upper(coalesce(from_currency, '')) IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+      AND created_at       >= v_month_start;
+
+    SELECT COALESCE(SUM(
+      CASE
+        WHEN upper(coalesce(to_currency, '')) = ANY (v_stable_to) THEN amount_received::NUMERIC
+        WHEN upper(coalesce(to_currency, '')) = 'CNGN' THEN amount_received::NUMERIC / p_cngn_to_usd_rate
+        WHEN upper(coalesce(from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN')
+          THEN amount_sent::NUMERIC / p_cngn_to_usd_rate
+        ELSE amount_received::NUMERIC
+      END
+    ), 0)
+    INTO v_onramp_spent
+    FROM transactions
+    WHERE wallet_address   = ANY (v_scope_wallets)
+      AND transaction_type = 'onramp'
+      AND status           = ANY (v_spend_statuses)
+      AND created_at       >= v_month_start;
+
+    v_monthly_spent := v_offramp_spent + v_onramp_spent;
+
+    IF p_transaction_type = 'onramp' THEN
+      IF upper(coalesce(p_to_currency, '')) = ANY (v_stable_to) THEN
+        v_this_tx_usd := p_amount_received;
+      ELSIF upper(coalesce(p_to_currency, '')) = 'CNGN' THEN
+        v_this_tx_usd := p_amount_received / p_cngn_to_usd_rate;
+      ELSIF upper(coalesce(p_from_currency, '')) NOT IN ('USDC', 'USDT', 'CUSD', 'CNGN') THEN
+        v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+      ELSE
+        v_this_tx_usd := p_amount_received;
+      END IF;
+    ELSIF upper(coalesce(p_from_currency, '')) = 'CNGN' THEN
+      v_this_tx_usd := p_amount_sent / p_cngn_to_usd_rate;
+    ELSE
+      v_this_tx_usd := p_amount_sent;
+    END IF;
+
+    IF v_monthly_spent + v_this_tx_usd > p_monthly_limit THEN
+      -- monthly_spent now covers the whole identity group, not just this wallet.
+      RETURN jsonb_build_object(
+        'error',         'limit_exceeded',
+        'monthly_spent', v_monthly_spent,
+        'this_tx_usd',   v_this_tx_usd,
+        'monthly_limit', p_monthly_limit
+      );
+    END IF;
+  END IF;
+
+  IF COALESCE(p_dry_run, FALSE) THEN
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  -- Only aggregation and locking widen; the row is still written for the caller.
+  INSERT INTO transactions (
+    wallet_address, transaction_type, from_currency, to_currency,
+    amount_sent, amount_received, fee, recipient, status, network,
+    time_spent, tx_hash, order_id, email, explorer_link
+  ) VALUES (
+    p_wallet_address, p_transaction_type, p_from_currency, p_to_currency,
+    p_amount_sent, p_amount_received, p_fee, p_recipient, p_status, p_network,
+    p_time_spent, p_tx_hash, p_order_id, p_email, p_explorer_link
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object('id', v_new_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.insert_swap_transaction_if_within_limit TO service_role;

--- a/supabase/migrations/20260726120100_injected_identity_uniqueness_exemption.sql
+++ b/supabase/migrations/20260726120100_injected_identity_uniqueness_exemption.sql
@@ -1,0 +1,44 @@
+-- Exempt injected-wallet profiles from verified-identity uniqueness.
+--
+-- The uniqueness indexes added in 20260611120000 assume one wallet per person. That
+-- holds for Privy embedded wallets but not for injected/bridge mode, where the user
+-- brings their own external wallet: the same person legitimately arrives on several
+-- addresses (an extension wallet on the main app, the host page's wallet on a partner
+-- site) and every address after the first was hard-blocked at phone verification.
+--
+-- Uniqueness existed to stop one identity backing several wallets for several monthly
+-- limits. 20260726120000 removed that motive by pooling spend per identity rather than
+-- per wallet, so injected rows can safely leave the uniqueness set: no matter how many
+-- wallets an identity spans, the group shares one allowance.
+--
+-- Injected rows are exempt in *both* directions — they neither collide with each other
+-- nor block a Privy account from claiming the same number. Uniqueness continues to hold
+-- among non-injected profiles exactly as before.
+
+ALTER TABLE public.user_kyc_profiles
+    ADD COLUMN IF NOT EXISTS is_injected_wallet boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.user_kyc_profiles.is_injected_wallet IS
+  'Profile was created/updated from an injected-wallet (SIWE) session. Exempt from the '
+  'verified phone/ID uniqueness indexes. Set once and never cleared: downgrading would '
+  'pull the row back into the indexes and could fail an otherwise valid write with 23505.';
+
+-- Backfill from the `injected-<address>` subject middleware already persists to user_id.
+UPDATE public.user_kyc_profiles
+   SET is_injected_wallet = true
+ WHERE user_id LIKE 'injected-%'
+   AND is_injected_wallet = false;
+
+-- No duplicate-guard block is needed here (unlike 20260611120000): each new predicate
+-- covers a strict subset of the rows the old one did, so recreation cannot fail on data
+-- that already satisfied the stricter version.
+
+DROP INDEX IF EXISTS uniq_user_kyc_profiles_verified_phone;
+CREATE UNIQUE INDEX uniq_user_kyc_profiles_verified_phone
+    ON public.user_kyc_profiles (phone_number)
+ WHERE phone_number IS NOT NULL AND tier >= 1 AND NOT is_injected_wallet;
+
+DROP INDEX IF EXISTS uniq_user_kyc_profiles_verified_id;
+CREATE UNIQUE INDEX uniq_user_kyc_profiles_verified_id
+    ON public.user_kyc_profiles (id_country, id_type, id_number)
+ WHERE id_number IS NOT NULL AND tier >= 2 AND NOT is_injected_wallet;


### PR DESCRIPTION
### Description

Injected/bridge wallets were hard-blocked at phone verification. The verified phone/ID uniqueness indexes assume one wallet per person — true for Privy embedded wallets, but not for injected mode, where the user brings their own external wallet and legitimately arrives on several addresses. Every address after the first got *"This phone number is already verified on another account."*

Uniqueness could not simply be dropped. The monthly limit was enforced **per wallet**, so uniqueness was the only thing stopping one person from minting wallets for a fresh allowance each. Both halves therefore ship together.

**1 — The spend pool moves from the wallet to the verified identity.**

- `resolveIdentityScope()` gathers the wallets sharing a caller's verified phone or ID document, and the group's highest tier. **The identity carries the tier**, so verifying an ID once lifts every wallet that person holds. It fails closed — a Supabase error throws rather than narrowing the pool, since a narrower pool would leave siblings' spend uncounted and the cap bypassable.
- `insert_swap_transaction_if_within_limit` aggregates spend across that set and takes advisory locks on the **identity keys rather than the wallet**. Locking the wallet let two sibling wallets pass the check concurrently and both commit. Keys are taken in sorted order so phone/ID locks cannot deadlock.
- The parameter list grows, so the old 18-argument signature is **dropped rather than replaced** — `CREATE OR REPLACE` would register a second overload and make existing calls ambiguous. Both new parameters default to the previous per-wallet behavior.
- `transaction-summary` and `kyc/status` report the same scope and tier, so the UI cannot show headroom that enforcement will not grant.

**2 — With spend bounded per identity, the exemption is safe.**

Wallet count no longer affects total spend, so injected profiles can leave the uniqueness set. `is_injected_wallet` is set from the `injected-` subject middleware mints, is **sticky** (clearing it would pull a row back into the index and could fail a valid write with `23505`), and narrows both partial unique indexes. Uniqueness still holds among non-injected profiles, and the `23505` handlers stay for non-injected races. The server cannot distinguish `?injected=true` from `?injected=bridge` — both mint the same SIWE token — so the exemption necessarily covers both.

**3 — Shared-allowance copy and a SmileID callback fix.**

- Pooling means someone with several wallets sees spend their current wallet never made, so `/api/kyc/status` returns `pooledWalletCount` and the limit surfaces name the shared allowance. **At one wallet every string is byte-identical to before** — pooling is invisible to the unaffected majority.
- The SmileID callback promoted `tier` to 2 without writing `id_number`, which still pulls the row into `uniq_user_kyc_profiles_verified_id` because that index covers `tier >= 2`. The `23505` became a 500, so SmileID retried a request that could never succeed. It now returns 200 `duplicate_id_conflict` and skips the promotion. The other 500s are untouched — those retries are legitimate.

**Breaking changes / impacts.** Pooling tightens limits for existing multi-wallet Privy users: someone running two wallets off one phone gets one shared pool where they have two today. This is intended (confirmed on #639); user notification is in-app only.

**Alternatives considered.** Per-wallet tiers with a shared pool were rejected in favour of the identity carrying the tier — the former freezes a lower-tier sibling once the shared counter passes its own cap, which reads as broken. Transitive sibling resolution was rejected because it would pool unrelated people who share a phone number; see the review reply for the full reasoning.

### References

- Closes #639
- Related: #496 (tiered-KYC API surfaces), #524 (phone/ID uniqueness enforcement), #539 (swap monthly-limit RPC)

### Testing

Reviewers can exercise this locally with `pnpm dev`:

1. **Injected path** — open `/?injected=true` with an extension wallet, sign the SIWE challenge, and verify a phone number already verified on a different Privy account. Expect success, not a 409. Repeat on a second injected address.
2. **Privy regression** — with two Privy accounts, verify the same number twice. The second must still get 409. A number held only by an injected row must now succeed.
3. **Pooled limits** — with two wallets on one phone, spend on the first and confirm the second shows reduced headroom rather than a fresh allowance, and that the profile page, limit modal, and blocked-swap toast all name the wallet count. On a single-wallet account, confirm all three surfaces render exactly as on `main`.

Automated: `pnpm test` (235 passing), `pnpm exec tsc --noEmit`, `pnpm lint`. New unit tests cover `resolveIdentityScope` (sibling resolution, effective tier, fail-closed errors), `isInjectedUserId`, and the copy helper — the last asserting the single-wallet strings byte-for-byte.

**Also verified against a real PostgreSQL 16 instance**, since the concurrency and index behavior cannot be covered by Jest:

| Check | Result |
| --- | --- |
| Both migrations apply to a schema with existing data | clean |
| Three wallets share one verified phone | accepted |
| A fourth **non-injected** wallet on that number | still `23505` |
| $3,000 on A, $1,500 on B, then $800 on C | third rejected, sees group spend $4,500 |
| Group total across all three wallets | **exactly $5,000**, not 3× |
| Two concurrent sibling swaps that individually fit | **one** commits |
| …same test with a wallet-keyed lock (control) | **both** commit, overshoots by $1,000 |
| Legacy RPC call without the new params | per-wallet behavior preserved |
| Tier promotion sharing a document with a tier-2 row | `23505` reproduced, pre-check catches it |
| Same promotion on an injected row | proceeds normally |

Environment: Node 22 / pnpm 10.27 / Next 15, PostgreSQL 16.13.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

> The one outstanding CodeRabbit pre-merge warning is Docstring Coverage (40% vs an 80% threshold). The new modules each carry module-level and per-export JSDoc; the shortfall is internal helpers, left unpadded deliberately.

### Reviewer notes

- **Address casing is the sharp edge.** This is the first code to read `wallet_address` out of `user_kyc_profiles` and query `transactions` with it. A mismatch would silently under-count siblings and leave the cap bypassable *with a green test suite*. It holds by construction (`middleware.ts` lowercases on both auth paths), and the resolver lowercases defensively regardless.
- Sibling matching is direct, not transitive — the known ceiling and the reasoning are on #639 and in the review reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VKBXsrAopBC6BctkhrhuJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KYC status and transaction limits now use a pooled identity scope across linked wallets.
  * API responses and UI messaging show when monthly spending limits are shared.
  * Injected/bridge wallets can reuse verified phone/ID without triggering ownership conflicts.

* **Bug Fixes**
  * Injected/bridge wallets are exempt from verified-phone/verified-ID uniqueness checks.
  * Identity-scope resolution failures now return clearer server errors.

* **Tests**
  * Added Jest coverage for injected identity detection, pooled identity scope behavior, and shared-limit copy.

* **Database / Maintenance**
  * Added injected-wallet exemption storage and updated swap-limit enforcement to use identity scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->