### PR TITLE
Extend reconcile-pending-orders to handle onramp transactions

### DIFF
--- a/__tests__/aggregatorStatusMapping.test.ts
+++ b/__tests__/aggregatorStatusMapping.test.ts
@@ -1,0 +1,103 @@
+import {
+  mapAggregatorStatusToDbStatus,
+  resolveOnrampOrderStatusFromV2Response,
+} from "../app/api/aggregator";
+
+/**
+ * These mappings are ported into the reconcile-pending-orders Edge Function
+ * (supabase/functions/reconcile-pending-orders/index.ts), which cannot import
+ * from app/ (Deno runtime, separate bundle). Keep the port in sync when these
+ * change — the reconciler writes the same statuses the client does.
+ */
+describe("mapAggregatorStatusToDbStatus", () => {
+  it("completes an onramp only on settled", () => {
+    expect(mapAggregatorStatusToDbStatus("settled", { onramp: true })).toBe(
+      "completed",
+    );
+    // `validated` is NOT terminal for an onramp: the crypto is not with the user
+    // until the order settles, so the row stays pending and keeps being polled.
+    expect(mapAggregatorStatusToDbStatus("validated", { onramp: true })).toBe(
+      "pending",
+    );
+    expect(mapAggregatorStatusToDbStatus("settling", { onramp: true })).toBe(
+      "pending",
+    );
+  });
+
+  it("completes an offramp on validated as well as settled", () => {
+    expect(mapAggregatorStatusToDbStatus("validated")).toBe("completed");
+    expect(mapAggregatorStatusToDbStatus("settled")).toBe("completed");
+  });
+
+  it("maps the shared terminal states identically for both ramps", () => {
+    for (const onramp of [true, false]) {
+      expect(mapAggregatorStatusToDbStatus("refunded", { onramp })).toBe(
+        "refunded",
+      );
+      expect(mapAggregatorStatusToDbStatus("expired", { onramp })).toBe(
+        "expired",
+      );
+      expect(mapAggregatorStatusToDbStatus("fulfilled", { onramp })).toBe(
+        "fulfilled",
+      );
+    }
+  });
+
+  it("falls back to pending for unknown statuses", () => {
+    expect(mapAggregatorStatusToDbStatus("who-knows")).toBe("pending");
+    expect(mapAggregatorStatusToDbStatus("")).toBe("pending");
+  });
+});
+
+describe("resolveOnrampOrderStatusFromV2Response", () => {
+  const envelope = (data: unknown) => ({ data }) as never;
+  const iso = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+  it("passes through any non-pending status untouched", () => {
+    expect(resolveOnrampOrderStatusFromV2Response(envelope({ status: "settled" }))).toBe(
+      "settled",
+    );
+  });
+
+  it("keeps pending while the payment window is still open", () => {
+    expect(
+      resolveOnrampOrderStatusFromV2Response(
+        envelope({
+          status: "pending",
+          providerAccount: { validUntil: iso(60_000) },
+        }),
+      ),
+    ).toBe("pending");
+  });
+
+  it("infers expired once the payment window has closed", () => {
+    // Without this an unfunded onramp order stays pending forever — the client
+    // polls it endlessly and the reconciler re-fetches it on every run.
+    expect(
+      resolveOnrampOrderStatusFromV2Response(
+        envelope({
+          status: "pending",
+          providerAccount: { validUntil: iso(-60_000) },
+        }),
+      ),
+    ).toBe("expired");
+  });
+
+  it("keeps pending when there is no usable validUntil", () => {
+    expect(
+      resolveOnrampOrderStatusFromV2Response(envelope({ status: "pending" })),
+    ).toBe("pending");
+    expect(
+      resolveOnrampOrderStatusFromV2Response(
+        envelope({
+          status: "pending",
+          providerAccount: { validUntil: "not-a-date" },
+        }),
+      ),
+    ).toBe("pending");
+  });
+
+  it("returns undefined when the envelope carries no order data", () => {
+    expect(resolveOnrampOrderStatusFromV2Response(envelope(null))).toBeUndefined();
+  });
+});

--- a/__tests__/kycIdentity.test.ts
+++ b/__tests__/kycIdentity.test.ts
@@ -1,4 +1,7 @@
-import { resolveIdentityScope } from "../app/lib/kyc-identity";
+import {
+  identityScopeHasVerifiedPhone,
+  resolveIdentityScope,
+} from "../app/lib/kyc-identity";
 import { supabaseAdmin } from "../app/lib/supabase";
 
 // Stub Supabase entirely: these tests are about which wallets end up sharing a spend
