### PR TITLE
feat(observability): integrate Datadog RUM on EU site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,18 @@ PRIVY_ISSUER=privy.io
 NEXT_PUBLIC_MIXPANEL_TOKEN=
 NEXT_PUBLIC_HOTJAR_SITE_ID=
 
+# Datadog Real User Monitoring (browser). EU site; consent-gated like Mixpanel.
+# Create an application at https://app.datadoghq.eu/rum/list
+NEXT_PUBLIC_DD_APPLICATION_ID=
+NEXT_PUBLIC_DD_CLIENT_TOKEN=
+NEXT_PUBLIC_DD_SITE=datadoghq.eu
+NEXT_PUBLIC_DD_SERVICE=noblocks
+NEXT_PUBLIC_DD_ENV=production
+NEXT_PUBLIC_DD_VERSION=
+NEXT_PUBLIC_DD_RUM_SAMPLE_RATE=100
+NEXT_PUBLIC_DD_SESSION_REPLAY_SAMPLE_RATE=0
+NEXT_PUBLIC_DD_ENABLE_IN_DEV=false
+
 # Server-side Analytics
 MIXPANEL_TOKEN=
 MIXPANEL_PRIVACY_MODE=strict

--- a/app/hooks/analytics/client.ts
+++ b/app/hooks/analytics/client.ts
@@ -1,5 +1,6 @@
 // Client-side analytics exports only
 // These are safe to use in client components and browser environments
 
+export * from "./useDatadogRum";
 export * from "./useHotjar";
 export * from "./useMixpanel";

--- a/app/hooks/analytics/useDatadogRum.ts
+++ b/app/hooks/analytics/useDatadogRum.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+import {
+  initDatadogRum,
+  isDatadogRumInitialized,
+  trackDatadogView,
+} from "@/app/lib/datadog.client";
+
+export const useDatadogRum = (enabled: boolean = true) => {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Disabled inside partner iframes (/widget) — same rule as Mixpanel.
+    if (!enabled) return;
+
+    const handleConsentChange = () => {
+      initDatadogRum();
+    };
+
+    window.addEventListener("cookieConsentChange", handleConsentChange);
+    window.addEventListener("cookieConsent", handleConsentChange);
+    handleConsentChange();
+
+    return () => {
+      window.removeEventListener("cookieConsentChange", handleConsentChange);
+      window.removeEventListener("cookieConsent", handleConsentChange);
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !pathname) return;
+    if (!isDatadogRumInitialized()) return;
+    trackDatadogView(pathname);
+  }, [enabled, pathname]);
+};

