### PR TITLE
Fix embed post-transaction sign-out and repeat phone verification

### DIFF
--- a/__tests__/resolveAccountsChangedAction.test.ts
+++ b/__tests__/resolveAccountsChangedAction.test.ts
@@ -1,0 +1,62 @@
+import { resolveAccountsChangedAction } from "../app/context/InjectedWalletContext";
+
+const ADDRESS = "0xeAd3288C7Fb1e0BeC5C8D4E5B8f9A8abBBDE7001";
+const OTHER = "0xB7a6000000000000000000000000000000005556";
+
+describe("resolveAccountsChangedAction", () => {
+  it("treats a re-emit of the same account as unchanged", () => {
+    // Hosts re-emit accountsChanged on reconnect / tab refocus. Dropping the SIWE session
+    // there costs the user a needless signature and resets every wallet-keyed cache.
+    expect(resolveAccountsChangedAction(ADDRESS, ADDRESS)).toEqual({
+      kind: "unchanged",
+      clearSession: false,
+      setAddress: false,
+    });
+  });
+
+  it("treats the same account in different casing as unchanged", () => {
+    // The session token asserts the lowercased address, so casing is not an identity change.
+    // Letting the string flip would also reset KYC status, which keys on the raw address.
+    expect(
+      resolveAccountsChangedAction(ADDRESS, ADDRESS.toLowerCase()),
+    ).toEqual({ kind: "unchanged", clearSession: false, setAddress: false });
+    expect(
+      resolveAccountsChangedAction(ADDRESS.toLowerCase(), ADDRESS),
+    ).toEqual({ kind: "unchanged", clearSession: false, setAddress: false });
+  });
+
+  it("ignores surrounding whitespace when comparing", () => {
+    expect(resolveAccountsChangedAction(ADDRESS, ` ${ADDRESS} `)).toEqual({
+      kind: "unchanged",
+      clearSession: false,
+      setAddress: false,
+    });
+  });
+
+  it("clears the session on a real account switch", () => {
+    expect(resolveAccountsChangedAction(ADDRESS, OTHER)).toEqual({
+      kind: "switched",
+      clearSession: true,
+      setAddress: true,
+    });
+  });
+
+  it("treats the first account as a switch so the address is adopted", () => {
+    expect(resolveAccountsChangedAction(null, ADDRESS)).toEqual({
+      kind: "switched",
+      clearSession: true,
+      setAddress: true,
+    });
+  });
+
+  it.each([undefined, null, "", "   "])(
+    "treats %p as a disconnect",
+    (next) => {
+      expect(resolveAccountsChangedAction(ADDRESS, next)).toEqual({
+        kind: "disconnected",
+        clearSession: true,
+        setAddress: true,
+      });
+    },
+  );
+});