@@ -20,7 +23,7 @@ type QueryResult = { data: unknown; error: unknown };
  */
 function query(result: QueryResult) {
   const builder: Record<string, unknown> = {};
-  for (const method of ["select", "eq", "gte", "neq", "limit", "in"]) {
+  for (const method of ["select", "eq", "gte", "neq", "limit", "in", "not"]) {
     builder[method] = () => builder;
   }
   builder.maybeSingle = () => Promise.resolve(result);
@@ -207,5 +210,40 @@ describe("resolveIdentityScope", () => {
     await expect(resolveIdentityScope(CALLER)).rejects.toEqual({
       message: "sibling boom",
     });
+  });
+});
+
+describe("identityScopeHasVerifiedPhone", () => {
+  it("returns false for an empty wallet list without querying", async () => {
+    mockedFrom.mockReset();
+
+    await expect(identityScopeHasVerifiedPhone([])).resolves.toBe(false);
+    expect(mockedFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns true when a wallet in scope holds a verified phone", async () => {
+    queueQueries(ok([{ wallet_address: SIBLING }]));
+
+    // The ID-pooled caller has no phone of its own, but its sibling verified one — the
+    // identity counts as phone-verified so the tier-2 gate cannot loop forever.
+    await expect(
+      identityScopeHasVerifiedPhone([CALLER, SIBLING]),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when no wallet in scope holds a verified phone", async () => {
+    queueQueries(ok([]));
+
+    await expect(
+      identityScopeHasVerifiedPhone([CALLER, SIBLING]),
+    ).resolves.toBe(false);
+  });
+
+  it("throws when the lookup fails so callers can fail-soft explicitly", async () => {
+    queueQueries({ data: null, error: { message: "phone boom" } });
+
+    await expect(
+      identityScopeHasVerifiedPhone([CALLER, SIBLING]),
+    ).rejects.toEqual({ message: "phone boom" });
   });
 });

--- a/__tests__/orderStatus.test.ts
+++ b/__tests__/orderStatus.test.ts
@@ -1,0 +1,37 @@
+import { isKnownAggregatorOrderStatus } from "../app/lib/order-status";
+
+describe("isKnownAggregatorOrderStatus", () => {
+  it.each([
+    "pending",
+    "fulfilling",
+    "fulfilled",
+    "validated",
+    "settling",
+    "settled",
+    "refunding",
+    "refunded",
+    "expired",
+  ])("accepts the real aggregator status %s", (status) => {
+    expect(isKnownAggregatorOrderStatus(status)).toBe(true);
+  });
+
+  it("accepts statuses case-insensitively", () => {
+    expect(isKnownAggregatorOrderStatus("Settled")).toBe(true);
+    expect(isKnownAggregatorOrderStatus("PENDING")).toBe(true);
+  });
+
+  it.each(["success", "error"])(
+    "rejects the HTTP envelope value %s that the unwrap fallback can surface",
+    (status) => {
+      expect(isKnownAggregatorOrderStatus(status)).toBe(false);
+    },
+  );
+
+  it("rejects unknown strings and non-strings", () => {
+    expect(isKnownAggregatorOrderStatus("processing")).toBe(false);
+    expect(isKnownAggregatorOrderStatus("")).toBe(false);
+    expect(isKnownAggregatorOrderStatus(undefined)).toBe(false);
+    expect(isKnownAggregatorOrderStatus(null)).toBe(false);
+    expect(isKnownAggregatorOrderStatus(42)).toBe(false);
+  });
+});

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
-import { resolveIdentityScope } from "@/app/lib/kyc-identity";
+import {
+  identityScopeHasVerifiedPhone,
+  resolveIdentityScope,
+} from "@/app/lib/kyc-identity";
 import {
   trackApiRequest,
   trackApiResponse,
@@ -57,12 +60,14 @@ export async function GET(request: NextRequest) {
     // enforcement will actually apply.
     let tier: 0 | 1 | 2 | 3;
     let pooledWalletCount: number;
+    let scopeWallets: string[];
     try {
       const scope = await resolveIdentityScope(walletAddress);
       tier = scope.effectiveTier as 0 | 1 | 2 | 3;
       // How many wallets share this allowance. > 1 is what makes the UI explain the
       // pool; at 1 every limit surface renders exactly as it did before pooling.
       pooledWalletCount = scope.wallets.length;
+      scopeWallets = scope.wallets;
     } catch (scopeError) {
       trackApiError(request, "/api/kyc/status", "GET", scopeError as Error, 500);
       return NextResponse.json(
@@ -77,6 +82,24 @@ export async function GET(request: NextRequest) {
     // phone as verified on a wallet that never verified one.
     const phoneVerified = tier >= 1 && !!phoneNumber;
 
+    // Identity-scoped view for gates that care about the person, not the wallet: a wallet that
+    // inherited its tier through the ID triple may hold no phone itself while a sibling wallet
+    // verified one. Without this flag the tier-2 phone gate loops forever (re-verifying the same
+    // number is rejected as already in use). Fail-soft to the per-wallet answer — the gate then
+    // behaves exactly as before.
+    let identityHasVerifiedPhone = phoneVerified;
+    if (!identityHasVerifiedPhone && scopeWallets.length > 1) {
+      try {
+        identityHasVerifiedPhone =
+          await identityScopeHasVerifiedPhone(scopeWallets);
+      } catch (phoneScopeError) {
+        console.error(
+          "[kyc/status] identity phone lookup failed:",
+          phoneScopeError,
+        );
+      }
+    }
+
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/kyc/status", "GET", 200, responseTime);
 
@@ -85,6 +108,7 @@ export async function GET(request: NextRequest) {
       tier,
       pooledWalletCount,
       isPhoneVerified: phoneVerified,
+      identityHasVerifiedPhone,
       phoneNumber,
       fullName: kycProfile?.full_name || null,
     });

--- a/app/components/ProfileView.tsx
+++ b/app/components/ProfileView.tsx
@@ -85,9 +85,16 @@ export default function ProfileView({ layout, onBack, onClose }: ProfileViewProp
     onSuccess: ({ user }) => {
       toast.success(`${user.email?.address} linked successfully`);
     },
-    onError: () => {
+    onError: (error) => {
+      // Privy reports why linking failed — surface the real reason instead of
+      // blanket-claiming the email is already linked.
+      const code = String(error);
+      if (code === "exited_link_flow") return; // user closed the modal — not an error
       toast.error("Error linking account", {
-        description: "You might have this email linked already",
+        description:
+          code === "linked_to_another_user"
+            ? "This email is already linked to another account"
+            : "Couldn't link your email. Please try again.",
       });
     },
   });
@@ -348,20 +355,23 @@ export default function ProfileView({ layout, onBack, onClose }: ProfileViewProp
                   className="object-fit h-[44px] w-[44px] rounded-full"
                 />
                 <div className="flex w-full flex-col items-start">
-                  {user?.email ? (
-                    <div>
-                      <p className="text-xs text-text-body dark:text-white/90">
-                        {user.email.address}
-                      </p>
-                    </div>
-                  ) : (
-                    <button
-                      onClick={linkEmail}
-                      className="text-sm text-lavender-600 hover:underline dark:text-lavender-400"
-                    >
-                      Connect my email
-                    </button>
-                  )}
+                  {/* Email linking is a Privy account action — injected (external) wallets have
+                      no Privy session, so linkEmail would always fail for them. */}
+                  {!isInjectedWallet &&
+                    (user?.email ? (
+                      <div>
+                        <p className="text-xs text-text-body dark:text-white/90">
+                          {user.email.address}
+                        </p>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={linkEmail}
+                        className="text-sm text-lavender-600 hover:underline dark:text-lavender-400"
+                      >
+                        Connect my email
+                      </button>
+                    ))}
 
                   {/* Wallet Address */}
                   {walletAddress ? (

--- a/app/components/SettingsDropdown.tsx
+++ b/app/components/SettingsDropdown.tsx
@@ -107,9 +107,16 @@ export const SettingsDropdown = () => {
     onSuccess: ({ user }) => {
       toast.success(`${user.email} linked successfully`);
     },
-    onError: () => {
+    onError: (error) => {
+      // Privy reports why linking failed — surface the real reason instead of
+      // blanket-claiming the email is already linked.
+      const code = String(error);
+      if (code === "exited_link_flow") return; // user closed the modal — not an error
       toast.error("Error linking account", {
-        description: "You might have this email linked already",
+        description:
+          code === "linked_to_another_user"
+            ? "This email is already linked to another account"
+            : "Couldn't link your email. Please try again.",
       });
     },
   });

--- a/app/context/KYCContext.tsx
+++ b/app/context/KYCContext.tsx
@@ -71,6 +71,19 @@ export interface KYCStatusSnapshot {
    */
   pooledWalletCount: number;
   isPhoneVerified: boolean;
+  /**
+   * Whether any wallet in this identity's pool holds an OTP-verified phone. A wallet that
+   * inherited its tier through the ID triple can have no phone of its own while a sibling
+   * verified one — gates that care about the person (tier-2 phone gate) use this, not
+   * `isPhoneVerified`, so they don't re-prompt for a number that can never be re-verified.
+   */
+  identityHasVerifiedPhone: boolean;
+  /**
+   * True once a status fetch for the CURRENT wallet actually succeeded. While false the
+   * snapshot is the reset default (tier 0), which must read as "unknown", not "unverified" —
+   * gating UIs should refresh before treating the user as unverified.
+   */
+  hasLoadedStatus: boolean;
   phoneNumber: string | null;
   fullName: string | null;
   transactionSummary: UserTransactionSummary;
@@ -80,6 +93,8 @@ interface KYCContextType {
   tier: KYCTierLevel;
   pooledWalletCount: number;
   isPhoneVerified: boolean;
+  identityHasVerifiedPhone: boolean;
+  hasLoadedStatus: boolean;
   phoneNumber: string | null;
   fullName: string | null;
   walletAddress: string | undefined;
@@ -104,6 +119,8 @@ function createEmptySnapshot(): KYCStatusSnapshot {
     tier: 0,
     pooledWalletCount: 1,
     isPhoneVerified: false,
+    identityHasVerifiedPhone: false,
+    hasLoadedStatus: false,
     phoneNumber: null,
     fullName: null,
     transactionSummary: { ...EMPTY_TX_SUMMARY },
@@ -148,6 +165,9 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
   const [tier, setTier] = useState<KYCTierLevel>(0);
   const [pooledWalletCount, setPooledWalletCount] = useState(1);
   const [isPhoneVerified, setIsPhoneVerified] = useState(false);
+  const [identityHasVerifiedPhone, setIdentityHasVerifiedPhone] =
+    useState(false);
+  const [hasLoadedStatus, setHasLoadedStatus] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState<string | null>(null);
   const [fullName, setFullName] = useState<string | null>(null);
   const [transactionSummary, setTransactionSummary] =
@@ -160,6 +180,11 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
         partial.pooledWalletCount ?? latestSnapshotRef.current.pooledWalletCount,
       isPhoneVerified:
         partial.isPhoneVerified ?? latestSnapshotRef.current.isPhoneVerified,
+      identityHasVerifiedPhone:
+        partial.identityHasVerifiedPhone ??
+        latestSnapshotRef.current.identityHasVerifiedPhone,
+      hasLoadedStatus:
+        partial.hasLoadedStatus ?? latestSnapshotRef.current.hasLoadedStatus,
       phoneNumber:
         partial.phoneNumber !== undefined
           ? partial.phoneNumber
@@ -175,6 +200,8 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
     setTier(next.tier);
     setPooledWalletCount(next.pooledWalletCount);
     setIsPhoneVerified(next.isPhoneVerified);
+    setIdentityHasVerifiedPhone(next.identityHasVerifiedPhone);
+    setHasLoadedStatus(next.hasLoadedStatus);
     setPhoneNumber(next.phoneNumber);
     setFullName(next.fullName);
     setTransactionSummary(next.transactionSummary);
@@ -311,6 +338,10 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
           tier: safeTier,
           pooledWalletCount: Math.max(1, Number(data.pooledWalletCount) || 1),
           isPhoneVerified: Boolean(data.isPhoneVerified),
+          identityHasVerifiedPhone: Boolean(
+            data.identityHasVerifiedPhone ?? data.isPhoneVerified,
+          ),
+          hasLoadedStatus: true,
           phoneNumber: data.phoneNumber ?? null,
           fullName: data.fullName ?? null,
         });
@@ -336,30 +367,53 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
         return latestSnapshotRef.current;
       }
 
-      if (refreshInFlightRef.current) {
-        return refreshInFlightRef.current;
-      }
-
       const run = async (): Promise<KYCStatusSnapshot | null> => {
         const guards = fetchGuardsRef.current;
         delete guards[`${guardKey}_kyc`];
         delete guards[`${guardKey}_tx`];
 
         const fetchOpts = { force: true as const };
-        await Promise.all([
+        const [kycOk] = await Promise.all([
           fetchKYCStatus(fetchOpts),
           fetchTransactionSummary(fetchOpts),
         ]);
 
-        lastFetchTimeRef.current = Date.now();
+        // Only a successful status fetch counts as fresh. Stamping on failure would serve
+        // the reset (tier-0) snapshot for the whole staleness window — verified users would
+        // transiently read as unverified and get re-prompted for phone verification.
+        if (kycOk) {
+          lastFetchTimeRef.current = Date.now();
+        }
         return latestSnapshotRef.current;
       };
 
-      refreshInFlightRef.current = run();
+      const inFlight = refreshInFlightRef.current;
+      if (inFlight) {
+        if (!force) {
+          return inFlight;
+        }
+        // A forced refresh must observe data fetched AFTER the caller's action (e.g. an OTP
+        // promotion) — piggybacking on an older in-flight fetch would hand back pre-action
+        // data and the caller would still see the user as unverified.
+        const chained = inFlight.catch(() => null).then(run);
+        refreshInFlightRef.current = chained;
+        try {
+          return await chained;
+        } finally {
+          if (refreshInFlightRef.current === chained) {
+            refreshInFlightRef.current = null;
+          }
+        }
+      }
+
+      const current = run();
+      refreshInFlightRef.current = current;
       try {
-        return await refreshInFlightRef.current;
+        return await current;
       } finally {
-        refreshInFlightRef.current = null;
+        if (refreshInFlightRef.current === current) {
+          refreshInFlightRef.current = null;
+        }
       }
     },
     [
@@ -377,6 +431,8 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
       setTier(empty.tier);
       setPooledWalletCount(empty.pooledWalletCount);
       setIsPhoneVerified(empty.isPhoneVerified);
+      setIdentityHasVerifiedPhone(empty.identityHasVerifiedPhone);
+      setHasLoadedStatus(empty.hasLoadedStatus);
       setPhoneNumber(empty.phoneNumber);
       setFullName(empty.fullName);
       setTransactionSummary({ ...EMPTY_TX_SUMMARY });
@@ -392,6 +448,8 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
         tier,
         pooledWalletCount,
         isPhoneVerified,
+        identityHasVerifiedPhone,
+        hasLoadedStatus,
         phoneNumber,
         fullName,
         walletAddress,

--- a/app/context/KYCContext.tsx
+++ b/app/context/KYCContext.tsx
@@ -438,6 +438,11 @@ export function KYCProvider({ children }: { children: React.ReactNode }) {
       setTransactionSummary({ ...EMPTY_TX_SUMMARY });
       fetchGuardsRef.current = {};
       lastFetchTimeRef.current = 0;
+      // Detach any refresh still in flight for the PREVIOUS wallet. A forced refresh chains
+      // onto whatever is in flight, so leaving it attached would make this wallet's status
+      // wait on an unrelated (and untimed) fetch before it even starts. The run's own
+      // ownership check means the detached promise can't clobber this wallet's state.
+      refreshInFlightRef.current = null;
       void refreshStatus(true);
     }
   }, [walletAddress, refreshStatus]);

--- a/app/lib/kyc-identity.ts
+++ b/app/lib/kyc-identity.ts
@@ -47,6 +47,32 @@ type SiblingRow = { wallet_address: string | null; tier: number | null };
  * silently narrowing the pool would let siblings' spend go uncounted and bypass the
  * limit entirely.
  */
+/**
+ * Whether any wallet in the identity scope holds an OTP-verified phone number.
+ *
+ * `phone_number` is deliberately per-wallet (only OTP-confirmed numbers land there), so a wallet
+ * that inherited its tier through the ID triple can have `phone_number: null` while a sibling
+ * wallet of the same person verified one. The tier-2 phone gate must treat that identity as
+ * phone-verified — otherwise it re-prompts forever, and re-verifying the same number is rejected
+ * as already in use by the sibling.
+ */
+export async function identityScopeHasVerifiedPhone(
+  wallets: string[],
+): Promise<boolean> {
+  if (wallets.length === 0) return false;
+  const { data, error } = await supabaseAdmin
+    .from("user_kyc_profiles")
+    .select("wallet_address")
+    .in("wallet_address", wallets)
+    .not("phone_number", "is", null)
+    .gte("tier", 1)
+    .limit(1);
+  if (error) {
+    throw error;
+  }
+  return (data ?? []).length > 0;
+}
+
 export async function resolveIdentityScope(
   walletAddress: string,
 ): Promise<IdentityScope> {

--- a/app/lib/order-status.ts
+++ b/app/lib/order-status.ts
@@ -1,0 +1,25 @@
+/**
+ * Aggregator order statuses that may flow into transaction-status state/persistence. Envelope
+ * fallbacks can surface `"success"`/`"error"` (the HTTP envelope, not an order status) — callers
+ * must skip those instead of rendering or persisting them.
+ */
+const KNOWN_AGGREGATOR_ORDER_STATUSES = new Set([
+  "pending",
+  "fulfilling",
+  "fulfilled",
+  "validated",
+  "settling",
+  "settled",
+  "refunding",
+  "refunded",
+  "expired",
+]);
+
+export function isKnownAggregatorOrderStatus(
+  status: unknown,
+): status is string {
+  return (
+    typeof status === "string" &&
+    KNOWN_AGGREGATOR_ORDER_STATUSES.has(status.toLowerCase())
+  );
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -869,6 +869,13 @@ export const TransactionForm = ({
   const handleSwap = async () => {
     let kyc = getKycStatusSnapshot();
 
+    // Consume the post-OTP continuation flag exactly once per call. Clearing it only inside
+    // the tier-2 branch would leave it set whenever the phone was verified below tier 2, and
+    // that stale `true` would later wave a genuinely ungated wallet past the tier-2 gate.
+    const resumingAfterPhoneVerification =
+      pendingContinueSwapAfterPhoneRef.current;
+    pendingContinueSwapAfterPhoneRef.current = false;
+
     // Tier 2+ (e.g. migrated ID KYC) still requires a stored phone — prompt before swap.
     // The identity, not the wallet, satisfies this: a wallet that inherited its tier through
     // the ID triple may hold no phone itself while a sibling wallet verified one, and
@@ -876,11 +883,10 @@ export const TransactionForm = ({
     if (kyc.tier >= 2) {
       const hasPhone =
         Boolean(kyc.phoneNumber?.trim()) || kyc.identityHasVerifiedPhone;
-      if (!hasPhone && !pendingContinueSwapAfterPhoneRef.current) {
+      if (!hasPhone && !resumingAfterPhoneVerification) {
         setIsTier2PhoneGateOpen(true);
         return;
       }
-      pendingContinueSwapAfterPhoneRef.current = false;
     }
 
     setOrderId("");
@@ -943,8 +949,7 @@ export const TransactionForm = ({
             formData.institution,
         );
     if (!hasRecipient) {
-      if (pendingContinueSwapAfterPhoneRef.current) {
-        pendingContinueSwapAfterPhoneRef.current = false;
+      if (resumingAfterPhoneVerification) {
         toast.info("Phone number verified — add the recipient details to continue.");
       } else {
         toast.error("Add recipient details to continue.");

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -866,12 +866,16 @@ export const TransactionForm = ({
   /** After phone OTP, KYC context may not have updated before the next handleSwap; allow one continuation. */
   const pendingContinueSwapAfterPhoneRef = useRef(false);
 
-  const handleSwap = () => {
-    const kyc = getKycStatusSnapshot();
+  const handleSwap = async () => {
+    let kyc = getKycStatusSnapshot();
 
     // Tier 2+ (e.g. migrated ID KYC) still requires a stored phone — prompt before swap.
+    // The identity, not the wallet, satisfies this: a wallet that inherited its tier through
+    // the ID triple may hold no phone itself while a sibling wallet verified one, and
+    // re-verifying that number would be rejected as already in use — an unsatisfiable loop.
     if (kyc.tier >= 2) {
-      const hasPhone = Boolean(kyc.phoneNumber?.trim());
+      const hasPhone =
+        Boolean(kyc.phoneNumber?.trim()) || kyc.identityHasVerifiedPhone;
       if (!hasPhone && !pendingContinueSwapAfterPhoneRef.current) {
         setIsTier2PhoneGateOpen(true);
         return;
@@ -901,7 +905,16 @@ export const TransactionForm = ({
     });
 
     // Check transaction limits based on KYC tier
-    const limitCheck = canTransact(usdAmount);
+    let limitCheck = canTransact(usdAmount);
+
+    if (!limitCheck.allowed && !kyc.hasLoadedStatus) {
+      // The snapshot is still the reset default — "status unknown", not "unverified". Deciding
+      // on it would send an already-verified user back to phone verification whenever the
+      // status fetch failed or hasn't landed yet. Load the real status once, then re-decide.
+      await refreshStatus(true);
+      kyc = getKycStatusSnapshot();
+      limitCheck = canTransact(usdAmount);
+    }
 
     if (!limitCheck.allowed) {
       if (kyc.tier < 1 || !kyc.isPhoneVerified) {
@@ -910,6 +923,32 @@ export const TransactionForm = ({
       }
       setBlockedTransactionAmount(usdAmount);
       setIsLimitModalOpen(true);
+      return;
+    }
+
+    // A recipient must exist before anything can submit. The recipient section only mounts once
+    // the user is verified, so every unverified entry point (notably the post-OTP continuation in
+    // handlePhoneVerified) reaches here with empty recipient fields — and an empty on-ramp wallet
+    // address would otherwise pass validateWalletAddress (empty is "valid" there; the `required`
+    // rule lives on a field that was never registered). Without this guard the preview renders a
+    // blank recipient ("Account: undefined") and the order params would be built empty.
+    // Note: the recipient section additionally requires the receive destination to be explicitly
+    // selected, so the user may still need that tap before the fields appear.
+    const onrampWalletAddress = String(formData.walletAddress ?? "").trim();
+    const hasRecipient = formData.isSwapped
+      ? onrampWalletAddress.length > 0
+      : Boolean(
+          formData.recipientName &&
+            formData.accountIdentifier &&
+            formData.institution,
+        );
+    if (!hasRecipient) {
+      if (pendingContinueSwapAfterPhoneRef.current) {
+        pendingContinueSwapAfterPhoneRef.current = false;
+        toast.info("Phone number verified — add the recipient details to continue.");
+      } else {
+        toast.error("Add recipient details to continue.");
+      }
       return;
     }
 
@@ -936,7 +975,7 @@ export const TransactionForm = ({
     setIsTier2PhoneGateOpen(false);
     pendingContinueSwapAfterPhoneRef.current = true;
     await refreshStatus(true);
-    handleSwap();
+    await handleSwap();
   };
 
   // Clear recipient when it is invalid for the selected network (EVM ↔ Starknet switches)

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -147,7 +147,11 @@ export const TransactionPreview = ({
     walletAddress,
   } = formValues;
 
-  const isOnramp = !!walletAddress;
+  // Derive the flow from the form's own mode, never from `!!walletAddress` — a Buy that somehow
+  // reaches the preview with an empty wallet address must still render (and order) as an onramp,
+  // not silently fall into the offramp layout with blank recipient fields.
+  const isOnramp =
+    formValues.swapMode === "onramp" || formValues.isSwapped === true;
   const currencySymbol = currency ? getCurrencySymbol(currency) : "";
 
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -346,7 +350,7 @@ export const TransactionPreview = ({
         .split(" ")
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(" "),
-      account: `${accountIdentifier} • ${getInstitutionNameByCode(institution, supportedInstitutions)}`,
+      account: `${accountIdentifier} • ${getInstitutionNameByCode(institution, supportedInstitutions) ?? institution ?? ""}`,
       ...(memo && { description: memo }),
       network: selectedNetwork.chain.name,
     };

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -791,13 +791,18 @@ export function TransactionStatus({
 
           // The envelope fallback can surface `"success"`/`"error"` (HTTP envelope, not an order
           // status) — never let those flow into UI state or DB persistence.
-          if (!isKnownAggregatorOrderStatus(responseData?.status)) {
+          const rawStatus = responseData?.status;
+          if (!isKnownAggregatorOrderStatus(rawStatus)) {
             console.warn(
               "[TransactionStatus] Skipping unknown order status:",
-              responseData?.status,
+              rawStatus,
             );
             return;
           }
+          // Canonicalize before anything reads it: the guard matches case-insensitively, but
+          // every comparison below (and the persisted value) is lowercase, so a mixed-case
+          // terminal status would otherwise poll forever and be stored non-canonically.
+          responseData = { ...responseData, status: rawStatus.toLowerCase() };
 
           setOrderDetails(responseData);
 

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -44,6 +44,7 @@ import {
   saveRecipient,
   deleteSavedRecipient,
 } from "../api/aggregator";
+import { isKnownAggregatorOrderStatus } from "../lib/order-status";
 import { reindexSingleTransaction } from "../lib/reindex";
 import {
   STEPS,
@@ -75,6 +76,7 @@ import {
 import { readForwardBalanceWei } from "../lib/onrampForwarding/readForwardBalanceWei";
 import type { Token } from "../types";
 import { usePrivy } from "@privy-io/react-auth";
+import { useApiAuth } from "../hooks/useApiAuth";
 import { TransactionHelperText } from "../components/TransactionHelperText";
 import { useConfetti } from "../hooks/useConfetti";
 import { BlockFestCashbackComponent } from "../components/blockfest";
@@ -152,6 +154,7 @@ export function TransactionStatus({
   } = useBalance();
   const { isInjectedWallet, injectedAddress } = useInjectedWallet();
   const { user, getAccessToken } = usePrivy();
+  const { resolveAuth } = useApiAuth();
   const { setRocketStatus } = useRocketStatus();
 
   const embeddedWallet = user?.linkedAccounts.find(
@@ -178,6 +181,12 @@ export function TransactionStatus({
   const latestRequestIdRef = useRef<number>(0);
   const lastPersistedOrderStatusRef = useRef<string | null>(null);
   const lastFulfillPersistKeyRef = useRef<string | null>(null);
+  /**
+   * DB row id for THIS order, pinned once per order. `currentTransactionId` in localStorage is a
+   * global key that any wallet transfer (including the leg-2 forward) overwrites — status writes
+   * must keep targeting the order's own row, not whatever the key holds later.
+   */
+  const transactionDbIdRef = useRef<string | null>(null);
 
   const fireConfetti = useConfetti();
 
@@ -198,6 +207,10 @@ export function TransactionStatus({
   useEffect(() => {
     lastPersistedOrderStatusRef.current = null;
     lastFulfillPersistKeyRef.current = null;
+    transactionDbIdRef.current =
+      typeof window !== "undefined"
+        ? localStorage.getItem("currentTransactionId")
+        : null;
     setProcessingStartedAt("");
   }, [orderId]);
 
@@ -319,6 +332,14 @@ export function TransactionStatus({
 
     // Permanent unsupported / misconfig cases: fail closed to a terminal state so the settled onramp
     // resolves (funds stay safe in the Noblocks wallet) instead of spinning forever.
+    // Injected mode has no Noblocks (Privy embedded) wallet — leg 1 already paid the user's own
+    // wallet directly, so there is nothing to forward. Without this the `!noblocksWallet` wait
+    // below would never resolve and the settled onramp would show "processing" forever.
+    if (isInjectedWallet) {
+      forwardDoneRef.current = true;
+      setForwardingStatus("skipped");
+      return;
+    }
     // EVM-only for now; Starknet forwarding isn't supported by this flow.
     if (selectedNetwork.chain.name === "Starknet") {
       forwardDoneRef.current = true;
@@ -332,9 +353,13 @@ export function TransactionStatus({
       return;
     }
 
-    // Transient: embedded wallet not hydrated yet — retry on a later render/tick.
+    // Transient: embedded wallet not hydrated yet — schedule a recheck so a slow Privy hydration
+    // re-evaluates instead of stalling (a bare return would only retry if something else re-rendered).
     const noblocksWallet = embeddedWallet?.address ?? "";
-    if (!noblocksWallet) return;
+    if (!noblocksWallet) {
+      scheduleRecheck();
+      return;
+    }
 
     forwardEvalRef.current = true;
     let cancelled = false;
@@ -353,7 +378,18 @@ export function TransactionStatus({
         const tokenData = tokens.find(
           (t) => t.symbol.toUpperCase() === tokenSymbol.toUpperCase(),
         );
-        if (!tokenData || tokenData.decimals === undefined) return;
+        if (!tokenData || tokenData.decimals === undefined) {
+          if (tokens.length === 0) {
+            // Token list not loaded yet — transient; re-evaluate shortly.
+            if (!cancelled) scheduleRecheck();
+          } else {
+            // Token list is loaded but this symbol isn't supported here — permanent; resolve
+            // terminally so the settled onramp doesn't spin forever. Funds stay in the wallet.
+            forwardDoneRef.current = true;
+            setForwardingStatus("skipped");
+          }
+          return;
+        }
         const decimals = tokenData.decimals;
 
         const orderAmountWei = existing?.amountWei
@@ -431,6 +467,8 @@ export function TransactionStatus({
               return;
             }
             forwardStartedRef.current = true;
+            // Privy-only by construction: the injected-mode guard above resolves before we can
+            // get here, so the Noblocks embedded wallet (and its Privy token) always exists.
             const accessToken = await getAccessToken();
             if (cancelled) return;
             if (!accessToken) {
@@ -469,6 +507,7 @@ export function TransactionStatus({
     };
   }, [
     isOnramp,
+    isInjectedWallet,
     transactionStatus,
     orderId,
     forwardRecheckTick,
@@ -598,7 +637,10 @@ export function TransactionStatus({
     statusOverride?: string,
     txHashOverride?: string,
   ) => {
-    if (!embeddedWallet?.address) return;
+    const persistWalletAddress = isInjectedWallet
+      ? injectedAddress
+      : embeddedWallet?.address;
+    if (!persistWalletAddress) return;
 
     const effectiveAggregatorStatus = statusOverride ?? transactionStatus;
     const effectiveTxHash =
@@ -614,13 +656,18 @@ export function TransactionStatus({
     const requestId = ++latestRequestIdRef.current;
 
     try {
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
+      const { accessToken, injectedToken } = await resolveAuth({
+        interactive: false,
+      });
+      if (!accessToken && !injectedToken) {
         throw new Error("No access token available");
       }
 
-      // Get the stored transaction ID
-      const transactionId = localStorage.getItem("currentTransactionId");
+      // Pin the order's own DB row on first use; the localStorage key is global and may already
+      // point at a later transfer's row (e.g. the leg-2 forward).
+      transactionDbIdRef.current ??=
+        localStorage.getItem("currentTransactionId");
+      const transactionId = transactionDbIdRef.current;
       if (!transactionId) {
         console.error("No transaction ID found");
         return;
@@ -645,7 +692,8 @@ export function TransactionStatus({
         txHash: effectiveTxHash,
         timeSpent,
         accessToken,
-        walletAddress: embeddedWallet.address,
+        injectedToken,
+        walletAddress: persistWalletAddress,
         isOnramp: isOnramp === true,
       });
 
@@ -667,7 +715,17 @@ export function TransactionStatus({
    */
   useEffect(
     function pollOrderDetails() {
-      let intervalId: NodeJS.Timeout;
+      let intervalId: NodeJS.Timeout | null = null;
+      let cancelled = false;
+      let tokenlessCycles = 0;
+      let hasShownSessionToast = false;
+
+      const stopPollingLoop = () => {
+        if (intervalId) {
+          clearInterval(intervalId);
+          intervalId = null;
+        }
+      };
 
       const persistIfStatusChanged = (s: string) => {
         if (lastPersistedOrderStatusRef.current === s) return;
@@ -686,18 +744,32 @@ export function TransactionStatus({
         "Session expired. Please refresh to continue tracking your transaction.";
 
       const getOrderDetails = async () => {
+        if (cancelled) return;
         try {
-          const accessToken = await getAccessToken();
-          if (!accessToken) {
-            toast.error(sessionExpiredMessage);
-            if (intervalId) clearInterval(intervalId);
+          const { accessToken, injectedToken } = await resolveAuth({
+            interactive: false,
+          });
+          if (cancelled) return;
+          if (!accessToken && !injectedToken) {
+            // A missing token can be a transient blip (refresh, backgrounded tab). Skip this
+            // cycle and keep polling — killing the interval here strands the status forever.
+            tokenlessCycles += 1;
+            if (tokenlessCycles >= 6 && !hasShownSessionToast) {
+              hasShownSessionToast = true;
+              toast.error(sessionExpiredMessage);
+            }
             return;
           }
+          tokenlessCycles = 0;
 
           let responseData: OrderDetailsData;
 
           if (isOnramp) {
-            const res = await fetchV2SenderPaymentOrderById(orderId, accessToken);
+            const res = await fetchV2SenderPaymentOrderById(
+              orderId,
+              accessToken,
+              injectedToken,
+            );
             const resolvedStatus = resolveOnrampOrderStatusFromV2Response(res);
             responseData =
               unwrapV2SenderOrderEnvelope(res) ??
@@ -710,9 +782,21 @@ export function TransactionStatus({
             const orderDetailsResponse = await fetchOrderDetails(
               orderId,
               accessToken,
-              { network: selectedNetwork.chain.name },
+              { network: selectedNetwork.chain.name, injectedToken },
             );
             responseData = orderDetailsResponse.data;
+          }
+
+          if (cancelled) return;
+
+          // The envelope fallback can surface `"success"`/`"error"` (HTTP envelope, not an order
+          // status) — never let those flow into UI state or DB persistence.
+          if (!isKnownAggregatorOrderStatus(responseData?.status)) {
+            console.warn(
+              "[TransactionStatus] Skipping unknown order status:",
+              responseData?.status,
+            );
+            return;
           }
 
           setOrderDetails(responseData);
@@ -731,7 +815,7 @@ export function TransactionStatus({
               );
             setCompletedAt(doneAt);
             setTransactionStatus("expired");
-            clearInterval(intervalId);
+            stopPollingLoop();
             persistIfStatusChanged("expired");
             return;
           }
@@ -756,7 +840,7 @@ export function TransactionStatus({
             );
             refreshBalance();
             setRocketStatus("pending");
-            clearInterval(intervalId);
+            stopPollingLoop();
             persistIfStatusChanged(status);
             return;
           }
@@ -806,7 +890,7 @@ export function TransactionStatus({
               responseData.txReceipts?.[0]?.txHash;
 
             if (stopPolling) {
-              clearInterval(intervalId);
+              stopPollingLoop();
               if (hashFromOrder) {
                 setCreatedHash(hashFromOrder);
               }
@@ -823,18 +907,14 @@ export function TransactionStatus({
         }
       };
 
-      void (async () => {
-        const accessToken = await getAccessToken();
-        if (!accessToken) {
-          toast.error(sessionExpiredMessage);
-          return;
-        }
-        await getOrderDetails();
-        intervalId = setInterval(getOrderDetails, 5000);
-      })();
+      // Create the interval synchronously so a cleanup from an effect re-run (every status
+      // change) can never race an in-flight async bootstrap and orphan it.
+      void getOrderDetails();
+      intervalId = setInterval(getOrderDetails, 5000);
 
       return () => {
-        if (intervalId) clearInterval(intervalId);
+        cancelled = true;
+        stopPollingLoop();
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/supabase/functions/reconcile-pending-orders/index.ts
+++ b/supabase/functions/reconcile-pending-orders/index.ts
@@ -47,6 +47,10 @@ const FETCH_TIMEOUT_MS = 8_000;
 // remaining (older) rows are picked up on the next cron tick, which restarts from
 // the oldest. Kept well below the pg_net timeout in the cron migration.
 const MAX_RUN_MS = 90_000;
+// Cap on per-row entries in the response/log. Non-reconcilable rows (e.g. an onramp row whose
+// order_id isn't a sender UUID) never leave the scan set, so they would otherwise re-emit a
+// detail entry on every run and grow the payload without bound. Counters stay exact.
+const MAX_DETAILS = 200;
 
 // Non-final statuses we re-check. Final states (completed/failed/refunded/expired)
 // are intentionally excluded so they drop out of the scan.
@@ -150,10 +154,16 @@ interface Summary {
   skipped: number;
   notFound: number;
   errors: number;
-  truncated: boolean; // true if the wall-clock budget cut the run short
+  /** True only if the shared run deadline was hit — not when offramp merely used up its half. */
+  truncated: boolean;
+  /** Per-scan cut-offs, including offramp stopping at its half-budget cap. */
+  truncatedOfframp: boolean;
+  truncatedOnramp: boolean;
   /** Set when onramp rows were not scanned at all (sender API key not configured). */
   onrampSkippedReason?: string;
+  /** Bounded sample — see MAX_DETAILS. `detailsOmitted` counts what didn't fit. */
   details: Array<Record<string, unknown>>;
+  detailsOmitted: number;
 }
 
 type StatusResult =
@@ -258,8 +268,17 @@ async function reconcile(): Promise<Summary> {
     notFound: 0,
     errors: 0,
     truncated: false,
+    truncatedOfframp: false,
+    truncatedOnramp: false,
     details: [],
+    detailsOmitted: 0,
   };
+
+  /** Bounded detail sink: keeps the first MAX_DETAILS entries and counts the rest. */
+  function pushDetail(detail: Record<string, unknown>) {
+    if (summary.details.length < MAX_DETAILS) summary.details.push(detail);
+    else summary.detailsOmitted++;
+  }
 
   /** Picks the right aggregator lookup for a row, or reports why it isn't reconcilable. */
   function statusFetcherFor(
@@ -302,7 +321,7 @@ async function reconcile(): Promise<Summary> {
         const fetcher = statusFetcherFor(transactionType, row);
         if ("skipReason" in fetcher) {
           summary.skipped++;
-          summary.details.push({ id: row.id, type: transactionType, action: "skipped", reason: fetcher.skipReason, network: row.network });
+          pushDetail({ id: row.id, type: transactionType, action: "skipped", reason: fetcher.skipReason, network: row.network });
           continue;
         }
 
@@ -313,7 +332,7 @@ async function reconcile(): Promise<Summary> {
         }
         if (result.kind === "error") {
           summary.errors++;
-          summary.details.push({ id: row.id, type: transactionType, action: "error", reason: result.message });
+          pushDetail({ id: row.id, type: transactionType, action: "error", reason: result.message });
           continue;
         }
 
@@ -336,12 +355,12 @@ async function reconcile(): Promise<Summary> {
 
         if (updErr) {
           summary.errors++;
-          summary.details.push({ id: row.id, type: transactionType, action: "update_error", reason: updErr.message });
+          pushDetail({ id: row.id, type: transactionType, action: "update_error", reason: updErr.message });
           continue;
         }
         if (updatedRows && updatedRows.length > 0) {
           summary.updated++;
-          summary.details.push({ id: row.id, type: transactionType, action: "updated", from: row.status, to: mapped, aggregator: result.value });
+          pushDetail({ id: row.id, type: transactionType, action: "updated", from: row.status, to: mapped, aggregator: result.value });
         } else {
           summary.unchanged++; // lost the optimistic race — client already moved it
         }
@@ -358,10 +377,18 @@ async function reconcile(): Promise<Summary> {
     transactionType: "offramp" | "onramp",
     stopAt: number,
   ) {
+    // `stopAt` may be this scan's share of the budget rather than the run deadline, so
+    // record the cut-off per scan and reserve `truncated` for a genuine run timeout.
+    const markTruncated = () => {
+      if (transactionType === "onramp") summary.truncatedOnramp = true;
+      else summary.truncatedOfframp = true;
+      if (Date.now() >= deadline) summary.truncated = true;
+    };
+
     let cursorCreatedAt = "1970-01-01T00:00:00.000Z";
     while (true) {
       if (Date.now() >= stopAt) {
-        summary.truncated = true;
+        markTruncated();
         break;
       }
 
@@ -388,7 +415,7 @@ async function reconcile(): Promise<Summary> {
 
       // processPage may have bailed mid-page on the budget; flag it either way.
       if (Date.now() >= stopAt) {
-        summary.truncated = true;
+        markTruncated();
         break;
       }
       if (rows.length < BATCH_LIMIT) break; // drained the last page

--- a/supabase/functions/reconcile-pending-orders/index.ts
+++ b/supabase/functions/reconcile-pending-orders/index.ts
@@ -1,27 +1,34 @@
 // Supabase Edge Function: reconcile-pending-orders
 //
 // WHY THIS EXISTS
-// Offramp orders are created directly on-chain against the Gateway contract, so
-// Noblocks never registers a Paycrest sender API key / webhook URL for them. The
-// only thing that moves an offramp row from `pending` -> `completed` is the
-// client-side poll in app/pages/TransactionStatus.tsx. If the user closes the tab
-// before the aggregator settles the payout, the DB row stays `pending` forever
-// even though the fiat was paid out — which then blocks referral-campaign
+// A transaction row only moves out of `pending` via the client-side poll in
+// app/pages/TransactionStatus.tsx. If the user closes the tab before the
+// aggregator reaches a terminal state, the DB row stays `pending` forever even
+// though the fiat/crypto was delivered — which then blocks referral-campaign
 // activation (the sweep only counts `completed` on/off-ramp volume).
 //
 // This function is a server-authoritative reconciler: on a pg_cron schedule it
-// re-reads the aggregator status of still-pending offramp orders and persists the
+// re-reads the aggregator status of still-pending orders and persists the
 // terminal status. No reindex is ever performed — read-and-reconcile only.
 //
-// SCOPE: offramp only. The gateway status endpoint requires NO API key (see
-// app/api/v1/payment-orders/[id]/route.ts — the gateway branch sends empty
-// headers). Onramp reconciliation would need the sender API key and is out of
-// scope for v1.
+// SCOPE: both ramps, each against the endpoint its order id belongs to.
+//   - offramp: gateway ids (0x + 64 hex) -> /v2/orders/{chainId}/{id}, NO API key.
+//   - onramp:  sender order UUIDs        -> /v2/sender/orders/{id}, API-Key header.
+// Onramp reconciliation is skipped (offramp still runs) when
+// AGGREGATOR_SENDER_API_KEY_ID is unset, so a missing secret degrades rather than
+// failing the run.
 //
-// PARITY NOTE: mapAggregatorStatusToDbStatus, aggregatorOriginForV2, and the
-// network-name -> chainId map below are ports of:
-//   - app/api/aggregator.ts  (mapAggregatorStatusToDbStatus, aggregatorOriginForV2)
-//   - app/lib/payment-order-id.ts + app/mocks.ts  (network -> chainId)
+// ONRAMP TERMINAL SEMANTICS: only `settled` completes an onramp — `validated`
+// maps to `pending`, exactly as the app does. Unfunded onramp orders would
+// otherwise never leave the scan set, so the app's validUntil expiry inference is
+// ported too (see resolveOnrampStatus).
+//
+// PARITY NOTE: mapAggregatorStatusToDbStatus, resolveOnrampStatus,
+// aggregatorOriginForV2, isSenderPaymentOrderUuid and the network-name -> chainId
+// map below are ports of:
+//   - app/api/aggregator.ts  (mapAggregatorStatusToDbStatus,
+//     resolveOnrampOrderStatusFromV2Response, aggregatorOriginForV2)
+//   - app/lib/payment-order-id.ts + app/mocks.ts  (network -> chainId, UUID test)
 // Keep them in sync if the originals change.
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
@@ -60,9 +67,13 @@ const NETWORK_NAME_TO_CHAIN_ID: Record<string, number> = {
 
 // --- ported helpers ----------------------------------------------------------
 
-/** Port of mapAggregatorStatusToDbStatus (offramp path, onramp=false). */
-function mapAggregatorStatusToDbStatus(status: string): string {
+/** Port of mapAggregatorStatusToDbStatus. */
+function mapAggregatorStatusToDbStatus(
+  status: string,
+  opts?: { onramp?: boolean },
+): string {
   const s = String(status || "").toLowerCase();
+  const onramp = opts?.onramp === true;
   if (s === "settled") return "completed";
   if (s === "refunded") return "refunded";
   if (s === "refunding") return "refunding";
@@ -72,9 +83,35 @@ function mapAggregatorStatusToDbStatus(status: string): string {
   // through to `pending` and loop in the scan forever. The app-side twin in
   // aggregator.ts has no `failed` case — keep this divergence in mind if syncing.
   if (s === "failed") return "failed";
-  if (s === "validated") return "completed"; // offramp: validated -> completed
+  // Only `settled` completes an onramp; offramp also completes on `validated`.
+  if (s === "validated") return onramp ? "pending" : "completed";
   if (["settling", "fulfilling", "pending"].includes(s)) return "pending";
   return "pending";
+}
+
+/**
+ * Port of resolveOnrampOrderStatusFromV2Response: the aggregator may still report
+ * `pending` after the virtual-account window closed. Treat a pending order whose
+ * `validUntil` has passed as expired — without this, every unfunded onramp order
+ * stays in the scan set forever and each run re-fetches it.
+ */
+function resolveOnrampStatus(data: Record<string, any> | null): string | null {
+  if (!data || typeof data !== "object") return null;
+  const status = String(data.status ?? "");
+  if (status === "") return null;
+  if (status.toLowerCase() !== "pending") return status;
+  const validUntil = data.providerAccount?.validUntil;
+  if (!validUntil) return status;
+  const end = new Date(validUntil).getTime();
+  if (Number.isNaN(end) || Date.now() <= end) return status;
+  return "expired";
+}
+
+/** Port of isSenderPaymentOrderUuid: aggregator v2 sender payment order id. */
+const SENDER_ORDER_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function isSenderPaymentOrderUuid(id: string): boolean {
+  return SENDER_ORDER_UUID_RE.test(id.trim());
 }
 
 /** Port of aggregatorOriginForV2: strip a trailing `/v1` so v2 paths are correct. */
@@ -106,27 +143,52 @@ interface Row {
 
 interface Summary {
   scanned: number;
+  scannedOfframp: number;
+  scannedOnramp: number;
   updated: number;
   unchanged: number;
   skipped: number;
   notFound: number;
   errors: number;
   truncated: boolean; // true if the wall-clock budget cut the run short
+  /** Set when onramp rows were not scanned at all (sender API key not configured). */
+  onrampSkippedReason?: string;
   details: Array<Record<string, unknown>>;
 }
 
-async function fetchGatewayStatus(
-  origin: string,
-  chainId: number,
-  orderId: string,
-): Promise<{ kind: "status"; value: string } | { kind: "notFound" } | { kind: "error"; message: string }> {
-  const url = `${origin}/v2/orders/${chainId}/${encodeURIComponent(orderId.trim())}`;
+type StatusResult =
+  | { kind: "status"; value: string }
+  | { kind: "notFound" }
+  | { kind: "error"; message: string };
+
+/**
+ * Shared aggregator GET + envelope handling. `readStatus` pulls the order status
+ * out of the envelope's `data` (onramp additionally applies the validUntil expiry
+ * inference), so both ramps share timeout, 404 and error-envelope handling.
+ */
+async function fetchAggregatorStatus(
+  url: string,
+  headers: Record<string, string>,
+  readStatus: (data: Record<string, any> | null) => string | null,
+): Promise<StatusResult> {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { signal: ctrl.signal }); // no API key for gateway reads
-    if (res.status === 404) return { kind: "notFound" };
+    const res = await fetch(url, { signal: ctrl.signal, headers });
     const body = await res.json().catch(() => null);
+    if (res.status === 404) {
+      // The sender endpoint also answers 404 for a bad/missing API key (see the
+      // "api key not found" special case in app/api/v1/payment-orders/[id]/route.ts).
+      // Counting that as "not indexed yet" would silently no-op every onramp row
+      // forever, so surface it as an error the run summary shows.
+      const msg = body && typeof body === "object" && typeof body.message === "string"
+        ? body.message
+        : "";
+      if (/api key/i.test(msg)) {
+        return { kind: "error", message: `aggregator rejected credentials: ${msg}` };
+      }
+      return { kind: "notFound" };
+    }
     if (!res.ok) {
       const msg = body && typeof body === "object" && typeof body.message === "string"
         ? body.message
@@ -136,7 +198,7 @@ async function fetchGatewayStatus(
     if (!body || body.status === "error") {
       return { kind: "error", message: (body && body.message) || "aggregator error envelope" };
     }
-    const orderStatus = body?.data?.status;
+    const orderStatus = readStatus(body?.data ?? null);
     if (typeof orderStatus !== "string" || orderStatus === "") {
       return { kind: "error", message: "missing data.status in aggregator response" };
     }
@@ -146,6 +208,29 @@ async function fetchGatewayStatus(
   } finally {
     clearTimeout(t);
   }
+}
+
+function fetchGatewayStatus(
+  origin: string,
+  chainId: number,
+  orderId: string,
+): Promise<StatusResult> {
+  const url = `${origin}/v2/orders/${chainId}/${encodeURIComponent(orderId.trim())}`;
+  // Gateway reads need no API key (mirrors the gateway branch of
+  // app/api/v1/payment-orders/[id]/route.ts).
+  return fetchAggregatorStatus(url, {}, (data) => {
+    const s = data?.status;
+    return typeof s === "string" && s !== "" ? s : null;
+  });
+}
+
+function fetchSenderOrderStatus(
+  origin: string,
+  apiKey: string,
+  orderId: string,
+): Promise<StatusResult> {
+  const url = `${origin}/v2/sender/orders/${encodeURIComponent(orderId.trim())}`;
+  return fetchAggregatorStatus(url, { "API-Key": apiKey }, resolveOnrampStatus);
 }
 
 async function reconcile(): Promise<Summary> {
@@ -158,11 +243,15 @@ async function reconcile(): Promise<Summary> {
     auth: { persistSession: false },
   });
 
+  const senderApiKey = (Deno.env.get("AGGREGATOR_SENDER_API_KEY_ID") ?? "").trim();
+
   const deadline = Date.now() + MAX_RUN_MS;
   const maxCreatedAt = new Date(Date.now() - MIN_AGE_SECONDS * 1000).toISOString();
 
   const summary: Summary = {
     scanned: 0,
+    scannedOfframp: 0,
+    scannedOnramp: 0,
     updated: 0,
     unchanged: 0,
     skipped: 0,
@@ -172,34 +261,65 @@ async function reconcile(): Promise<Summary> {
     details: [],
   };
 
+  /** Picks the right aggregator lookup for a row, or reports why it isn't reconcilable. */
+  function statusFetcherFor(
+    transactionType: "offramp" | "onramp",
+    row: Row,
+  ): { fetch: () => Promise<StatusResult> } | { skipReason: string } {
+    const orderId = row.order_id?.trim();
+    if (!orderId) return { skipReason: "missing order_id" };
+
+    if (transactionType === "onramp") {
+      // Onramp lookups are chain-agnostic (the UUID identifies the sender order),
+      // so unlike offramp there is no network -> chainId requirement here.
+      if (!isSenderPaymentOrderUuid(orderId)) {
+        return { skipReason: "order_id is not a sender payment order uuid" };
+      }
+      return { fetch: () => fetchSenderOrderStatus(origin, senderApiKey, orderId) };
+    }
+
+    const chainId = row.network ? resolveChainIdFromNetworkName(row.network) : null;
+    if (chainId == null) return { skipReason: "unknown network" };
+    return { fetch: () => fetchGatewayStatus(origin, chainId, orderId) };
+  }
+
   // Process one page of candidates with a bounded worker pool. Stops starting new
   // work once the wall-clock budget is spent.
-  async function processPage(rows: Row[]) {
+  async function processPage(
+    rows: Row[],
+    transactionType: "offramp" | "onramp",
+    stopAt: number,
+  ) {
     let idx = 0;
     async function worker() {
       while (idx < rows.length) {
-        if (Date.now() >= deadline) return;
+        if (Date.now() >= stopAt) return;
         const row = rows[idx++];
         summary.scanned++;
-        const chainId = row.network ? resolveChainIdFromNetworkName(row.network) : null;
-        if (!row.order_id || chainId == null) {
+        if (transactionType === "onramp") summary.scannedOnramp++;
+        else summary.scannedOfframp++;
+
+        const fetcher = statusFetcherFor(transactionType, row);
+        if ("skipReason" in fetcher) {
           summary.skipped++;
-          summary.details.push({ id: row.id, action: "skipped", reason: "missing order_id or unknown network", network: row.network });
+          summary.details.push({ id: row.id, type: transactionType, action: "skipped", reason: fetcher.skipReason, network: row.network });
           continue;
         }
 
-        const result = await fetchGatewayStatus(origin, chainId, row.order_id);
+        const result = await fetcher.fetch();
         if (result.kind === "notFound") {
           summary.notFound++; // not indexed yet — a later cycle retries. No reindex.
           continue;
         }
         if (result.kind === "error") {
           summary.errors++;
-          summary.details.push({ id: row.id, action: "error", reason: result.message });
+          summary.details.push({ id: row.id, type: transactionType, action: "error", reason: result.message });
           continue;
         }
 
-        const mapped = mapAggregatorStatusToDbStatus(result.value);
+        const mapped = mapAggregatorStatusToDbStatus(result.value, {
+          onramp: transactionType === "onramp",
+        });
         if (mapped === row.status) {
           summary.unchanged++;
           continue;
@@ -216,12 +336,12 @@ async function reconcile(): Promise<Summary> {
 
         if (updErr) {
           summary.errors++;
-          summary.details.push({ id: row.id, action: "update_error", reason: updErr.message });
+          summary.details.push({ id: row.id, type: transactionType, action: "update_error", reason: updErr.message });
           continue;
         }
         if (updatedRows && updatedRows.length > 0) {
           summary.updated++;
-          summary.details.push({ id: row.id, action: "updated", from: row.status, to: mapped, aggregator: result.value });
+          summary.details.push({ id: row.id, type: transactionType, action: "updated", from: row.status, to: mapped, aggregator: result.value });
         } else {
           summary.unchanged++; // lost the optimistic race — client already moved it
         }
@@ -234,39 +354,62 @@ async function reconcile(): Promise<Summary> {
   // drop out of SCANNABLE_STATUSES, so offset pagination would skip rows — a
   // forward created_at cursor is stable against that. `.gt` guarantees forward
   // progress; any rows sharing a page-boundary timestamp are retried next tick.
-  let cursorCreatedAt = "1970-01-01T00:00:00.000Z";
-  while (true) {
-    if (Date.now() >= deadline) {
-      summary.truncated = true;
-      break;
+  async function scanType(
+    transactionType: "offramp" | "onramp",
+    stopAt: number,
+  ) {
+    let cursorCreatedAt = "1970-01-01T00:00:00.000Z";
+    while (true) {
+      if (Date.now() >= stopAt) {
+        summary.truncated = true;
+        break;
+      }
+
+      const { data, error } = await admin
+        .from("transactions")
+        .select("id, order_id, network, status, created_at")
+        .eq("transaction_type", transactionType)
+        .in("status", SCANNABLE_STATUSES)
+        .not("order_id", "is", null)
+        .gt("created_at", cursorCreatedAt) // keyset cursor (advances forward)
+        .lt("created_at", maxCreatedAt) // min-age guard: skip rows a client may still be polling
+        .order("created_at", { ascending: true })
+        .limit(BATCH_LIMIT);
+
+      if (error) {
+        throw new Error(`${transactionType} candidate query failed: ${error.message}`);
+      }
+
+      const rows = (data ?? []) as Row[];
+      if (rows.length === 0) break;
+
+      await processPage(rows, transactionType, stopAt);
+      cursorCreatedAt = rows[rows.length - 1].created_at;
+
+      // processPage may have bailed mid-page on the budget; flag it either way.
+      if (Date.now() >= stopAt) {
+        summary.truncated = true;
+        break;
+      }
+      if (rows.length < BATCH_LIMIT) break; // drained the last page
     }
-
-    const { data, error } = await admin
-      .from("transactions")
-      .select("id, order_id, network, status, created_at")
-      .eq("transaction_type", "offramp")
-      .in("status", SCANNABLE_STATUSES)
-      .not("order_id", "is", null)
-      .gt("created_at", cursorCreatedAt) // keyset cursor (advances forward)
-      .lt("created_at", maxCreatedAt) // min-age guard: skip rows a client may still be polling
-      .order("created_at", { ascending: true })
-      .limit(BATCH_LIMIT);
-
-    if (error) throw new Error(`candidate query failed: ${error.message}`);
-
-    const rows = (data ?? []) as Row[];
-    if (rows.length === 0) break;
-
-    await processPage(rows);
-    cursorCreatedAt = rows[rows.length - 1].created_at;
-
-    // processPage may have bailed mid-page on the budget; flag it either way.
-    if (Date.now() >= deadline) {
-      summary.truncated = true;
-      break;
-    }
-    if (rows.length < BATCH_LIMIT) break; // drained the last page
   }
+
+  // Offramp runs first but is capped at half the budget, so a large offramp backlog
+  // can never starve onramp reconciliation. If offramp finishes early, onramp
+  // inherits the whole remainder.
+  await scanType("offramp", Math.min(Date.now() + MAX_RUN_MS / 2, deadline));
+
+  if (!senderApiKey) {
+    // Degrade instead of failing: offramp reconciliation above already ran.
+    summary.onrampSkippedReason = "AGGREGATOR_SENDER_API_KEY_ID is not configured";
+    console.warn(
+      "reconcile-pending-orders: skipping onramp scan — AGGREGATOR_SENDER_API_KEY_ID is not configured",
+    );
+    return summary;
+  }
+
+  await scanType("onramp", deadline);
 
   return summary;
 }

--- a/supabase/migrations/20260727120000_create_onramp_pending_reconcile_index.sql
+++ b/supabase/migrations/20260727120000_create_onramp_pending_reconcile_index.sql
@@ -1,0 +1,40 @@
+-- Partial index supporting the onramp half of the reconcile-pending-orders cron
+-- (companion to 20260723120001_create_offramp_pending_reconcile_index.sql, which
+-- covers offramp).
+--
+-- WHY: the reconciler now scans onramp rows too. An onramp row only leaves
+-- `pending` via the client-side poll, so a closed tab strands it even though the
+-- crypto was delivered — the same failure the offramp scan was built for. Onramp
+-- lookups go to /v2/sender/orders/{uuid} with the sender API key; only `settled`
+-- completes an onramp (`validated` stays pending), and unfunded orders drop out
+-- once their validUntil window closes and they map to `expired`.
+--
+-- This index matches the reconciler's onramp scan predicate exactly and INCLUDEs
+-- the columns it projects, so each run scans just the still-pending onramp rows
+-- (keyset-ordered by created_at) and can be served index-only when visibility-map
+-- conditions permit. `network` is included to keep the projection identical to the
+-- offramp scan even though onramp lookups are chain-agnostic. Rows advanced to a
+-- terminal status leave this partial index automatically, keeping it tiny.
+--
+-- NEW EDGE FUNCTION SECRET (set out-of-band, alongside AGGREGATOR_URL and
+-- RECONCILE_CRON_SECRET from 20260723120000):
+--   AGGREGATOR_SENDER_API_KEY_ID = <same sender API key the app uses>
+-- Without it the function still runs and reconciles offramp; the onramp scan is
+-- skipped and reported as onrampSkippedReason in the run summary.
+--
+-- Built CONCURRENTLY so creating it does not lock writes on the (populated)
+-- transactions table. CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- block, which is why this migration contains only this statement — do NOT add
+-- other statements or wrap it in BEGIN/COMMIT.
+--
+-- Operational note: if a CONCURRENTLY build is interrupted it can leave an INVALID
+-- index of this name behind (IF NOT EXISTS will then skip a re-create). If that
+-- happens, drop it and re-run:
+--   DROP INDEX IF EXISTS idx_transactions_onramp_pending_reconcile;
+
+create index concurrently if not exists idx_transactions_onramp_pending_reconcile
+  on transactions (created_at)
+  include (id, order_id, network, status)
+  where transaction_type = 'onramp'
+    and order_id is not null
+    and status in ('pending', 'fulfilling', 'fulfilled', 'refunding');


### PR DESCRIPTION
### Description

This PR extends the `reconcile-pending-orders` Edge Function to reconcile both offramp and onramp transactions, addressing a gap where unfunded or unpolled onramp orders would remain stuck in `pending` status indefinitely.

**Problem**: Transaction rows only transition out of `pending` via client-side polling in `TransactionStatus.tsx`. If a user closes the tab before the aggregator reaches a terminal state, the database row stays `pending` forever—even though fiat/crypto was delivered. This blocks referral-campaign activation (which only counts `completed` volume). Previously, only offramp orders were reconciled server-side; onramp orders had no reconciliation path.

**Solution**: 
- Extend the reconciler to scan both offramp (gateway order IDs) and onramp (sender order UUIDs) transactions
- Onramp lookups use `/v2/sender/orders/{uuid}` with the `AGGREGATOR_SENDER_API_KEY_ID` secret
- Implement onramp-specific terminal semantics: only `settled` completes an onramp; `validated` maps to `pending` (crypto isn't with the user until settlement)
- Port the `validUntil` expiry inference from the app: unfunded onramp orders whose payment window has closed are marked `expired` instead of staying `pending` forever
- Gracefully degrade when the sender API key is unconfigured: offramp reconciliation continues, onramp is skipped with a reason in the summary

**Key changes**:
- Refactored `fetchGatewayStatus` into a shared `fetchAggregatorStatus` that handles both endpoints with pluggable status extraction
- Added `resolveOnrampStatus` to apply `validUntil` expiry logic (ported from `resolveOnrampOrderStatusFromV2Response`)
- Added `isSenderPaymentOrderUuid` to identify onramp order IDs by UUID format
- Updated `mapAggregatorStatusToDbStatus` to accept an `onramp` flag for ramp-specific terminal semantics
- Split the reconciliation loop into separate `scanType` functions for offramp and onramp with independent pagination
- Enhanced summary reporting with `scannedOfframp`, `scannedOnramp`, and `onrampSkippedReason` fields
- Updated `TransactionStatus.tsx` to pin the transaction DB row ID on first use (preventing overwrites when the localStorage key is reused for subsequent transfers)
- Added KYC context fields (`identityHasVerifiedPhone`, `hasLoadedStatus`) to distinguish between "unknown" and "unverified" status states
- Improved phone verification gating to check identity-level phone verification (a wallet that inherited its tier may have no phone itself while a sibling verified one)

**Parity notes**: `mapAggregatorStatusToDbStatus`, `resolveOnrampStatus`, and UUID validation are ported from `app/api/aggregator.ts` and `app/lib/payment-order-id.ts`. A new test file validates these mappings stay in sync.

### Testing

- Added `__tests__/aggregatorStatusMapping.test.ts` to verify `mapAggregatorStatusToDbStatus` and `resolveOnrampOrderStatusFromV2Response` mappings for both ramps
- Added `__tests__/orderStatus.test.ts` to validate `isKnownAggregatorOrderStatus` filtering
- Updated `__tests__/kycIdentity.test.ts` to cover the new `identityScopeHasVerifiedPhone` function
- Existing tests pass; new functionality is covered by unit tests

### Database

- Added `supabase/migrations/20260727120000_create_onramp_pending_reconcile_index.sql`: a partial index on `transactions(created_at)` filtered to onramp pending rows, enabling efficient keyset-ordered scans. Built `CONCURRENTLY` to avoid locking the populated table.
- Requires new Edge Function secret: `AGGREGATOR_SENDER_API_KEY_ID` (set out-of-band alongside existing `AGGREGATOR_URL` and `RECONCILE_CRON_SECRET`)

### Chec

https://claude.ai/code/session_019FVH15Dsqay4qpRfwTeyov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded server reconciliation to include on-ramp orders in addition to off-ramp orders.
  * Added identity-level “verified phone” gating that can satisfy eligible phone requirements.
  * Improved recipient validation before submitting transactions, with clearer resume behavior.

* **Bug Fixes**
  * Improved KYC status loading and refresh behavior, including “status loaded” tracking.
  * Enhanced injected-wallet status polling robustness and terminal-state handling.
  * Fixed transaction preview on/off-ramp determination and safer institution display fallback.
  * Updated email-link and linking failure toasts with more specific messaging.

* **Tests**
  * Added coverage for order status mapping and known aggregator status detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->