--- a/app/hooks/analytics/useDatadogRum.ts
+++ b/app/hooks/analytics/useDatadogRum.ts
@@ -1,26 +1,34 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
 import {
-  initDatadogRum,
-  isDatadogRumInitialized,
+  syncDatadogRumConsent,
   trackDatadogView,
 } from "@/app/lib/datadog.client";
 
 export const useDatadogRum = (enabled: boolean = true) => {
   const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
 
   useEffect(() => {
     // Disabled inside partner iframes (/widget) — same rule as Mixpanel.
     if (!enabled) return;
 
     const handleConsentChange = () => {
-      initDatadogRum();
+      const trackingEnabled = syncDatadogRumConsent();
+      // Late consent grant / re-grant: start the current SPA view immediately
+      // (pathname effect alone won't rerun until the next navigation).
+      if (trackingEnabled && pathnameRef.current) {
+        trackDatadogView(pathnameRef.current);
+      }
     };
 
     window.addEventListener("cookieConsentChange", handleConsentChange);
     window.addEventListener("cookieConsent", handleConsentChange);
-    handleConsentChange();
+    // Initial sync only — view tracking is owned by the pathname effect so we
+    // don't double-start a view when consent is already present on mount.
+    syncDatadogRumConsent();
 
     return () => {
       window.removeEventListener("cookieConsentChange", handleConsentChange);
@@ -30,7 +38,6 @@ export const useDatadogRum = (enabled: boolean = true) => {
 
   useEffect(() => {
     if (!enabled || !pathname) return;
-    if (!isDatadogRumInitialized()) return;
     trackDatadogView(pathname);
   }, [enabled, pathname]);
 };

--- a/app/lib/datadog.client.ts
+++ b/app/lib/datadog.client.ts
@@ -78,45 +78,50 @@ export function initDatadogRum(): boolean {
     process.env.NEXT_PUBLIC_DD_SESSION_REPLAY_SAMPLE_RATE ?? "0",
   );
 
-  g[INIT_KEY] = true;
-
-  datadogRum.init({
-    applicationId,
-    clientToken,
-    site: process.env.NEXT_PUBLIC_DD_SITE || "datadoghq.eu",
-    service: process.env.NEXT_PUBLIC_DD_SERVICE || "noblocks",
-    env:
-      process.env.NEXT_PUBLIC_DD_ENV ||
-      process.env.NODE_ENV ||
-      "development",
-    version: process.env.NEXT_PUBLIC_DD_VERSION,
-    sessionSampleRate: Number.isFinite(sessionSampleRate)
-      ? sessionSampleRate
-      : 100,
-    sessionReplaySampleRate: Number.isFinite(sessionReplaySampleRate)
-      ? sessionReplaySampleRate
-      : 0,
-    trackUserInteractions: true,
-    trackResources: true,
-    trackLongTasks: true,
-    trackViewsManually: true,
-    defaultPrivacyLevel: "mask-user-input",
-    beforeSend(event) {
-      if (event.type === "action" && event.action?.target?.name) {
-        const name = event.action.target.name.toLowerCase();
-        if (SENSITIVE_KEYS.some((s) => name.includes(s))) {
-          return false;
+  try {
+    datadogRum.init({
+      applicationId,
+      clientToken,
+      site: process.env.NEXT_PUBLIC_DD_SITE || "datadoghq.eu",
+      service: process.env.NEXT_PUBLIC_DD_SERVICE || "noblocks",
+      env:
+        process.env.NEXT_PUBLIC_DD_ENV ||
+        process.env.NODE_ENV ||
+        "development",
+      version: process.env.NEXT_PUBLIC_DD_VERSION,
+      sessionSampleRate: Number.isFinite(sessionSampleRate)
+        ? sessionSampleRate
+        : 100,
+      sessionReplaySampleRate: Number.isFinite(sessionReplaySampleRate)
+        ? sessionReplaySampleRate
+        : 0,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      trackViewsManually: true,
+      defaultPrivacyLevel: "mask-user-input",
+      trackingConsent: "granted",
+      beforeSend(event) {
+        if (event.type === "action" && event.action?.target?.name) {
+          const name = event.action.target.name.toLowerCase();
+          if (SENSITIVE_KEYS.some((s) => name.includes(s))) {
+            return false;
+          }
         }
-      }
-      if (event.context) {
-        event.context = scrubContext(
-          event.context as Record<string, unknown>,
-        ) as typeof event.context;
-      }
-      return true;
-    },
-  });
+        if (event.context) {
+          event.context = scrubContext(
+            event.context as Record<string, unknown>,
+          ) as typeof event.context;
+        }
+        return true;
+      },
+    });
+  } catch {
+    // Leave INIT_KEY unset so a later consent event can retry.
+    return false;
+  }
 
+  g[INIT_KEY] = true;
   return true;
 }
 
@@ -125,9 +130,28 @@ export function isDatadogRumInitialized(): boolean {
   return !!(window as Window & { [INIT_KEY]?: boolean })[INIT_KEY];
 }
 
+/**
+ * Applies the current analytics cookie consent to Datadog RUM.
+ * Initializes on grant; sets trackingConsent to not-granted on revoke.
+ * Returns true when RUM is initialized and tracking is granted.
+ */
+export function syncDatadogRumConsent(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const consented = hasAnalyticsCookieConsent();
+
+  if (isDatadogRumInitialized()) {
+    datadogRum.setTrackingConsent(consented ? "granted" : "not-granted");
+    return consented;
+  }
+
+  if (!consented) return false;
+  return initDatadogRum();
+}
+
 /** Record a SPA view after client-side navigation. */
 export function trackDatadogView(pathname: string): void {
-  if (!isDatadogRumInitialized()) return;
+  if (!isDatadogRumInitialized() || !hasAnalyticsCookieConsent()) return;
   datadogRum.startView({ name: pathname });
 }
 

--- a/app/lib/datadog.client.ts
+++ b/app/lib/datadog.client.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { datadogRum } from "@datadog/browser-rum";
+import Cookies from "js-cookie";
+
+const INIT_KEY = "__noblocks_datadog_rum_init__" as const;
+
+const SENSITIVE_KEYS = [
+  "authorization",
+  "cookie",
+  "password",
+  "otp",
+  "otpcode",
+  "phonenumber",
+  "phone",
+  "email",
+  "token",
+  "secret",
+  "wallet",
+  "address",
+];
+
+export function hasAnalyticsCookieConsent(): boolean {
+  const consent = Cookies.get("cookieConsent");
+  if (!consent) return false;
+
+  try {
+    return !!JSON.parse(consent).analytics;
+  } catch {
+    return false;
+  }
+}
+
+function scrubContext(
+  context: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!context) return context;
+
+  const scrubbed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (SENSITIVE_KEYS.some((s) => key.toLowerCase().includes(s))) {
+      scrubbed[key] = "[redacted]";
+      continue;
+    }
+    if (typeof value === "string" && value.length > 500) {
+      scrubbed[key] = `${value.slice(0, 80)}…[truncated]`;
+      continue;
+    }
+    scrubbed[key] = value;
+  }
+  return scrubbed;
+}
+
+/**
+ * Initializes browser Datadog RUM (EU site by default). Consent-gated and
+ * disabled in development unless NEXT_PUBLIC_DD_ENABLE_IN_DEV=true.
+ * Safe to call multiple times; runs once per tab after consent.
+ */
+export function initDatadogRum(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const g = window as Window & { [INIT_KEY]?: boolean };
+  if (g[INIT_KEY]) return true;
+
+  if (!hasAnalyticsCookieConsent()) return false;
+
+  const applicationId = process.env.NEXT_PUBLIC_DD_APPLICATION_ID?.trim();
+  const clientToken = process.env.NEXT_PUBLIC_DD_CLIENT_TOKEN?.trim();
+  if (!applicationId || !clientToken) return false;
+
+  const enableInDev = process.env.NEXT_PUBLIC_DD_ENABLE_IN_DEV === "true";
+  if (process.env.NODE_ENV === "development" && !enableInDev) return false;
+
+  const sessionSampleRate = Number(
+    process.env.NEXT_PUBLIC_DD_RUM_SAMPLE_RATE ?? "100",
+  );
+  const sessionReplaySampleRate = Number(
+    process.env.NEXT_PUBLIC_DD_SESSION_REPLAY_SAMPLE_RATE ?? "0",
+  );
+
+  g[INIT_KEY] = true;
+
+  datadogRum.init({
+    applicationId,
+    clientToken,
+    site: process.env.NEXT_PUBLIC_DD_SITE || "datadoghq.eu",
+    service: process.env.NEXT_PUBLIC_DD_SERVICE || "noblocks",
+    env:
+      process.env.NEXT_PUBLIC_DD_ENV ||
+      process.env.NODE_ENV ||
+      "development",
+    version: process.env.NEXT_PUBLIC_DD_VERSION,
+    sessionSampleRate: Number.isFinite(sessionSampleRate)
+      ? sessionSampleRate
+      : 100,
+    sessionReplaySampleRate: Number.isFinite(sessionReplaySampleRate)
+      ? sessionReplaySampleRate
+      : 0,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    trackViewsManually: true,
+    defaultPrivacyLevel: "mask-user-input",
+    beforeSend(event) {
+      if (event.type === "action" && event.action?.target?.name) {
+        const name = event.action.target.name.toLowerCase();
+        if (SENSITIVE_KEYS.some((s) => name.includes(s))) {
+          return false;
+        }
+      }
+      if (event.context) {
+        event.context = scrubContext(
+          event.context as Record<string, unknown>,
+        ) as typeof event.context;
+      }
+      return true;
+    },
+  });
+
+  return true;
+}
+
+export function isDatadogRumInitialized(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!(window as Window & { [INIT_KEY]?: boolean })[INIT_KEY];
+}
+
+/** Record a SPA view after client-side navigation. */
+export function trackDatadogView(pathname: string): void {
+  if (!isDatadogRumInitialized()) return;
+  datadogRum.startView({ name: pathname });
+}
+
+export { datadogRum };

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -30,7 +30,7 @@ import {
 } from "./context";
 import { EmbedNetworkLockApplier } from "./components/EmbedNetworkLockApplier";
 import { useActualTheme } from "./hooks/useActualTheme";
-import { useMixpanel } from "./hooks/analytics/client";
+import { useDatadogRum, useMixpanel } from "./hooks/analytics/client";
 import { BlockFestClaimProvider } from "./context/BlockFestClaimContext";
 
 function Providers({ children }: { children: ReactNode }) {
@@ -108,6 +108,7 @@ function ContextProviders({ children }: { children: ReactNode }) {
   // No client-side trackers inside partner iframes; source-domain attribution
   // happens server-side in middleware.ts instead.
   useMixpanel(!isEmbed);
+  useDatadogRum(!isEmbed);
 
   return (
     <EmbedProvider>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -77,6 +77,24 @@ NEXT_PUBLIC_HOTJAR_SITE_ID=
 NEXT_PUBLIC_ENABLE_EMAIL_IN_ANALYTICS=false
 ```
 
+### Datadog RUM (Real User Monitoring)
+
+Browser-only session monitoring on the EU site (`datadoghq.eu`). Initialized only after the user accepts analytics cookies (same gate as Mixpanel/Hotjar). Disabled on `/widget` embeds.
+
+Create a RUM application in [Datadog EU](https://app.datadoghq.eu/rum/list) and copy the application ID and client token.
+
+```bash
+NEXT_PUBLIC_DD_APPLICATION_ID=
+NEXT_PUBLIC_DD_CLIENT_TOKEN=
+NEXT_PUBLIC_DD_SITE=datadoghq.eu
+NEXT_PUBLIC_DD_SERVICE=noblocks
+NEXT_PUBLIC_DD_ENV=production
+NEXT_PUBLIC_DD_VERSION=                     # Optional (e.g. git SHA from CI)
+NEXT_PUBLIC_DD_RUM_SAMPLE_RATE=100          # 0–100
+NEXT_PUBLIC_DD_SESSION_REPLAY_SAMPLE_RATE=0 # 0–100; keep 0 unless replay is approved
+NEXT_PUBLIC_DD_ENABLE_IN_DEV=false          # Send RUM from local dev when true
+```
+
 ### Server-Side Analytics
 
 ```bash

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -7,6 +7,15 @@ jest.mock('@sentry/react', () => ({
   ErrorBoundary: ({ children }) => children,
 }))
 
+jest.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    init: jest.fn(),
+    startView: jest.fn(),
+    addAction: jest.fn(),
+    setUser: jest.fn(),
+  },
+}))
+
 // Mock environment variables for tests
 process.env.SUPABASE_URL = 'https://test.supabase.co'
 process.env.SUPABASE_SECRET_KEY = 'sb_secret_test_placeholder'

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,6 +13,7 @@ jest.mock('@datadog/browser-rum', () => ({
     startView: jest.fn(),
     addAction: jest.fn(),
     setUser: jest.fn(),
+    setTrackingConsent: jest.fn(),
   },
 }))
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "sanity:undeploy": "sanity undeploy"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^7.6.1",
     "@dicebear/collection": "^9.2.2",
     "@dicebear/core": "^9.4.2",
     "@headlessui/react": "^2.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
 
   .:
     dependencies:
+      '@datadog/browser-rum':
+        specifier: ^7.6.1
+        version: 7.6.1
       '@dicebear/collection':
         specifier: ^9.2.2
         version: 9.4.2(@dicebear/core@9.4.2)
@@ -167,7 +170,7 @@ importers:
         version: 15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-sanity:
         specifier: ^10.0.4
-        version: 10.0.10(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(next@15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3))(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.8.3)
+        version: 10.0.10(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(next@15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3))(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.8.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -194,7 +197,7 @@ importers:
         version: 3.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       sanity:
         specifier: ^4.4.1
-        version: 4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3)
+        version: 4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1151,6 +1154,23 @@ packages:
 
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
+
+  '@datadog/browser-core@7.6.1':
+    resolution: {integrity: sha512-xfExkTuolUYO/OXOVX+8NY3qi0BQAD9D+FWG85VzkI+921HBpVuo79YRnKtIJlTIplSyJaBKF48voX6he9kpXw==}
+
+  '@datadog/browser-rum-core@7.6.1':
+    resolution: {integrity: sha512-Dlk8ZRPZ/yjFKUq/swbWPHFg21YYzMPQEwNgdX9fmwWb4Z/Tpd8Tfjehe3Z7cy4SYYHwV8NuwjvseTaYHM4w7g==}
+
+  '@datadog/browser-rum@7.6.1':
+    resolution: {integrity: sha512-nNaAlRqW5estVXfayl+WSWyTGtue5l0VPyEJGHWsok2zd9BwlGZ62i1XgON9Mi/cP5U9IlUeRKfOkhq5DWcfNg==}
+    peerDependencies:
+      '@datadog/browser-logs': 7.6.1
+    peerDependenciesMeta:
+      '@datadog/browser-logs':
+        optional: true
+
+  '@datadog/js-core@0.0.7':
+    resolution: {integrity: sha512-zthB0nZQ+spdeueG7doqdIxY1BVeOvCPqBDJjm2hyZNuci/wErLzfg/OW/3SvzPGeg8QJryMWIGgPyyw8owqkw==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -11892,6 +11912,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@datadog/browser-core@7.6.1':
+    dependencies:
+      '@datadog/js-core': 0.0.7
+
+  '@datadog/browser-rum-core@7.6.1':
+    dependencies:
+      '@datadog/browser-core': 7.6.1
+      '@datadog/js-core': 0.0.7
+
+  '@datadog/browser-rum@7.6.1':
+    dependencies:
+      '@datadog/browser-core': 7.6.1
+      '@datadog/browser-rum-core': 7.6.1
+      '@datadog/js-core': 0.0.7
+
+  '@datadog/js-core@0.0.7': {}
+
   '@date-fns/tz@1.4.1': {}
 
   '@date-fns/utc@2.1.1': {}
@@ -13453,9 +13490,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@portabletext/block-tools@3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@types/react@19.0.8)':
+  '@portabletext/block-tools@3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)':
     dependencies:
-      '@portabletext/sanity-bridge': 1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@portabletext/sanity-bridge': 1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))
       '@portabletext/schema': 1.0.0
       '@sanity/types': 4.4.1(@types/react@19.0.8)(debug@4.4.1)
       '@types/react': 19.0.8
@@ -13464,12 +13501,12 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/schema'
 
-  '@portabletext/editor@2.3.8(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@types/react@19.0.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rxjs@7.8.2)':
+  '@portabletext/editor@2.3.8(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rxjs@7.8.2)':
     dependencies:
-      '@portabletext/block-tools': 3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@types/react@19.0.8)
+      '@portabletext/block-tools': 3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)
       '@portabletext/keyboard-shortcuts': 1.1.1
       '@portabletext/patches': 1.1.6
-      '@portabletext/sanity-bridge': 1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@portabletext/sanity-bridge': 1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))
       '@portabletext/schema': 1.0.0
       '@portabletext/to-html': 2.0.14
       '@sanity/schema': 4.4.1(@types/react@19.0.8)(debug@4.4.1)
@@ -13505,7 +13542,7 @@ snapshots:
       '@portabletext/types': 2.0.13
       react: 19.2.1
 
-  '@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))':
+  '@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))':
     dependencies:
       '@portabletext/schema': 1.0.0
       '@sanity/schema': 4.4.1(@types/react@19.0.8)(debug@4.4.1)
