### PR TITLE
feat(onramp): add KES fiat-to-crypto on-ramp support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -268,8 +268,7 @@ SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
 # (client-signed, gas-sponsored) to the user's chosen destination if it differs.
 NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED=false
 
-# KES fiat→crypto on-ramp (NGN on-ramp is always on). Default enabled when unset; set false to disable.
-# NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
+NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
 
 NEXT_PUBLIC_REFERRAL_MIN_QUALIFYING_VOLUME_USD=20 # in USDC
 NEXT_PUBLIC_REFERRAL_REWARD_AMOUNT_USD=1 # in USDC

--- a/.env.example
+++ b/.env.example
@@ -268,5 +268,8 @@ SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
 # (client-signed, gas-sponsored) to the user's chosen destination if it differs.
 NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED=false
 
+# KES fiat→crypto on-ramp (NGN on-ramp is always on). Default enabled when unset; set false to disable.
+# NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
+
 NEXT_PUBLIC_REFERRAL_MIN_QUALIFYING_VOLUME_USD=20 # in USDC
 NEXT_PUBLIC_REFERRAL_REWARD_AMOUNT_USD=1 # in USDC

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -79,28 +79,31 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       );
     }
 
-    const sourceCurrency =
+    const sourceCurrencyRaw =
       typeof (source as { currency?: unknown })?.currency === "string"
         ? (source as { currency: string }).currency.trim()
         : "";
+    const sourceCurrency = sourceCurrencyRaw.toUpperCase();
     if (!sourceCurrency || !isOnrampFiatCurrencyCode(sourceCurrency)) {
       trackApiError(
         request,
         "/api/v1/payment-orders",
         "POST",
-        new Error(`On-ramp not supported for fiat currency: ${sourceCurrency || "missing"}`),
+        new Error(`On-ramp not supported for fiat currency: ${sourceCurrencyRaw || "missing"}`),
         400,
       );
       return NextResponse.json(
         {
           success: false,
-          error: sourceCurrency
-            ? `${sourceCurrency} on-ramp is not available.`
+          error: sourceCurrencyRaw
+            ? `${sourceCurrencyRaw} on-ramp is not available.`
             : "On-ramp order is missing source currency.",
         },
         { status: 400 },
       );
     }
+
+    (body as { source?: { currency?: string } }).source!.currency = sourceCurrency;
 
     // Refund-account name policy (authoritative gate at money time). The refund account must belong
     // to the same person as the verified KYC profile. A modified client must not be able to bypass

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/app/lib/server-analytics";
 import config from "@/app/lib/config";
 import { getKycFullName } from "@/app/lib/kyc-profile-server";