--- a/__tests__/useSwapButton.test.tsx
+++ b/__tests__/useSwapButton.test.tsx
@@ -1,0 +1,166 @@
+/// <reference types="jest" />
+
+import { renderHook } from "@testing-library/react";
+
+import { useSwapButton } from "../app/hooks/useSwapButton";
+
+const mockUsePrivy = jest.fn();
+const mockUseInjectedWallet = jest.fn();
+
+jest.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => mockUsePrivy(),
+}));
+
+jest.mock("../app/context", () => ({
+  useInjectedWallet: () => mockUseInjectedWallet(),
+}));
+
+/** Off-ramp form state that passes every non-KYC gate, so only KYC decides the outcome. */
+const FORM_VALUES = {
+  amountSent: 100,
+  currency: "NGN",
+  recipientName: "Ada Lovelace",
+  walletAddress: "",
+  receiveDestinationExplicitlySelected: true,
+  token: "USDC",
+};
+
+const handleSwap = () => {};
+const login = () => {};
+const handleFundWallet = () => {};
+const openPhoneVerification = () => {};
+const openLimitModal = () => {};
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const watch = (() => FORM_VALUES) as never;
+  return renderHook(() =>
+    useSwapButton({
+      watch,
+      balance: 1000,
+      isDirty: true,
+      isValid: true,
+      isUserVerified: false,
+      rate: 1,
+      ...overrides,
+    }),
+  ).result.current;
+}
+
+/**
+ * Resolves the CTA's action to a readable name. `buttonAction` takes isPhoneVerified and
+ * isUserVerified as arguments (they shadow the hook's props), so callers must pass the same
+ * values they configured the hook with.
+ */
+function actionNameOf(
+  result: ReturnType<typeof setup>,
+  args: { isPhoneVerified?: boolean; isUserVerified?: boolean } = {},
+) {
+  const action = result.buttonAction(
+    handleSwap,
+    login,
+    handleFundWallet,
+    openPhoneVerification,
+    openLimitModal,
+    args.isPhoneVerified ?? false,
+    args.isUserVerified ?? false,
+  );
+  if (action === handleSwap) return "handleSwap";
+  if (action === openPhoneVerification) return "openPhoneVerification";
+  if (action === openLimitModal) return "openLimitModal";
+  if (action === handleFundWallet) return "handleFundWallet";
+  if (action === login) return "login";
+  return "unknown";
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUsePrivy.mockReturnValue({ authenticated: true });
+  mockUseInjectedWallet.mockReturnValue({
+    isInjectedWallet: false,
+    injectedReady: false,
+    injectedRequested: false,
+    injectedStatus: "idle",
+  });
+});
+
+describe("useSwapButton KYC gating", () => {
+  it("defers to handleSwap while KYC status has not loaded", () => {
+    // Unknown status must not be read as unverified: handleSwap refreshes (re-establishing the
+    // injected session if needed) before any verification step is chosen. Opening the phone
+    // modal from the CTA would bypass that refresh entirely.
+    const result = setup({ hasLoadedStatus: false, kycTier: 0 });
+
+    expect(actionNameOf(result)).toBe("handleSwap");
+    expect(result.buttonText).toBe("Swap");
+  });
+
+  it("defers to handleSwap for an unloaded injected wallet too", () => {
+    mockUsePrivy.mockReturnValue({ authenticated: false });
+    mockUseInjectedWallet.mockReturnValue({
+      isInjectedWallet: true,
+      injectedReady: true,
+      injectedRequested: true,
+      injectedStatus: "connected",
+    });
+
+    const result = setup({ hasLoadedStatus: false, kycTier: 0 });
+
+    expect(actionNameOf(result)).toBe("handleSwap");
+    expect(result.buttonText).toBe("Swap");
+  });
+
+  it("opens phone verification once status is loaded and the user is tier 0", () => {
+    const result = setup({ hasLoadedStatus: true, kycTier: 0 });
+
+    expect(actionNameOf(result)).toBe("openPhoneVerification");
+    expect(result.buttonText).toBe("Get started");
+  });
+
+  it("labels a returning tier-0 wallet 'Swap' but still opens phone verification", () => {
+    const result = setup({
+      hasLoadedStatus: true,
+      kycTier: 0,
+      hasPriorTransactionActivity: true,
+    });
+
+    expect(actionNameOf(result)).toBe("openPhoneVerification");
+    expect(result.buttonText).toBe("Swap");
+  });
+
+  it("opens the limit modal when phone is verified but the tier is capped", () => {
+    const result = setup({
+      hasLoadedStatus: true,
+      kycTier: 1,
+      isPhoneVerified: true,
+    });
+
+    expect(actionNameOf(result, { isPhoneVerified: true })).toBe(
+      "openLimitModal",
+    );
+  });
+
+  it("swaps at max tier — there is nothing left to verify", () => {
+    const result = setup({
+      hasLoadedStatus: true,
+      kycTier: 3,
+      isPhoneVerified: true,
+    });
+
+    expect(actionNameOf(result, { isPhoneVerified: true })).toBe("handleSwap");
+    expect(result.buttonText).toBe("Swap");
+  });
+
+  it("keeps pre-existing behavior when hasLoadedStatus is omitted", () => {
+    // Defaults to loaded so callers that don't pass KYC state are unaffected.
+    const result = setup({ kycTier: 0 });
+
+    expect(actionNameOf(result)).toBe("openPhoneVerification");
+  });
+
+  it("still swaps when the user is already verified", () => {
+    const result = setup({ isUserVerified: true, hasLoadedStatus: false });
+
+    expect(actionNameOf(result, { isUserVerified: true })).toBe("handleSwap");
+    expect(result.buttonText).toBe("Swap");
+  });
+});

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -943,6 +943,9 @@ export function MainPageContent() {
               clearFormState(formMethods);
               setSelectedRecipient(null);
               setActiveOrderIsOnramp(false);
+              // Starting a new payment must not inherit the finished order's virtual
+              // account, which would otherwise resurface the "Make payment" step.
+              setOnrampPaymentAccount(null);
             }}
             clearTransactionStatus={() => {
               setTransactionStatus("idle");
@@ -972,6 +975,7 @@ export function MainPageContent() {
     setTransactionStatus,
     setCurrentStep,
     setOrderId,
+    setOnrampPaymentAccount,
     activeOrderIsOnramp,
   ]);
 

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useState,
   useEffect,
+  useLayoutEffect,
   useRef,
   Suspense,
 } from "react";