@@ -14680,7 +14717,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.1)
       '@sanity/types': 4.4.1(@types/react@19.0.8)(debug@4.4.1)
@@ -14779,7 +14816,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.8.2(debug@4.4.1)
       '@sanity/comlink': 3.0.9
-      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))
       dequal: 2.0.3
       next: 15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
@@ -14788,11 +14825,11 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/presentation-comlink@1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))':
+  '@sanity/presentation-comlink@1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))':
     dependencies:
       '@sanity/client': 7.8.2(debug@4.4.1)
       '@sanity/comlink': 3.0.9
-      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))
     transitivePeerDependencies:
       - '@sanity/types'
 
@@ -14988,13 +15025,13 @@ snapshots:
   '@sanity/visual-editing-csm@2.0.23(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(typescript@5.8.3)':
     dependencies:
       '@sanity/client': 7.8.2(debug@4.4.1)
-      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))
       valibot: 1.3.1(typescript@5.8.3)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))':
+  '@sanity/visual-editing-types@1.1.5(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))':
     dependencies:
       '@sanity/client': 7.8.2(debug@4.4.1)
     optionalDependencies:
@@ -15004,9 +15041,9 @@ snapshots:
     dependencies:
       '@sanity/comlink': 3.0.9
       '@sanity/icons': 3.7.4(react@19.2.1)