+import { isOnrampFiatCurrencyCode } from "@/app/utils";
 import {
   accountNameMatchesKyc,
   REFUND_NAME_MISMATCH_MESSAGE,
@@ -73,6 +74,29 @@ export const POST = withRateLimit(async (request: NextRequest) => {
           success: false,
           error:
             "Only on-ramp (fiat source) orders are supported. Off-ramp uses on-chain gateway.createOrder.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const sourceCurrency =
+      typeof (source as { currency?: unknown })?.currency === "string"
+        ? (source as { currency: string }).currency.trim()
+        : "";
+    if (!sourceCurrency || !isOnrampFiatCurrencyCode(sourceCurrency)) {
+      trackApiError(
+        request,
+        "/api/v1/payment-orders",
+        "POST",
+        new Error(`On-ramp not supported for fiat currency: ${sourceCurrency || "missing"}`),
+        400,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error: sourceCurrency
+            ? `${sourceCurrency} on-ramp is not available.`
+            : "On-ramp order is missing source currency.",
         },
         { status: 400 },
       );

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -73,6 +73,7 @@ const config: Config = {
   bridgeEnabled: process.env.NEXT_PUBLIC_BRIDGE_ENABLED === "true",
   onrampChainedForwardingEnabled:
     process.env.NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED === "true",
+  kesOnrampEnabled: process.env.NEXT_PUBLIC_KES_ONRAMP_ENABLED !== "false",
   fantasyEnabled: process.env.NEXT_PUBLIC_FANTASY_ENABLED === "true",
   // When true (and fantasyEnabled), public /play shows the end-of-campaign
   // announcement instead of the live game. Flip off to revive Play for a

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -702,7 +702,11 @@ export const TransactionForm = ({
         let minAmountSentValue = 0.5;
 
         if (swapMode === "onramp") {
-          maxAmountSentValue = getOnrampFiatMaxAmount(currency || "NGN");
+          const safeCurrency =
+            currency?.trim() && isOnrampFiatCurrencyCode(currency.trim())
+              ? currency.trim()
+              : "NGN";
+          maxAmountSentValue = getOnrampFiatMaxAmount(safeCurrency);
           setRateError(null);
         } else if (tokensEqual(token, "cNGN")) {
           if (cngnRate && cngnRate > 0) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -450,6 +450,11 @@ export type Config = {
   /** Bridge/Swap feature flag. Controls Convert button visibility + proxy routes. */
   bridgeEnabled: boolean;
   onrampChainedForwardingEnabled: boolean;
+  /**
+   * KES fiat→crypto onramp. Default on (unset env); set
+   * NEXT_PUBLIC_KES_ONRAMP_ENABLED=false to hide KES in on-ramp mode.
+   */
+  kesOnrampEnabled: boolean;
   /** Noblocks Play (World Cup fantasy league) feature flag. Gates /play UI + API. */
   fantasyEnabled: boolean;
   /**

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -255,11 +255,17 @@ export function filterAndSortInstitutions(
   return [...filtered].sort(compareInstitutionsForDisplay);
 }
 
-/** Fiat codes enabled for on-ramp (send fiat → receive crypto). */
-export const ONRAMP_FIAT_CURRENCY_CODES = new Set(["NGN", "KES"]);
+/** Fiat codes enabled for on-ramp (send fiat → receive crypto). NGN is always on; KES is flag-gated. */
+export function getOnrampFiatCurrencyCodes(): Set<string> {
+  const codes = new Set(["NGN"]);
+  if (config.kesOnrampEnabled) {
+    codes.add("KES");
+  }
+  return codes;
+}
 
 export function isOnrampFiatCurrencyCode(code: string): boolean {
-  return ONRAMP_FIAT_CURRENCY_CODES.has(code.toUpperCase());
+  return getOnrampFiatCurrencyCodes().has(code.toUpperCase());
 }
 
 /**
@@ -269,6 +275,9 @@ export function isOnrampFiatCurrencyCode(code: string): boolean {
  */
 export function getOnrampFiatMaxAmount(currencyCode: string): number {
   const code = (currencyCode ?? "").trim().toUpperCase();
+  if (!isOnrampFiatCurrencyCode(code)) {
+    throw new Error(`Unsupported on-ramp fiat currency: ${currencyCode}`);
+  }
   switch (code) {
     case "KES":
       return 3_000_000;

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -191,6 +191,9 @@ NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 # Onramp chained forwarding: crypto settles to user wallet then auto-forward to destination
 NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED=false
 
+# KES fiat→crypto on-ramp (NGN on-ramp always on). Omit or any value except "false" = enabled.
+NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
+
 # Embeddable widget (/widget, iframed by whitelisted partners) — see docs/embed-widget.md
 NEXT_PUBLIC_EMBED_ENABLED=false
 # Comma-separated origins allowed to iframe /widget (https only; http allowed


### PR DESCRIPTION
- Introduced a new environment variable `NEXT_PUBLIC_KES_ONRAMP_ENABLED` to control KES on-ramp availability.
- Updated configuration to include `kesOnrampEnabled` flag.
- Modified utility functions to conditionally include KES in the on-ramp currency codes.
- Enhanced payment order API to validate source currency against supported on-ramp currencies.
- Updated documentation to reflect new environment variable and its usage.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed e.g closes #407
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### env
- NEXT_PUBLIC_KES_ONRAMP_ENABLED=false


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to enable or disable the KES fiat-to-crypto on-ramp.
  * KES is enabled by default unless `NEXT_PUBLIC_KES_ONRAMP_ENABLED=false`; NGN remains enabled.
* **Bug Fixes**
  * Improved on-ramp currency handling by trimming/uppercasing and rejecting missing or unsupported currencies.
  * Ensures KES-related max amount logic fails closed when KES is disabled.
* **Documentation**
  * Updated environment variable documentation with the new KES on-ramp setting and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->