### PR TITLE
fix(embed): use injected SIWE auth on payment details; gate migrations in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@
 - [ ] I have added documentation and tests for new/changed functionality in this PR
 - [ ] All active GitHub checks for tests, formatting, and security are passing
 - [ ] The correct base branch is being used, if not `main`
+- [ ] If this PR adds a database migration, the application code in it still works against the **pre-migration** schema — migrations are applied around the deploy, not before it, so code that requires new schema in the same release will break until they converge
 
 
 By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@
 - [ ] I have added documentation and tests for new/changed functionality in this PR
 - [ ] All active GitHub checks for tests, formatting, and security are passing
 - [ ] The correct base branch is being used, if not `main`
-- [ ] If this PR adds a database migration, the application code in it still works against the **pre-migration** schema — migrations are applied around the deploy, not before it, so code that requires new schema in the same release will break until they converge
+- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it
 
 
 By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,50 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm run build
+
+  # Applies pending Supabase migrations after a merge to main.
+  #
+  # Migrations were previously applied by hand, so application code could reach
+  # production before the schema it depends on — a merged change that selected a
+  # not-yet-created column took KYC and swaps down until someone noticed.
+  #
+  # Caveat worth knowing: deploys come from the hosting platform's Git integration,
+  # which starts on the same push that triggers this workflow. This job therefore runs
+  # alongside the deploy rather than before it — it removes the "nobody remembered"
+  # failure mode, not the race. Ordering them properly means either deploying from
+  # Actions gated on `needs: migrate`, or suppressing auto-deploy and firing a deploy
+  # hook from here. Until then the real safeguard is the expand/contract rule in
+  # .github/pull_request_template.md: a migration must be deployable before the code
+  # that needs it.
+  migrate:
+    # Never from a pull request — only a merge to main touches the database.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Do not migrate for a commit that does not build.
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      # Two pushes must not apply migrations to one database concurrently, and a
+      # queued run must not be cancelled midway through applying.
+      group: migrate-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # Direct Postgres connection string. The SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+      # secrets above are PostgREST credentials and cannot apply migrations.
+      # Re-runs are a no-op: db push skips migrations already in supabase_migrations.
+      - name: Apply migrations
+        run: supabase db push --db-url "${{ secrets.SUPABASE_DB_URL }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,15 @@ jobs:
 
       # Direct Postgres connection string. The SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
       # secrets above are PostgREST credentials and cannot apply migrations.
-      # Re-runs are a no-op: db push skips migrations already in supabase_migrations.
+      #
+      # Re-runs are a no-op *provided the ledger is accurate*: db push skips versions
+      # recorded in supabase_migrations.schema_migrations, which only the CLI writes.
+      # Migrations were historically applied by hand, so this needs a one-time baseline
+      # before the first run — record each already-applied version with
+      # `supabase migration repair --status applied <version> --db-url ...`, then
+      # confirm a manual `supabase db push` reports the database up to date. Without
+      # that, this job re-applies history and fails on the first duplicate object.
+      # Note: files without a `<timestamp>_` prefix are ignored by the CLI entirely
+      # and remain hand-managed.
       - name: Apply migrations
         run: supabase db push --db-url "${{ secrets.SUPABASE_DB_URL }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Pinned so migration parsing/validation does not change under us between
+      # releases; keep in step with the `supabase` devDependency in package.json
+      # and upgrade deliberately.
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.98.2
 
       # Direct Postgres connection string. The SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
       # secrets above are PostgREST credentials and cannot apply migrations.

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import { ImSpinner } from "react-icons/im";
 import { PiCheck } from "react-icons/pi";
 import { toast } from "sonner";
