### PR TITLE
fix(observability): address CodeRabbit Datadog RUM review

### DIFF
--- a/app/hooks/analytics/useDatadogRum.ts
+++ b/app/hooks/analytics/useDatadogRum.ts
@@ -1,26 +1,34 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
 import {
-  initDatadogRum,
-  isDatadogRumInitialized,
+  syncDatadogRumConsent,
   trackDatadogView,
 } from "@/app/lib/datadog.client";
 
 export const useDatadogRum = (enabled: boolean = true) => {
   const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
 
   useEffect(() => {
     // Disabled inside partner iframes (/widget) — same rule as Mixpanel.
     if (!enabled) return;
 
     const handleConsentChange = () => {
-      initDatadogRum();
+      const trackingEnabled = syncDatadogRumConsent();
+      // Late consent grant / re-grant: start the current SPA view immediately
+      // (pathname effect alone won't rerun until the next navigation).
+      if (trackingEnabled && pathnameRef.current) {
+        trackDatadogView(pathnameRef.current);
+      }
     };
 
     window.addEventListener("cookieConsentChange", handleConsentChange);
     window.addEventListener("cookieConsent", handleConsentChange);
-    handleConsentChange();
+    // Initial sync only — view tracking is owned by the pathname effect so we
+    // don't double-start a view when consent is already present on mount.
+    syncDatadogRumConsent();
 
     return () => {
       window.removeEventListener("cookieConsentChange", handleConsentChange);
@@ -30,7 +38,6 @@ export const useDatadogRum = (enabled: boolean = true) => {
 
   useEffect(() => {
     if (!enabled || !pathname) return;
-    if (!isDatadogRumInitialized()) return;
     trackDatadogView(pathname);
   }, [enabled, pathname]);
 };

--- a/app/lib/datadog.client.ts
+++ b/app/lib/datadog.client.ts
@@ -78,45 +78,50 @@ export function initDatadogRum(): boolean {
     process.env.NEXT_PUBLIC_DD_SESSION_REPLAY_SAMPLE_RATE ?? "0",
   );
 
-  g[INIT_KEY] = true;
-
-  datadogRum.init({
-    applicationId,
-    clientToken,
-    site: process.env.NEXT_PUBLIC_DD_SITE || "datadoghq.eu",
-    service: process.env.NEXT_PUBLIC_DD_SERVICE || "noblocks",
-    env:
-      process.env.NEXT_PUBLIC_DD_ENV ||
-      process.env.NODE_ENV ||
-      "development",
-    version: process.env.NEXT_PUBLIC_DD_VERSION,
-    sessionSampleRate: Number.isFinite(sessionSampleRate)
-      ? sessionSampleRate
-      : 100,
-    sessionReplaySampleRate: Number.isFinite(sessionReplaySampleRate)
-      ? sessionReplaySampleRate
-      : 0,
-    trackUserInteractions: true,
-    trackResources: true,
-    trackLongTasks: true,
-    trackViewsManually: true,
-    defaultPrivacyLevel: "mask-user-input",
-    beforeSend(event) {
-      if (event.type === "action" && event.action?.target?.name) {
-        const name = event.action.target.name.toLowerCase();
-        if (SENSITIVE_KEYS.some((s) => name.includes(s))) {
-          return false;
+  try {
+    datadogRum.init({
+      applicationId,
+      clientToken,
+      site: process.env.NEXT_PUBLIC_DD_SITE || "datadoghq.eu",
+      service: process.env.NEXT_PUBLIC_DD_SERVICE || "noblocks",
+      env:
+        process.env.NEXT_PUBLIC_DD_ENV ||
+        process.env.NODE_ENV ||
+        "development",
+      version: process.env.NEXT_PUBLIC_DD_VERSION,
+      sessionSampleRate: Number.isFinite(sessionSampleRate)
+        ? sessionSampleRate
+        : 100,
+      sessionReplaySampleRate: Number.isFinite(sessionReplaySampleRate)
+        ? sessionReplaySampleRate
+        : 0,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      trackViewsManually: true,
+      defaultPrivacyLevel: "mask-user-input",
+      trackingConsent: "granted",
+      beforeSend(event) {
+        if (event.type === "action" && event.action?.target?.name) {
+          const name = event.action.target.name.toLowerCase();
+          if (SENSITIVE_KEYS.some((s) => name.includes(s))) {
+            return false;
+          }
         }
-      }
-      if (event.context) {
-        event.context = scrubContext(
-          event.context as Record<string, unknown>,
-        ) as typeof event.context;
-      }
-      return true;
-    },
-  });
+        if (event.context) {
+          event.context = scrubContext(
+            event.context as Record<string, unknown>,
+          ) as typeof event.context;
+        }
+        return true;
+      },
+    });
+  } catch {
+    // Leave INIT_KEY unset so a later consent event can retry.
+    return false;
+  }
 
+  g[INIT_KEY] = true;
   return true;
 }
 
@@ -125,9 +130,28 @@ export function isDatadogRumInitialized(): boolean {
   return !!(window as Window & { [INIT_KEY]?: boolean })[INIT_KEY];
 }
 
+/**
+ * Applies the current analytics cookie consent to Datadog RUM.
+ * Initializes on grant; sets trackingConsent to not-granted on revoke.
+ * Returns true when RUM is initialized and tracking is granted.
+ */
+export function syncDatadogRumConsent(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const consented = hasAnalyticsCookieConsent();
+
+  if (isDatadogRumInitialized()) {
+    datadogRum.setTrackingConsent(consented ? "granted" : "not-granted");
+    return consented;
+  }
+
+  if (!consented) return false;
+  return initDatadogRum();
+}
+
 /** Record a SPA view after client-side navigation. */
 export function trackDatadogView(pathname: string): void {
-  if (!isDatadogRumInitialized()) return;
+  if (!isDatadogRumInitialized() || !hasAnalyticsCookieConsent()) return;
   datadogRum.startView({ name: pathname });
 }
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,6 +13,7 @@ jest.mock('@datadog/browser-rum', () => ({
     startView: jest.fn(),
     addAction: jest.fn(),
     setUser: jest.fn(),
+    setTrackingConsent: jest.fn(),
   },
 }))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes the two actionable CodeRabbit review comments on #646 (Datadog RUM integration).

**Consent sync (`useDatadogRum` / `syncDatadogRumConsent`):**
- Consent changes now call `datadogRum.setTrackingConsent("not-granted")` when analytics cookies are revoked, so an already-started session stops collecting.
- After a late consent grant (or re-grant), the current SPA pathname is tracked immediately via `trackDatadogView`, without waiting for the next navigation.
- View tracking stays gated on both initialization and current analytics consent.

**Init flag (`initDatadogRum`):**
- `g[INIT_KEY]` is set only after `datadogRum.init()` succeeds.
- If `init()` throws, the flag stays unset so a later consent event can retry.

Also mocks `setTrackingConsent` in `jest.setup.js`.

**Breaking changes:** None.

### References

- Parent PR: https://github.com/paycrest/noblocks/pull/646
- CodeRabbit review on #646 (consent sync + init-flag ordering)

### Testing

- `pnpm exec tsc --noEmit` — passes
- `pnpm test` — 235 tests pass
- Manual: accept analytics cookies → RUM starts and current view is recorded; revoke analytics → `setTrackingConsent("not-granted")`; re-accept → tracking resumes and current view starts.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f06886f0-847c-473c-941b-932ca39b06f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f06886f0-847c-473c-941b-932ca39b06f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