-      '@sanity/insert-menu': 2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@sanity/insert-menu': 2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.20.2)
-      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))
       '@sanity/preview-url-secret': 2.1.14(@sanity/client@7.8.2)
       '@sanity/ui': 3.0.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sanity/visual-editing-csm': 2.0.23(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(typescript@5.8.3)
@@ -17533,7 +17570,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
       resolve: 1.22.10
     optional: true
@@ -18835,7 +18872,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.7.0)))(eslint@9.28.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
@@ -18857,7 +18894,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.7.0)))(eslint@9.28.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21100,7 +21137,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-sanity@10.0.10(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(next@15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3))(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.8.3):
+  next-sanity@10.0.10(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))(next@15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3))(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.8.3):
     dependencies:
       '@portabletext/react': 3.2.1(react@19.2.1)
       '@sanity/client': 7.8.2(debug@4.4.1)
@@ -21112,7 +21149,7 @@ snapshots:
       next: 15.5.15(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      sanity: 4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3)
+      sanity: 4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3)
       styled-components: 6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -22347,7 +22384,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3):
+  sanity@4.4.1(@emotion/is-prop-valid@1.3.1)(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@types/node@22.15.31)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(bufferutil@4.0.9)(immer@10.1.1)(jiti@2.7.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(tsx@4.22.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(yaml@2.8.3):
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -22355,8 +22392,8 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.1)
       '@juggle/resize-observer': 3.4.0
       '@mux/mux-player-react': 3.5.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@portabletext/block-tools': 3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@types/react@19.0.8)
-      '@portabletext/editor': 2.3.8(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1)))(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@types/react@19.0.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rxjs@7.8.2)
+      '@portabletext/block-tools': 3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)
+      '@portabletext/editor': 2.3.8(@portabletext/sanity-bridge@1.1.2(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8)))(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rxjs@7.8.2)
       '@portabletext/react': 3.2.1(react@19.2.1)
       '@portabletext/toolkit': 2.0.17
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.1)
@@ -22375,13 +22412,13 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 1.1.0
       '@sanity/import': 3.38.3(@types/react@19.0.8)