-import { usePrivy } from "@privy-io/react-auth";
+import { useApiAuth } from "../../hooks/useApiAuth";
 import { CopyAddressWarningModal } from "../CopyAddressWarningModal";
 import type {
   OnrampPaymentInstructions,
@@ -962,7 +962,7 @@ function OnrampPendingPaymentInstructions({
   clientSessionExpired: boolean;
   clientTimeRemainingLabel: string;
 }) {
-  const { getAccessToken } = usePrivy();
+  const { resolveAuth } = useApiAuth();
   const [instructions, setInstructions] = useState<OnrampPaymentInstructions | null>(
     null,
   );
@@ -984,11 +984,19 @@ function OnrampPendingPaymentInstructions({
 
     void (async () => {
       try {
-        const token = await getAccessToken();
-        if (!token) throw new Error("Sign in to load payment details");
+        // Injected/bridge wallets authenticate with a SIWE session token rather than a
+        // Privy one, so reading Privy alone reports a signed-in user as signed out.
+        // interactive: false — this runs from a mount effect and must never raise a
+        // wallet signature prompt.
+        const { accessToken, injectedToken } = await resolveAuth({
+          interactive: false,
+        });
+        if (!accessToken && !injectedToken)
+          throw new Error("Sign in to load payment details");
         const res = await fetchV2SenderPaymentOrderById(
           transaction.order_id!,
-          token,
+          accessToken,
+          injectedToken,
         );
         const data =
           unwrapV2SenderOrderEnvelope(res) ??
@@ -1030,7 +1038,7 @@ function OnrampPendingPaymentInstructions({
     transaction.status,
     transaction.from_currency,
     transaction.amount_sent,
-    getAccessToken,
+    resolveAuth,
     clientSessionExpired,
   ]);
 

--- a/app/pages/MakePayment.tsx
+++ b/app/pages/MakePayment.tsx
@@ -102,6 +102,7 @@ export const MakePayment = ({
                 const { accessToken, injectedToken } = await resolveAuth({
                     interactive: false,
                 });
+                if (cancelled) return;
                 if (!accessToken && !injectedToken) {
                     setLoadError("Please sign in to load payment details.");
                     return;

--- a/app/pages/MakePayment.tsx
+++ b/app/pages/MakePayment.tsx
@@ -197,12 +197,17 @@ export const MakePayment = ({
                 const { accessToken, injectedToken } = await resolveAuth({
                     interactive: false,
                 });
+                if (cancelled) return;
                 if (!accessToken && !injectedToken) throw new Error("No access token");
                 const res = await fetchV2SenderPaymentOrderById(
                     orderId,
                     accessToken,
                     injectedToken,
                 );
+                // Re-check after every await: pollingIntervalRef is shared across
+                // effect runs, so a stale callback that reaches clearPolling() would
+                // silently kill the interval a newer effect installed.
+                if (cancelled) return;
                 const status =
                     resolveOnrampOrderStatusFromV2Response(res) ??
                     getOrderStatusFromFetchPayload(res);
@@ -214,7 +219,6 @@ export const MakePayment = ({
                     status.toLowerCase() !== "pending"
                 ) {
                     clearPolling();
-                    if (cancelled) return;
                     setTransactionStatus(
                         status as
                         | "fulfilling"

--- a/app/pages/MakePayment.tsx
+++ b/app/pages/MakePayment.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from "react";
 import { Copy01Icon } from "hugeicons-react";
 import { PiCheck } from "react-icons/pi";
 import { ImSpinner } from "react-icons/im";
-import { usePrivy } from "@privy-io/react-auth";
+import { useApiAuth } from "../hooks/useApiAuth";
 import {
     classNames,
     formatNumberWithCommas,
@@ -50,7 +50,7 @@ export const MakePayment = ({
         orderId,
         onrampPaymentAccount,
     } = stateProps;
-    const { getAccessToken } = usePrivy();
+    const { resolveAuth } = useApiAuth();
     const { setCurrentStep } = useStep();
     const { amountSent, currency } = formValues;
 
@@ -95,12 +95,22 @@ export const MakePayment = ({
             }
 
             try {
-                const accessToken = await getAccessToken();
-                if (!accessToken) {
+                // Injected/bridge wallets authenticate with a SIWE session token rather
+                // than a Privy one, so reading Privy alone reports a signed-in user as
+                // signed out. interactive: false — this runs on mount and must never
+                // raise a wallet signature prompt.
+                const { accessToken, injectedToken } = await resolveAuth({
+                    interactive: false,
+                });
+                if (!accessToken && !injectedToken) {
                     setLoadError("Please sign in to load payment details.");
                     return;
                 }
-                const res = await fetchV2SenderPaymentOrderById(orderId, accessToken);
+                const res = await fetchV2SenderPaymentOrderById(
+                    orderId,
+                    accessToken,
+                    injectedToken,
+                );
                 if (cancelled) return;
                 if (res.status !== "success" || !res.data?.providerAccount) {
                     throw new Error(res.message || "Could not load payment instructions");
@@ -125,7 +135,7 @@ export const MakePayment = ({
         return () => {
             cancelled = true;
         };
-    }, [orderId, onrampPaymentAccount, amountSent, currency, getAccessToken]);
+    }, [orderId, onrampPaymentAccount, amountSent, currency, resolveAuth]);
 
     // Countdown from client session deadline (not API expiresAt)
     useEffect(() => {
@@ -183,9 +193,15 @@ export const MakePayment = ({
         const checkPaymentStatus = async () => {
             if (cancelled) return;
             try {
-                const accessToken = await getAccessToken();
-                if (!accessToken) throw new Error("No access token");
-                const res = await fetchV2SenderPaymentOrderById(orderId, accessToken);
+                const { accessToken, injectedToken } = await resolveAuth({
+                    interactive: false,
+                });
+                if (!accessToken && !injectedToken) throw new Error("No access token");
+                const res = await fetchV2SenderPaymentOrderById(
+                    orderId,
+                    accessToken,
+                    injectedToken,
+                );
                 const status =
                     resolveOnrampOrderStatusFromV2Response(res) ??
                     getOrderStatusFromFetchPayload(res);
@@ -224,7 +240,7 @@ export const MakePayment = ({
             clearPolling();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps -- stable polling for one order load
-    }, [paymentDetails, orderId, getAccessToken, sessionExpired]);
+    }, [paymentDetails, orderId, resolveAuth, sessionExpired]);
 
     const currencySymbol = paymentDetails
         ? getCurrencySymbol(paymentDetails.currency)


### PR DESCRIPTION
### Description

Two fixes, both fallout from #640.

**1 — Payment details told an already-signed-in injected user to sign in.**

In injected/bridge mode the session is a SIWE token (`x-injected-token`), not a Privy one, so `usePrivy().getAccessToken()` returns `null` for a fully signed-in user. Three call sites read that `null` as "signed out":

| File | Symptom |
| --- | --- |
| `app/pages/MakePayment.tsx` (initial load) | *"Please sign in to load payment details."* |
| `app/pages/MakePayment.tsx` (status poller) | threw `"No access token"`, so the order status never advanced |
| `app/components/transaction/TransactionDetails.tsx` | *"Sign in to load payment details"* |

All three now resolve credentials through `useApiAuth().resolveAuth({ interactive: false })` — the canonical helper `TransactionList`, `TransactionsContext`, `WalletDetails` and `TransactionPreview` already use — and pass the injected token to `fetchV2SenderPaymentOrderById`, which has accepted one all along (`app/api/aggregator.ts`). This was purely a client wiring gap; no API changes.

`interactive: false` is load-bearing: both screens fetch from mount/polling effects, and the helper's contract is that background work must never raise a wallet signature prompt. Getting this wrong would trade a spurious sign-in message for a spurious signature popup.

Review hardening on the same screens: the initial-load effect and the status poller now re-check the effect's `cancelled` flag after every `await`, so a stale callback can neither set an error after cleanup nor clear the polling interval a newer effect installed (`pollingIntervalRef` is shared across effect runs).

**2 — CI now applies Supabase migrations on merge to `main`.**

#640 shipped code that selected `is_injected_wallet` before the column existed, because migrations were applied by hand and nothing ordered schema against code — phone verification and swap creation were down until the migrations were run manually. The new `migrate` job:

- runs only on push to `main` (never on PRs), gated on `needs: build`;
- holds a non-cancelling `migrate-production` concurrency group so two pushes cannot apply migrations to one database at once;
- pins the Supabase CLI to `2.98.2` (matching the `package.json` devDependency);
- uses `supabase db push --db-url`; once the ledger is baselined (below), re-runs are a no-op.

**Honest limits, stated in the workflow comments:** deploys come from the hosting platform's Git integration and start on the same push, so this job runs *alongside* the deploy, not before it — it removes the "nobody remembered" failure mode, not the race (tracked in #644). The rule that actually prevents a repeat is the new PR-template checklist item: bidirectional expand/contract — new code works against the pre-migration schema, deployed code against the post-migration schema, destructive changes deferred.

Also adds `pnpm test` to CI, which previously ran lint and build only — the green check on #640 executed zero tests.

> ⚠️ **Before merging — two required ops steps, in either order:**
>
> **1. Add the `SUPABASE_DB_URL` repo secret** (direct Postgres connection string). The existing `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` secrets are PostgREST credentials and cannot apply migrations.
>
> **2. Baseline the migration ledger (one-time).** `db push` skips only versions recorded in `supabase_migrations.schema_migrations`, which only the CLI writes — and this database has been migrated by hand. Without a baseline, the job's first run re-applies all of history and fails on the first unguarded `CREATE TABLE`. From a repo checkout:
>
> ```bash
> # Read-only diff of local files vs remote ledger — expect everything "local-only":
> supabase migration list --db-url "$SUPABASE_DB_URL"
>
> # Record every timestamped migration as applied (all are, through 20260726120100):
> for f in supabase/migrations/[0-9]*_*.sql; do
>   v=$(basename "$f" | cut -d_ -f1)
>   supabase migration repair --status applied "$v" --db-url "$SUPABASE_DB_URL"
> done
>
> # Verify: local and remote agree, and db push reports "Remote database is up to date":
> supabase migration list --db-url "$SUPABASE_DB_URL"
> supabase db push --db-url "$SUPABASE_DB_URL"
> ```
>
> Known gap: `add_credit_transaction_type.sql`, `add_referrals_referred_wallet_unique.sql` and `moralis_deposit_idempotency.sql` have no timestamp prefix, so the Supabase CLI ignores them — they stay hand-managed unless later renamed with timestamps (and immediately `migration repair`ed, since their content is already applied).

### References

- Fallout from #640 (identity-scoped limits / injected uniqueness exemption) and the post-merge incident where its migrations were unapplied
- #642 — follow-up audit of the remaining raw `getAccessToken()` call sites; deliberately not swept here because several similar-looking components are Privy-only by design
- #644 — ordering deploys against migrations (the race this job deliberately does not solve)

### Testing

Automated: `pnpm exec tsc --noEmit` clean, `pnpm test` (235 passing), lint clean on all changed files, workflow YAML parsed and job wiring (`if` guard, `needs`, concurrency) validated. Confirmed on this PR's own runs that `migrate` is skipped and `Test` executes in `build`.

Manual, for reviewers:

1. In `?injected=bridge`, start an onramp order and open the payment-details screen: account details must render instead of a sign-in prompt, and the status poll must advance the order without throwing.
2. Repeat the same flow as a Privy user — no regression.
3. Confirm no wallet signature prompt appears on either screen (that would mean `interactive: false` was missed).
4. After the ledger baseline (see warning above), `supabase db push --db-url` must report the database up to date without applying anything.

Environment: Node 22 / pnpm 10.27 / Next 15.

- [x] This change adds test coverage for new/changed/fixed functionality — the 235-test suite now actually runs in CI; no new unit tests, as the change is client wiring + workflow config

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract — no migrations in this PR (it adds the rule and the CI job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VKBXsrAopBC6BctkhrhuJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved on-ramp payment instruction loading and payment-status polling with a more reliable API auth flow.
  - Added safeguards to stop fetching when required auth tokens are unavailable.
- **Quality Improvements**
  - CI now runs tests before building.
  - Automatically applies production database migrations after successful merges to the main branch (with controlled concurrency).
- **Documentation**
  - Updated the pull request checklist to remind contributors about keeping migration code compatible with the pre-migration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->