@@ -147,7 +148,14 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   // current address without taking it as an effect dependency (that would resubscribe the
   // provider listener on every account change).
   const injectedAddressRef = useRef<string | null>(null);
-  injectedAddressRef.current = injectedAddress;
+  // Synced in a layout effect, not during render: a render can be discarded or replayed, and
+  // mutating a ref directly in the render body would leak that discarded value into the
+  // listener. Layout effects for this commit all run before the accountsChanged subscription
+  // effect below (layout effects run before passive effects, regardless of declaration order),
+  // so the ref is always current by the time the listener could possibly fire.
+  useLayoutEffect(() => {
+    injectedAddressRef.current = injectedAddress;
+  }, [injectedAddress]);
   const [injectedProvider, setInjectedProvider] = useState<any | null>(null);
   const [injectedReady, setInjectedReady] = useState(false);
   const [injectedStatus, setInjectedStatus] =
@@ -397,7 +405,11 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!injectedProvider?.on) return;
     const handleAccountsChanged = (accounts: unknown) => {
-      const [address] = (accounts as string[]) ?? [];
+      const [rawAddress] = (accounts as string[]) ?? [];
+      // Normalize once: resolveAccountsChangedAction treats whitespace-only as a disconnect, so
+      // every branch below must key off the same normalized value or a "disconnected"
+      // classification could still be treated as a truthy (connected) address.
+      const address = rawAddress?.trim() || null;
       // A real account switch invalidates the SIWE session — the token asserts the OLD
       // address's identity, so the next authed action re-prompts. A re-emit of the account we
       // already hold (reconnect, tab refocus, different casing) is not a switch: dropping the

--- a/app/context/InjectedWalletContext.tsx
+++ b/app/context/InjectedWalletContext.tsx
@@ -70,6 +70,35 @@ export function resolveInjectedTokenAction(params: {
   return interactive ? "start-sign-in" : "no-session";
 }
 
+/**
+ * How to react to an `accountsChanged` event, given the address we already hold.
+ *
+ * Hosts re-emit `accountsChanged` for reasons that are not account switches — reconnects, tab
+ * refocus, a wagmi/AppKit host re-binding — and may report the same account with different
+ * casing. Treating those as switches used to drop the SIWE session (forcing a needless re-sign)
+ * and change the address string, which resets every wallet-keyed cache including KYC status.
+ * The session only ever asserts the lowercased address, so same-address re-emits can keep it.
+ */
+export function resolveAccountsChangedAction(
+  previousAddress: string | null,
+  nextAddress: string | null | undefined,
+): {
+  kind: "unchanged" | "switched" | "disconnected";
+  clearSession: boolean;
+  setAddress: boolean;
+} {
+  const next = nextAddress?.trim();
+  if (!next) {
+    return { kind: "disconnected", clearSession: true, setAddress: true };
+  }
+  const isSameAccount =
+    !!previousAddress &&
+    previousAddress.trim().toLowerCase() === next.toLowerCase();
+  return isSameAccount
+    ? { kind: "unchanged", clearSession: false, setAddress: false }
+    : { kind: "switched", clearSession: true, setAddress: true };
+}
+
 interface InjectedWalletContextType {
   isInjectedWallet: boolean;
   injectedAddress: string | null;
@@ -114,6 +143,11 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
   const { parentOrigin, parentOriginResolved } = useEmbed();
   const [isInjectedWallet, setIsInjectedWallet] = useState(false);
   const [injectedAddress, setInjectedAddress] = useState<string | null>(null);
+  // Mirrors injectedAddress for the accountsChanged listener, which must compare against the
+  // current address without taking it as an effect dependency (that would resubscribe the
+  // provider listener on every account change).
+  const injectedAddressRef = useRef<string | null>(null);
+  injectedAddressRef.current = injectedAddress;
   const [injectedProvider, setInjectedProvider] = useState<any | null>(null);
   const [injectedReady, setInjectedReady] = useState(false);
   const [injectedStatus, setInjectedStatus] =
@@ -364,11 +398,21 @@ function InjectedWalletProviderContent({ children }: { children: ReactNode }) {
     if (!injectedProvider?.on) return;
     const handleAccountsChanged = (accounts: unknown) => {
       const [address] = (accounts as string[]) ?? [];
-      // Any account change invalidates the SIWE session — the token asserts
-      // the OLD address's identity. The next authed action re-prompts.
-      sessionRef.current = null;
+      // A real account switch invalidates the SIWE session — the token asserts the OLD
+      // address's identity, so the next authed action re-prompts. A re-emit of the account we
+      // already hold (reconnect, tab refocus, different casing) is not a switch: dropping the
+      // session there costs the user a signature and resets every wallet-keyed cache.
+      const action = resolveAccountsChangedAction(
+        injectedAddressRef.current,
+        address,
+      );
+      if (action.clearSession) {
+        sessionRef.current = null;
+      }
       if (address) {
-        setInjectedAddress(address);
+        if (action.setAddress) {
+          setInjectedAddress(address);
+        }
         setInjectedReady(true);
         setInjectedStatus("connected");
       } else {

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -23,6 +23,13 @@ interface UseSwapButtonProps {
   isPhoneVerified?: boolean;
   /** Current KYC tier (0–3); used when phone is done but swap is blocked by limits. */
   kycTier?: number;
+  /**
+   * Whether a KYC status fetch has actually succeeded for the current wallet. Until it has, the
+   * tier/phone values below are the reset defaults, which read identically to "unverified" — so
+   * a verified user whose status hasn't loaded (e.g. the injected SIWE session lapsed) would be
+   * sent back to phone verification. Defaults to true so callers without KYC keep their behavior.
+   */
+  hasLoadedStatus?: boolean;
   rate?: number | null;
   isSwapped?: boolean; // true when in onramp mode (fiat in Send, token in Receive)
   /** Selected chain name for on-ramp wallet validation (e.g. Base, Starknet). */
@@ -38,6 +45,7 @@ export function useSwapButton({
   hasPriorTransactionActivity = false,
   isPhoneVerified = false,
   kycTier = 0,
+  hasLoadedStatus = true,
   rate,
   isSwapped = false,
   networkName = "",
@@ -166,6 +174,11 @@ export function useSwapButton({
       (authenticated || isInjectedWallet) &&
       amountSent > 0
     ) {
+      // Status not loaded yet: unknown, not unverified. Naming a verification step here would
+      // greet a returning verified user as a newcomer; handleSwap resolves the real status.
+      if (!hasLoadedStatus) {
+        return "Swap";
+      }
       // Not on Tier 1 yet: start phone verification (not "Increase limit").
       if (kycTier < 1 || !isPhoneVerified) {
         // Existing wallets show "Swap" (tapping still opens phone verification);
@@ -203,6 +216,12 @@ export function useSwapButton({
       return handleFundWallet;
     }
     if (!hasInsufficientBalance && !isUserVerified && (authenticated || isInjectedWallet)) {
+      // Status unknown (never loaded for this wallet): defer to handleSwap, which refreshes —
+      // re-establishing the injected session if needed — before choosing a verification step.
+      // Opening the phone modal from here would bypass that refresh entirely.
+      if (!hasLoadedStatus) {
+        return handleSwap;
+      }
       // Tier 1 onboarding: phone modal. Active tier at cap: limit or ID/address upgrade.
       if (kycTier < 1 || !isPhoneVerified) {
         return openPhoneVerification;

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -129,6 +129,7 @@ export const TransactionForm = ({
     injectedAddress,
     injectedReady,
     connectInjectedWallet,
+    getInjectedToken,
   } = useInjectedWallet();
   // Privy `authenticated` is false in injected mode (extension or embed
   // bridge) — balance display and over-balance validation must treat a ready
@@ -153,6 +154,7 @@ export const TransactionForm = ({
     getKycStatusSnapshot,
     isPhoneVerified,
     tier,
+    hasLoadedStatus,
     phoneNumber,
     transactionSummary,
   } = useKYC();
@@ -860,6 +862,7 @@ export const TransactionForm = ({
     isPhoneVerified,
     hasPriorTransactionActivity,
     kycTier: tier,
+    hasLoadedStatus,
     rate,
     isSwapped,
     networkName: selectedNetwork.chain.name,
@@ -923,6 +926,19 @@ export const TransactionForm = ({
       // status fetch failed or hasn't landed yet. Load the real status once, then re-decide.
       await refreshStatus(true);
       kyc = getKycStatusSnapshot();
+
+      if (!kyc.hasLoadedStatus && isInjectedWallet && injectedReady) {
+        // Background KYC fetches are non-interactive, so they cannot recover a lapsed injected
+        // session on their own — the status would stay unknown forever and every swap would ask
+        // for phone verification again. This tap is a user gesture, so prompt for the SIWE
+        // signature once, then retry. Declining just falls through to the checks below.
+        const token = await getInjectedToken({ interactive: true });
+        if (token) {
+          await refreshStatus(true);
+          kyc = getKycStatusSnapshot();
+        }
+      }
+
       limitCheck = canTransact(usdAmount);
     }
 

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -887,13 +887,18 @@ export const TransactionForm = ({
     // The identity, not the wallet, satisfies this: a wallet that inherited its tier through
     // the ID triple may hold no phone itself while a sibling wallet verified one, and
     // re-verifying that number would be rejected as already in use — an unsatisfiable loop.
-    if (kyc.tier >= 2) {
-      const hasPhone =
-        Boolean(kyc.phoneNumber?.trim()) || kyc.identityHasVerifiedPhone;
-      if (!hasPhone && !resumingAfterPhoneVerification) {
-        setIsTier2PhoneGateOpen(true);
-        return;
-      }
+    // Defined as a closure over `kyc` (declared with `let`) and re-checked further down after
+    // the status refresh below: an unloaded snapshot reads as tier 0 and would otherwise let
+    // this gate be skipped here, then silently satisfied once the refresh reveals a real
+    // tier-2-no-phone identity.
+    const blockedByTier2PhoneGate = () =>
+      kyc.tier >= 2 &&
+      !(Boolean(kyc.phoneNumber?.trim()) || kyc.identityHasVerifiedPhone) &&
+      !resumingAfterPhoneVerification;
+
+    if (blockedByTier2PhoneGate()) {
+      setIsTier2PhoneGateOpen(true);
+      return;
     }
 
     setOrderId("");
@@ -931,7 +936,7 @@ export const TransactionForm = ({
         // Background KYC fetches are non-interactive, so they cannot recover a lapsed injected
         // session on their own — the status would stay unknown forever and every swap would ask
         // for phone verification again. This tap is a user gesture, so prompt for the SIWE
-        // signature once, then retry. Declining just falls through to the checks below.
+        // signature once, then retry. Declining just falls through to the check below.
         const token = await getInjectedToken({ interactive: true });
         if (token) {
           await refreshStatus(true);
@@ -939,7 +944,22 @@ export const TransactionForm = ({
         }
       }
 
+      if (!kyc.hasLoadedStatus) {
+        // Status genuinely could not be loaded (signature declined, or the fetch kept
+        // failing). Treating the reset defaults as "unverified" here is exactly the loop this
+        // recovery path exists to close — surface a retryable error instead of guessing.
+        toast.error("Couldn't verify your account status. Please try again.");
+        return;
+      }
+
       limitCheck = canTransact(usdAmount);
+    }
+
+    // Re-check with whatever `kyc` now is (refreshed above, or unchanged if the limit already
+    // allowed the amount at the first read) — see the comment on blockedByTier2PhoneGate.
+    if (blockedByTier2PhoneGate()) {
+      setIsTier2PhoneGateOpen(true);
+      return;
     }
 
     if (!limitCheck.allowed) {

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -133,6 +133,7 @@ export function TransactionStatus({
   createdAt,
   setTransactionStatus,
   setCurrentStep,
+  clearForm,
   clearTransactionStatus,
   formMethods,
   supportedInstitutions,
@@ -1132,16 +1133,33 @@ export function TransactionStatus({
 
   /**
    * Handles the back button click event.
-   * Clears the transaction status if it's refunded, otherwise clears the form and transaction status.
+   *
+   * "Retry transaction" (refunded/expired) keeps the form values so the user can resubmit.
+   * "New payment" (success) starts a clean order — it used to `window.location.reload()`, but a
+   * reload destroys the injected wallet's SIWE session (memory-only by design, see
+   * InjectedWalletContext), which signed embed users out and left KYC unable to reload, so the
+   * form then treated a verified user as unverified. Reset in-app instead: this component
+   * unmounts on the step change, so only shared state needs clearing here.
    */
   const handleBackButtonClick = () => {
     if (transactionStatus === "refunded" || transactionStatus === "expired") {
       refetchRate?.();
       clearTransactionStatus();
       setCurrentStep(STEPS.FORM);
-    } else {
-      window.location.reload();
+      return;
     }
+
+    clearForm();
+    clearTransactionStatus();
+    setOrderId("");
+    setRocketStatus("pending");
+    try {
+      // Pinned per order; a stale id must not follow the next one into status updates.
+      localStorage.removeItem("currentTransactionId");
+    } catch {
+      // Storage can be unavailable (private mode / blocked) — nothing else depends on this.
+    }
+    setCurrentStep(STEPS.FORM);
   };
 
   const handleAddToBeneficiariesChange = async (checked: boolean) => {


### PR DESCRIPTION
### Description

Two bugs reported from the Textile partner embed (injected external wallet + SIWE session auth), both occurring right after a completed transaction:

- **"After a transaction, when I click 'New payment', it signs out."** The widget fell back to a "Sign in" button while the host page's wallet pill still showed connected.
- **"It's requesting phone number verification after first transaction."** For a user who had already verified.

These turned out to be one causal chain, not two unrelated bugs:

1. The transaction-status screen's success path ("New payment") called `window.location.reload()`. The refunded/expired path ("Retry transaction") already did an in-app reset instead.
2. The injected wallet's SIWE session is memory-only by design (a documented tradeoff — nothing persisted for theft). The reload destroyed it, and the reloaded iframe could even fail its handshake outright and land on `injectedStatus: "unavailable"` → the Sign in button. The visible wallet pill was the host page's own UI; only the widget's session had died.
3. With no session, KYC status couldn't authenticate (background fetches are intentionally non-interactive), so the snapshot stayed at the reset default — tier 0, phone unverified.
4. The swap CTA's phone-verification branch read that tier/phone state directly and never checked whether a status fetch had actually succeeded, so "unknown" was indistinguishable from "unverified" — it opened the phone modal directly, bypassing the form's own submit-time refresh guard entirely.
5. Contributing: the injected wallet context dropped the SIWE session on *any* `accountsChanged` event, including a host re-emitting the same account (reconnect, tab refocus) — costing an extra signature, and in the case of a checksum/lowercase casing flip, also resetting every wallet-keyed cache including KYC.

### Changes

- **`app/pages/TransactionStatus.tsx`, `app/components/MainPageContent.tsx`** — "New payment" now resets in-app instead of reloading the page, mirroring the existing refunded/expired path. The status screen unmounts on step change, so only shared state needed clearing: form/recipient (via the `clearForm` prop, which existed but was never wired up), transaction status, order id, the rocket indicator, and the per-order `currentTransactionId` key. `clearForm` also now clears the onramp payment account so a finished order's virtual account can't resurface the "Make payment" step. Applied to all modes, not just the embed — the soft-reset path was already proven by the refunded/expired branch.
- **`app/hooks/useSwapButton.ts`, `app/pages/TransactionForm.tsx`** — a new `hasLoadedStatus` flag (defaulting to `true` for existing callers) makes the CTA defer to the normal swap/refresh path instead of jumping to the phone modal while KYC status is still unknown. Since background KYC fetches can't recover a lapsed injected session on their own, the swap handler now prompts once for a SIWE signature (within the user's tap) if the silent refresh comes back empty, then retries before deciding.
- **`app/context/InjectedWalletContext.tsx`** — `accountsChanged` only clears the session and updates the stored address when the account actually changed (compared case-insensitively); a same-account re-emit is a no-op. The stored address keeps its original casing since SIWE signing and display want it — only the comparison is normalized.

### Out of scope (filed as follow-ups, not implemented here)

- Persisting the SIWE token (e.g. sessionStorage) — would reverse a documented security decision; these fixes remove the need for it.
- Hardening the bridge handshake itself against a *host-page* reload (referrer loss, extension-injection race, ACK timeout) — a host-triggered iframe reload can still hit this independently of the app-side fixes here.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

Added `__tests__/useSwapButton.test.tsx` (CTA action/label across loaded/unloaded status, tiers, and injected vs. Privy) and `__tests__/resolveAccountsChangedAction.test.ts` (same-account re-emit, casing, whitespace, real switch, disconnect), following the existing `resolveInjectedTokenAction.test.ts` pattern of extracting the decision into a pure, testable function.

Full suite: `npx jest` — 278 passed. `npx tsc --noEmit` and `next lint` clean.

Manual verification not yet possible from this environment (no way to drive the actual Textile embed / injected wallet handshake); recommend before merge:
- Embed, `?injected=bridge`: complete an off-ramp → "New payment" → form step, no Sign in button, no re-sign prompt; start a second payment → straight to preview, no phone modal.
- Refunded/expired path still keeps form values on "Retry transaction" (unchanged branch).
- Non-embed Privy: complete a transaction → New payment → clean form, still authenticated, transaction present in history (this flow no longer reloads the page — worth a regression look since that's a long-standing behavior change).
- Host re-emits `accountsChanged` for the same account (tab refocus) → no re-sign on the next authenticated action.

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] N/A — no database migration in this PR

https://claude.ai/code/session_019FVH15Dsqay4qpRfwTeyov

---
_Generated by [Claude Code](https://claude.ai/code/session_019FVH15Dsqay4qpRfwTeyov)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Wallet account “accountsChanged” handling now properly differentiates unchanged re-emits (case/whitespace-insensitive), switched accounts, and disconnections, with correct session clearing.
  - Completed payment flows no longer carry over the previous payment account.
  - Returning from transaction status now resets the form/state without a full page reload (including safer local storage cleanup).
  - Swap CTA behavior is safer when verification/KYC status is not loaded, and the swap flow re-checks limits/eligibility after refreshing KYC when needed.
- **Tests**
  - Added coverage for account-change resolution and swap-button CTA logic across KYC/verification states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->