-      '@sanity/insert-menu': 2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@sanity/insert-menu': 2.0.1(@emotion/is-prop-valid@1.3.1)(@sanity/types@4.4.1(@types/react@19.0.8))(react-dom@19.2.1(react@19.2.1))(react-is@19.1.1)(react@19.2.1)(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sanity/logos': 2.2.2(react@19.2.1)
       '@sanity/media-library-types': 1.0.0
       '@sanity/message-protocol': 0.17.1
       '@sanity/migrate': 4.4.1(@types/react@19.0.8)
       '@sanity/mutator': 4.4.1(@types/react@19.0.8)
-      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8)(debug@4.4.1))
+      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.8.2)(@sanity/types@4.4.1(@types/react@19.0.8))
       '@sanity/preview-url-secret': 2.1.14(@sanity/client@7.8.2)
       '@sanity/schema': 4.4.1(@types/react@19.0.8)(debug@4.4.1)
       '@sanity/sdk': 2.1.2(@types/react@19.0.8)(debug@4.4.1)(immer@10.1.1)(react@19.2.1)(use-sync-external-store@1.5.0(react@19.2.1))


### PR DESCRIPTION
### Description

Adds Datadog Real User Monitoring (RUM) to the Noblocks Next.js app on the **EU site** (`datadoghq.eu`).

**Why:** Paycrest uses Datadog EU for aggregator observability; Noblocks had Mixpanel, Hotjar, and GlitchTip/Sentry but no Datadog RUM for session replay, frontend performance, and user-journey correlation.

**Implementation:**
- `@datadog/browser-rum` initialized in `app/lib/datadog.client.ts`
- Consent-gated via existing `cookieConsent.analytics` cookie (same gate as Mixpanel/Hotjar)
- Disabled on `/widget` embeds (`useDatadogRum(!isEmbed)` in `providers.tsx`)
- Manual SPA view tracking on pathname changes (App Router)
- `defaultPrivacyLevel: mask-user-input` and `beforeSend` scrubbing for sensitive field names
- Documented `NEXT_PUBLIC_DD_*` variables in `.env.example` and `docs/environment-variables.md`

**Not in scope:** Server-side APM (`dd-trace`), Session Replay above 0% sample rate (env defaults to 0 until approved), backend trace correlation.

**Breaking changes:** None. RUM is opt-in via env vars; when `NEXT_PUBLIC_DD_APPLICATION_ID` / `NEXT_PUBLIC_DD_CLIENT_TOKEN` are unset, nothing loads.

### References

- Datadog RUM EU: https://app.datadoghq.eu/rum/list

### Testing

- `pnpm exec tsc --noEmit` — passes
- `pnpm test` — 235 tests pass
- Manual (after setting env vars from a Datadog RUM application):
  1. Set `NEXT_PUBLIC_DD_APPLICATION_ID`, `NEXT_PUBLIC_DD_CLIENT_TOKEN`, `NEXT_PUBLIC_DD_ENV=staging`
  2. `pnpm dev`, accept analytics cookies
  3. Confirm sessions appear in Datadog RUM explorer (EU)
  4. Navigate between routes — views should update
  5. Open `/widget` — RUM should not initialize

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Datadog Real User Monitoring (browser) with SPA page-view tracking and configurable RUM/session replay sampling.
  * RUM activation and view tracking are now tied to analytics cookie consent and are disabled on embedded/widget pages.
  * Implemented consent syncing and safeguards to redact sensitive interaction data before sending.
* **Documentation**
  * Added environment variable guidance for Datadog RUM configuration, including dev enablement for local testing.
* **Testing**
  * Added Jest mocking support for Datadog RUM to enable monitoring-related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->