### PR TITLE
main → stable

### DIFF
--- a/__tests__/fetchMarkets.test.ts
+++ b/__tests__/fetchMarkets.test.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /v2/markets client: envelope tolerance, caching and request dedupe.
+ *
+ * The exact response envelope is not pinned down by a contract we control, so
+ * these tests fix the shapes the parser must survive — and prove an
+ * unrecognized shape degrades to "unknown" rather than throwing.
+ */
+import axios from "axios";
+
+import { fetchMarkets } from "../app/api/aggregator";
+
+jest.mock("axios");
+
+const mockedGet = axios.get as jest.MockedFunction<typeof axios.get>;
+// The real module reads this at import time via config.
+const OFFER = { min: 1, max: 100, balance: 100, rate: 1500 };
+
+/** Each test uses a fresh corridor so the module-level cache never bleeds over. */
+let corridor = 0;
+function nextCorridor() {
+  corridor += 1;
+  return {
+    side: "buy" as const,
+    token: `TOK${corridor}`,
+    currency: "NGN",
+    network: "base",
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (axios as unknown as { isAxiosError: () => boolean }).isAxiosError = () =>
+    false;
+});
+
+describe("fetchMarkets envelope parsing", () => {
+  it("reads a standard { data: [...] } envelope", async () => {
+    mockedGet.mockResolvedValue({
+      data: { status: "success", message: "ok", data: [OFFER] },
+    } as never);
+
+    await expect(fetchMarkets(nextCorridor())).resolves.toEqual([OFFER]);
+  });
+
+  it("reads a bare array response", async () => {
+    mockedGet.mockResolvedValue({ data: [OFFER] } as never);
+
+    await expect(fetchMarkets(nextCorridor())).resolves.toEqual([OFFER]);
+  });
+
+  it("reads the live shape, where the book sits beside metadata", async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        status: "success",
+        message: "OK",
+        data: {
+          asOf: "2026-07-28T03:12:14Z",
+          aggregates: { corridors: 4, tokens: 3, networks: 8 },
+          book: [OFFER],
+        },
+      },
+    } as never);
+
+    await expect(fetchMarkets(nextCorridor())).resolves.toEqual([OFFER]);
+  });
+
+  it("returns an empty book for an unrecognized shape instead of throwing", async () => {
+    mockedGet.mockResolvedValue({ data: { status: "success" } } as never);
+
+    await expect(fetchMarkets(nextCorridor())).resolves.toEqual([]);
+  });
+
+  it("surfaces an error envelope as a rejection", async () => {
+    mockedGet.mockResolvedValue({
+      data: { status: "error", message: "corridor disabled" },
+    } as never);
+
+    await expect(fetchMarkets(nextCorridor())).rejects.toThrow(
+      "corridor disabled",
+    );
+  });
+
+  it("sends the corridor as query params and omits network when absent", async () => {
+    mockedGet.mockResolvedValue({ data: { data: [] } } as never);
+    const { network, ...withoutNetwork } = nextCorridor();
+
+    await fetchMarkets(withoutNetwork);
+
+    expect(mockedGet).toHaveBeenCalledWith(
+      expect.stringContaining("/v2/markets"),
+      expect.objectContaining({
+        params: {
+          side: "buy",
+          fiat: "NGN",
+          token: withoutNetwork.token,
+        },
+      }),
+    );
+  });
+});
+
+describe("fetchMarkets caching", () => {
+  it("serves a repeat call for the same corridor from cache", async () => {
+    mockedGet.mockResolvedValue({ data: { data: [OFFER] } } as never);
+    const payload = nextCorridor();
+
+    await fetchMarkets(payload);
+    await fetchMarkets(payload);
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share a result across corridors", async () => {
+    mockedGet.mockResolvedValue({ data: { data: [OFFER] } } as never);
+
+    await fetchMarkets(nextCorridor());
+    await fetchMarkets(nextCorridor());
+
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses concurrent callers onto one request", async () => {
+    mockedGet.mockResolvedValue({ data: { data: [OFFER] } } as never);
+    const payload = nextCorridor();
+
+    await Promise.all([fetchMarkets(payload), fetchMarkets(payload)]);
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failure", async () => {
+    const payload = nextCorridor();
+    mockedGet.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(fetchMarkets(payload)).rejects.toThrow("boom");
+
+    mockedGet.mockResolvedValue({ data: { data: [OFFER] } } as never);
+    await expect(fetchMarkets(payload)).resolves.toEqual([OFFER]);
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/marketLiquidity.test.ts
+++ b/__tests__/marketLiquidity.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Fillable-range math derived from the aggregator order book (GET /v2/markets).
+ */
+import {
+  computeLiquidityEnvelope,
+  envelopesEqual,
+  fillableQuoteAmount,
+  filterOffersForCorridor,
+  isAmountFillable,
+  liquidityMaxMessage,
+  liquidityMinMessage,
+  nearestFillableAmount,
+  nearestFillableMessage,
+  noLiquidityMessage,
+  type LiquidityCorridor,
+} from "../app/lib/marketLiquidity";
+
+const BUY_NGN_BASE: LiquidityCorridor = {
+  side: "buy",
+  token: "CNGN",
+  currency: "NGN",
+  network: "base",
+};
+const SELL_NGN_BASE: LiquidityCorridor = {
+  side: "sell",
+  token: "USDC",
+  currency: "NGN",
+  network: "base",
+};
+
+/**
+ * Verbatim from GET /v2/markets — the corridor behind the reported
+ * "no provider available" toast for ~2,999,400 cNGN on Base.
+ */
+const CNGN_BUY_BASE = {
+  providerId: "LJByJEHF",
+  side: "buy",
+  token: "CNGN",
+  fiat: "NGN",
+  network: "base",
+  rate: "1.0002",
+  rateType: "fixed",
+  min: "900",
+  max: "10000000",
+  minFlatFee: "100",
+  maxFlatFee: "1000",
+  balance: "2995066.125456",
+  balanceCurrency: "CNGN",
+  balanceUsd: "2140.6020179506421664",
+};
+
+/** Fills in the corridor fields so a fixture only states what it is testing. */
+function offer(
+  corridor: LiquidityCorridor,
+  fields: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    side: corridor.side,
+    token: corridor.token,
+    fiat: corridor.currency,
+    network: corridor.network,
+    ...fields,
+  };
+}
+
+describe("filterOffersForCorridor", () => {
+  // Unfiltered, the endpoint serves every corridor in one array; this is what
+  // stops another corridor's depth being read as this one's if a request
+  // filter is ever dropped.
+  const book = [
+    offer(BUY_NGN_BASE, { min: 900, max: 10_000_000 }),
+    offer(SELL_NGN_BASE, { min: 250, max: 2000 }),
+    offer(
+      { side: "buy", token: "CNGN", currency: "NGN", network: "polygon" },
+      { min: 1, max: 2 },
+    ),
+    offer(
+      { side: "buy", token: "USDC", currency: "NGN", network: "base" },
+      { min: 1, max: 2 },
+    ),
+    offer(
+      { side: "buy", token: "CNGN", currency: "KES", network: "base" },
+      { min: 1, max: 2 },
+    ),
+  ];
+
+  it("keeps only rows matching side, token, fiat and network", () => {
+    const filtered = filterOffersForCorridor(book, BUY_NGN_BASE);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]).toMatchObject({ min: 900 });
+  });
+
+  it("matches codes case-insensitively", () => {
+    const filtered = filterOffersForCorridor(
+      [offer(BUY_NGN_BASE, { token: "cngn", network: "Base", min: 5, max: 9 })],
+      BUY_NGN_BASE,
+    );
+    expect(filtered).toHaveLength(1);
+  });
+});
+
+describe("computeLiquidityEnvelope", () => {
+  it("returns null for an empty book so callers keep their static limits", () => {
+    expect(computeLiquidityEnvelope([], BUY_NGN_BASE)).toBeNull();
+  });
+
+  it("reports non-viable when the book has rows but none for this corridor", () => {
+    const book = [offer(SELL_NGN_BASE, { min: 250, max: 2000, rate: 1386.2 })];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      viable: false,
+      min: null,
+      max: null,
+    });
+  });
+
+  it("ignores other corridors when computing the band", () => {
+    const book = [
+      offer(BUY_NGN_BASE, {
+        min: 900,
+        max: 5000,
+        balance: 5000,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+      // Far deeper, but a different network — must not raise this ceiling.
+      offer(
+        { side: "buy", token: "CNGN", currency: "NGN", network: "polygon" },
+        {
+          min: 900,
+          max: 9_000_000,
+          balance: 9_000_000,
+          balanceCurrency: "CNGN",
+          rate: 1,
+        },
+      ),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)?.max).toBe(5000);
+  });
+
+  it("caps a buy by the provider's token balance", () => {
+    const book = [
+      offer(BUY_NGN_BASE, {
+        min: 10,
+        max: 1_000_000,
+        balance: 2000,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)?.max).toBe(2000);
+  });
+
+  it("converts a fiat-denominated sell balance into token units", () => {
+    // balance is NGN on sell rows; 1,386,200 NGN / 1386.2 = 1000 USDC.
+    const book = [
+      offer(SELL_NGN_BASE, {
+        min: 250,
+        max: 2000,
+        balance: 1_386_200,
+        balanceCurrency: "NGN",
+        rate: 1386.2,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, SELL_NGN_BASE)).toMatchObject({
+      viable: true,
+      min: 250,
+      max: 1000,
+    });
+  });
+
+  it("takes the envelope across providers rather than summing balances", () => {
+    const book = [
+      offer(BUY_NGN_BASE, {
+        providerId: "a",
+        min: 100,
+        max: 5000,
+        balance: 5000,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+      offer(BUY_NGN_BASE, {
+        providerId: "b",
+        min: 50,
+        max: 3000,
+        balance: 3000,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+    ];
+    // Not 8000: a single order is filled by a single provider.
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      min: 50,
+      max: 5000,
+      offerCount: 2,
+    });
+  });
+
+  it("does not let a high-rate small offer inflate the ceiling of a bigger one", () => {
+    const book = [
+      offer(BUY_NGN_BASE, {
+        min: 1,
+        max: 10,
+        balance: 10,
+        balanceCurrency: "CNGN",
+        rate: 100,
+      }),
+      offer(BUY_NGN_BASE, {
+        min: 1,
+        max: 5000,
+        balance: 5000,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      min: 1,
+      max: 5000,
+      bestRate: 1,
+    });
+  });
+
+  it("marks a corridor whose only offers exceed their float as non-viable", () => {
+    const book = [
+      offer(BUY_NGN_BASE, {
+        min: 1000,
+        max: 5000,
+        balance: 10,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      viable: false,
+    });
+  });
+
+  it("skips offers with an unusable rate but keeps the rest", () => {
+    const book = [
+      offer(BUY_NGN_BASE, { min: 1, max: 100, balance: 100, rate: 0 }),
+      offer(BUY_NGN_BASE, {
+        min: 2,
+        max: 200,
+        balance: 200,
+        balanceCurrency: "CNGN",
+        rate: 1,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      viable: true,
+      min: 2,
+      max: 200,
+      offerCount: 1,
+    });
+  });
+
+  it("rounds inward so an accepted amount stays fillable", () => {
+    const buy = computeLiquidityEnvelope(
+      [
+        offer(BUY_NGN_BASE, {
+          min: 1.2,
+          max: 100.9,
+          balance: 100.9,
+          balanceCurrency: "CNGN",
+          rate: 1,
+        }),
+      ],
+      BUY_NGN_BASE,
+    );
+    expect(buy).toMatchObject({ min: 2, max: 100 });
+
+    const sell = computeLiquidityEnvelope(
+      [
+        offer(SELL_NGN_BASE, {
+          min: 0.500009,
+          max: 10.99999,
+          balance: 1e9,
+          balanceCurrency: "NGN",
+          rate: 1,
+        }),
+      ],
+      SELL_NGN_BASE,
+    );
+    expect(sell).toMatchObject({ min: 0.5001, max: 10.9999 });
+  });
+
+  it("falls back to unknown when a buy band rounds away to nothing", () => {
+    // Sub-unit fiat bounds would floor to a zero ceiling; unknown is safer
+    // than telling the user the maximum is 0.
+    const book = [
+      offer(BUY_NGN_BASE, {
+        min: 0.0001,
+        max: 0.001,
+        balance: 1,
+        balanceCurrency: "CNGN",
+        rate: 0.1,
+      }),
+    ];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toBeNull();
+  });
+
+  it("ignores a missing balance instead of discarding the offer", () => {
+    const book = [offer(BUY_NGN_BASE, { min: 10, max: 500, rate: 1 })];
+    expect(computeLiquidityEnvelope(book, BUY_NGN_BASE)).toMatchObject({
+      viable: true,
+      max: 500,
+    });
+  });
+});
+
+describe("computeLiquidityEnvelope against live book rows", () => {
+  it("caps cNGN on Base at the provider's float, not the 10M order band", () => {
+    const envelope = computeLiquidityEnvelope([CNGN_BUY_BASE], BUY_NGN_BASE);
+
+    expect(envelope).toMatchObject({ viable: true, min: 901, max: 2_995_665 });
+    // The amount that failed at ValidateRate is now rejected by the form.
+    expect(2_999_400).toBeGreaterThan(envelope!.max!);
+  });
+
+  it("reports no liquidity for a corridor whose provider float is dust", () => {
+    // Every USDC/Base buy band from this provider sits above its 0.039 USDC float.
+    const rows = [
+      { min: "0.5", max: "2", rate: "1414.17" },
+      { min: "2.000999", max: "7", rate: "1411.17" },
+      { min: "100.000999", max: "500", rate: "1406.17" },
+    ].map((band) => ({
+      providerId: "FZvfAEyg",
+      side: "buy",
+      token: "USDC",
+      fiat: "NGN",
+      network: "base",
+      balance: "0.039659",
+      balanceCurrency: "USDC",
+      ...band,
+    }));
+
+    const envelope = computeLiquidityEnvelope(rows, {
+      side: "buy",
+      token: "USDC",
+      currency: "NGN",
+      network: "base",
+    });
+
+    expect(envelope).toMatchObject({ viable: false });
+  });
+
+  it("reads a real sell row's fiat balance as a token cap", () => {
+    const row = {
+      providerId: "kVMyxKfB",
+      side: "sell",
+      token: "USDC",
+      fiat: "NGN",
+      network: "base",
+      rate: "1386.2",
+      min: "250",
+      max: "2000",
+      balance: "84489679.9110991",
+      balanceCurrency: "NGN",
+    };
+
+    // 84,489,679 NGN of float is far more than the 2000 USDC band allows.
+    expect(computeLiquidityEnvelope([row], SELL_NGN_BASE)).toMatchObject({
+      viable: true,
+      min: 250,
+      max: 2000,
+    });
+  });
+});
+
+describe("fillable segments", () => {
+  const buyBand = (band: Record<string, unknown>) =>
+    offer(BUY_NGN_BASE, { balanceCurrency: "CNGN", rate: 1, ...band });
+
+  it("merges a provider's own tiled bands into one run", () => {
+    // The aggregator tiles bands with a hairline gap so they do not overlap;
+    // those seams are not holes and must not be reported as such.
+    const rows = [
+      { min: 0.5, max: 2 },
+      { min: 2.000999, max: 7 },
+      { min: 7.000999, max: 20 },
+      { min: 20.000999, max: 100 },
+      { min: 100.000999, max: 500 },
+    ].map((band) => buyBand({ ...band, balance: 500 }));
+
+    const envelope = computeLiquidityEnvelope(rows, BUY_NGN_BASE);
+
+    expect(envelope?.segments).toEqual([{ min: 1, max: 500 }]);
+    [1, 2, 3, 50, 250, 500].forEach((amount) =>
+      expect(isAmountFillable(envelope, amount)).toBe(true),
+    );
+  });
+
+  it("reports a genuine hole between two providers as separate runs", () => {
+    const rows = [
+      buyBand({ providerId: "a", min: 0.5, max: 2, balance: 2 }),
+      buyBand({ providerId: "b", min: 100, max: 500, balance: 500 }),
+    ];
+
+    const envelope = computeLiquidityEnvelope(rows, BUY_NGN_BASE);
+
+    expect(envelope).toMatchObject({ viable: true, min: 1, max: 500 });
+    expect(envelope?.segments).toEqual([
+      { min: 1, max: 2 },
+      { min: 100, max: 500 },
+    ]);
+    // Inside [min, max] but no single provider covers it.
+    expect(isAmountFillable(envelope, 50)).toBe(false);
+  });
+
+  it("keeps a narrow hole between large bands intact", () => {
+    // A join that scales with the numbers would swallow this 5,000-wide hole
+    // simply because the bands are large.
+    const rows = [
+      buyBand({ providerId: "a", min: 1, max: 1_000_000, balance: 1_000_000 }),
+      buyBand({
+        providerId: "b",
+        min: 1_005_000,
+        max: 2_000_000,
+        balance: 2_000_000,
+      }),
+    ];
+
+    const envelope = computeLiquidityEnvelope(rows, BUY_NGN_BASE);
+
+    expect(envelope?.segments).toEqual([
+      { min: 1, max: 1_000_000 },
+      { min: 1_005_000, max: 2_000_000 },
+    ]);
+    expect(isAmountFillable(envelope, 1_002_500)).toBe(false);
+  });
+
+  it("prefers the larger band when a fractional amount is equidistant", () => {
+    // 0.3 is equidistant from 0.2 and 0.4 in decimal but not in binary.
+    const rows = [
+      offer(SELL_NGN_BASE, {
+        providerId: "a",
+        min: 0.1,
+        max: 0.2,
+        rate: 1000,
+        balance: 1e9,
+        balanceCurrency: "NGN",
+      }),
+      offer(SELL_NGN_BASE, {
+        providerId: "b",
+        min: 0.4,
+        max: 0.9,
+        rate: 1000,
+        balance: 1e9,
+        balanceCurrency: "NGN",
+      }),
+    ];
+
+    const envelope = computeLiquidityEnvelope(rows, SELL_NGN_BASE);
+
+    expect(envelope?.segments).toEqual([
+      { min: 0.1, max: 0.2 },
+      { min: 0.4, max: 0.9 },
+    ]);
+    expect(nearestFillableAmount(envelope, 0.3)).toBe(0.4);
+  });
+
+  it("names the nearest fillable amount across a hole", () => {
+    const envelope = computeLiquidityEnvelope(
+      [
+        buyBand({ providerId: "a", min: 0.5, max: 2, balance: 2 }),
+        buyBand({ providerId: "b", min: 100, max: 500, balance: 500 }),
+      ],
+      BUY_NGN_BASE,
+    );
+
+    expect(nearestFillableAmount(envelope, 10)).toBe(2);
+    expect(nearestFillableAmount(envelope, 90)).toBe(100);
+    // Equidistant between 2 and 100: prefer the larger, not a downgrade.
+    expect(nearestFillableAmount(envelope, 51)).toBe(100);
+    // Already fillable amounts come back untouched.
+    expect(nearestFillableAmount(envelope, 250)).toBe(250);
+    // Beyond the ceiling it steers to the ceiling.
+    expect(nearestFillableAmount(envelope, 9000)).toBe(500);
+  });
+
+  it("does not block when liquidity is unknown or non-viable", () => {
+    expect(isAmountFillable(null, 50)).toBe(true);
+    const nonViable = computeLiquidityEnvelope(
+      [offer(SELL_NGN_BASE, { min: 250, max: 2000, rate: 1386.2 })],
+      BUY_NGN_BASE,
+    );
+    expect(isAmountFillable(nonViable, 50)).toBe(true);
+    expect(nearestFillableAmount(nonViable, 50)).toBeNull();
+  });
+
+  it("keeps one run for a healthy corridor", () => {
+    const envelope = computeLiquidityEnvelope([CNGN_BUY_BASE], BUY_NGN_BASE);
+    expect(envelope?.segments).toHaveLength(1);
+  });
+});
+
+describe("envelopesEqual", () => {
+  const band = [
+    offer(BUY_NGN_BASE, {
+      min: 10,
+      max: 500,
+      balance: 500,
+      balanceCurrency: "CNGN",
+      rate: 1,
+    }),
+  ];
+  const base = computeLiquidityEnvelope(band, BUY_NGN_BASE);
+
+  it("treats identical bands as equal across polls", () => {
+    expect(
+      envelopesEqual(base, computeLiquidityEnvelope(band, BUY_NGN_BASE)),
+    ).toBe(true);
+  });
+
+  it("detects a moved ceiling", () => {
+    const moved = computeLiquidityEnvelope(
+      [
+        offer(BUY_NGN_BASE, {
+          min: 10,
+          max: 400,
+          balance: 400,
+          balanceCurrency: "CNGN",
+          rate: 1,
+        }),
+      ],
+      BUY_NGN_BASE,
+    );
+    expect(envelopesEqual(base, moved)).toBe(false);
+  });
+
+  it("handles nulls", () => {
+    expect(envelopesEqual(null, null)).toBe(true);
+    expect(envelopesEqual(base, null)).toBe(false);
+  });
+});
+
+describe("fillableQuoteAmount", () => {
+  // Sell corridor: Send units and query units are both the token, so the
+  // rescaled query equals the clamped Send amount.
+  const sellEnvelope = computeLiquidityEnvelope(
+    [
+      offer(SELL_NGN_BASE, {
+        rate: 1000,
+        min: 50,
+        max: 7500,
+        balance: 100_000_000,
+        balanceCurrency: "NGN",
+      }),
+    ],
+    SELL_NGN_BASE,
+  );
+
+  it("leaves a fillable amount alone", () => {
+    expect(fillableQuoteAmount(sellEnvelope, 1000, 1000)).toBe(1000);
+  });
+
+  it("quotes the ceiling instead of an amount above it", () => {
+    expect(fillableQuoteAmount(sellEnvelope, 9000, 9000)).toBe(7500);
+  });
+
+  it("quotes the floor instead of an amount below it", () => {
+    expect(fillableQuoteAmount(sellEnvelope, 0.2, 0.2)).toBe(50);
+  });
+
+  it("keeps the quote in token units when Send is fiat", () => {
+    // Buy: Send is fiat (1 CNGN per NGN here), the query is the token amount.
+    // 5,000 fiat clamps to 500, so a 5,000-token query scales by the same 1/10.
+    const buyEnvelope = computeLiquidityEnvelope(
+      [
+        offer(BUY_NGN_BASE, {
+          rate: 1,
+          min: 1,
+          max: 500,
+          balance: 500,
+          balanceCurrency: "CNGN",
+        }),
+      ],
+      BUY_NGN_BASE,
+    );
+
+    expect(fillableQuoteAmount(buyEnvelope, 5000, 5000)).toBe(500);
+  });
+
+  it("passes the amount through when the book is unknown", () => {
+    // An outage must not reshape the quote — that is the static-limit path.
+    expect(fillableQuoteAmount(null, 9000, 9000)).toBe(9000);
+  });
+
+  it("does not rescale away to zero", () => {
+    // A tiny query against a much smaller clamp would round to 0, which the
+    // aggregator rejects outright; the original stands instead.
+    expect(fillableQuoteAmount(sellEnvelope, 1_000_000_000, 0.0001)).toBe(
+      0.0001,
+    );
+  });
+
+  it("ignores a zero or absent Send amount", () => {
+    expect(fillableQuoteAmount(sellEnvelope, 0, 100)).toBe(100);
+  });
+});
+
+describe("copy", () => {
+  it("phrases limits as current availability, not standing rules", () => {
+    expect(liquidityMaxMessage(2_995_665, "buy", "NGN", "cNGN")).toBe(
+      "Up to ₦2,995,665 available right now",
+    );
+    expect(liquidityMaxMessage(8000, "sell", "NGN", "USDC")).toBe(
+      "Up to 8,000 USDC available right now",
+    );
+    expect(liquidityMinMessage(500, "buy", "NGN", "cNGN")).toBe(
+      "Minimum for available offers is ₦500",
+    );
+    expect(noLiquidityMessage("cNGN", "Base")).toBe(
+      "No liquidity available for cNGN on Base right now",
+    );
+    expect(nearestFillableMessage(100, "buy", "NGN", "cNGN")).toBe(
+      "Try ₦100 — the nearest amount available right now",
+    );
+  });
+});

--- a/__tests__/useSwapButton.test.tsx
+++ b/__tests__/useSwapButton.test.tsx
@@ -164,3 +164,157 @@ describe("useSwapButton KYC gating", () => {
     expect(result.buttonText).toBe("Swap");
   });
 });
+
+/** Off-ramp state that clears every gate, so only the liquidity band decides `isEnabled`. */
+function setupWithAmount(
+  formOverrides: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+) {
+  const watch = (() => ({ ...FORM_VALUES, ...formOverrides })) as never;
+  return renderHook(() =>
+    useSwapButton({
+      watch,
+      balance: 100_000_000,
+      isDirty: true,
+      isValid: true,
+      isUserVerified: true,
+      hasLoadedStatus: true,
+      rate: 1,
+      ...overrides,
+    }),
+  ).result.current;
+}
+
+describe("useSwapButton liquidity band", () => {
+  it("keeps pre-existing behavior when no band is supplied", () => {
+    expect(setupWithAmount({ amountSent: 100 }).isEnabled).toBe(true);
+    expect(setupWithAmount({ amountSent: 0.1 }).isEnabled).toBe(false);
+  });
+
+  it("blocks an off-ramp amount above what providers can fill", () => {
+    const amountBounds = { min: 1, max: 500, noLiquidity: false };
+
+    expect(setupWithAmount({ amountSent: 400 }, { amountBounds }).isEnabled).toBe(
+      true,
+    );
+    expect(setupWithAmount({ amountSent: 600 }, { amountBounds }).isEnabled).toBe(
+      false,
+    );
+  });
+
+  it("raises the off-ramp floor to the market minimum", () => {
+    const amountBounds = { min: 10, max: 500, noLiquidity: false };
+
+    // 5 clears the static 0.5 floor but not the live one.
+    expect(setupWithAmount({ amountSent: 5 }, { amountBounds }).isEnabled).toBe(
+      false,
+    );
+    expect(setupWithAmount({ amountSent: 20 }, { amountBounds }).isEnabled).toBe(
+      true,
+    );
+  });
+
+  it("enforces the band on on-ramp amounts too", () => {
+    const onramp = {
+      isSwapped: true,
+      networkName: "Base",
+      rate: 1500,
+    };
+    const formValues = {
+      walletAddress: "0x1234567890123456789012345678901234567890",
+    };
+    const amountBounds = { min: 1000, max: 2_000_000, noLiquidity: false };
+
+    expect(
+      setupWithAmount(
+        { ...formValues, amountSent: 1_000_000 },
+        { ...onramp, amountBounds },
+      ).isEnabled,
+    ).toBe(true);
+    expect(
+      setupWithAmount(
+        { ...formValues, amountSent: 3_000_000 },
+        { ...onramp, amountBounds },
+      ).isEnabled,
+    ).toBe(false);
+  });
+
+  it("disables the CTA when the corridor has no fillable offers", () => {
+    const result = setupWithAmount(
+      { amountSent: 100 },
+      { amountBounds: { min: 0.5, max: 10000, noLiquidity: true } },
+    );
+
+    expect(result.isEnabled).toBe(false);
+  });
+
+  it("does not offer 'Fund wallet' for a corridor with no liquidity", () => {
+    // The insufficient-balance branch otherwise enables unconditionally, on
+    // the theory that funding fixes it — but no balance fills an order when
+    // no provider serves this corridor at all.
+    const result = setupWithAmount(
+      { amountSent: 100 },
+      {
+        balance: 1,
+        amountBounds: { min: 0.5, max: 10000, noLiquidity: true },
+      },
+    );
+
+    expect(result.isEnabled).toBe(false);
+  });
+
+  it("enforces the static ceiling the form falls back to when liquidity is unknown", () => {
+    // The caller merges static limits into the bounds, so the CTA agrees with
+    // the field rule instead of enabling an amount the field has rejected.
+    const amountBounds = { min: 0.5, max: 10000, noLiquidity: false };
+
+    expect(
+      setupWithAmount({ amountSent: 5_000 }, { amountBounds }).isEnabled,
+    ).toBe(true);
+    expect(
+      setupWithAmount({ amountSent: 5_000_000 }, { amountBounds }).isEnabled,
+    ).toBe(false);
+  });
+
+  it("uses the cNGN floor the form computed rather than the bare 0.5 token floor", () => {
+    // 0.5 x cngnRate(1500); the divergence this prop exists to prevent.
+    const amountBounds = { min: 750, max: 50_000_000, noLiquidity: false };
+
+    expect(setupWithAmount({ amountSent: 100 }, { amountBounds }).isEnabled).toBe(
+      false,
+    );
+    expect(setupWithAmount({ amountSent: 800 }, { amountBounds }).isEnabled).toBe(
+      true,
+    );
+  });
+
+  it("rejects an amount falling in a hole between providers' bands", () => {
+    // Inside [min, max], but one order is filled by one provider and neither
+    // band covers 50.
+    const amountBounds = {
+      min: 1,
+      max: 500,
+      segments: [
+        { min: 1, max: 2 },
+        { min: 100, max: 500 },
+      ],
+      noLiquidity: false,
+    };
+
+    expect(setupWithAmount({ amountSent: 50 }, { amountBounds }).isEnabled).toBe(
+      false,
+    );
+    expect(setupWithAmount({ amountSent: 250 }, { amountBounds }).isEnabled).toBe(
+      true,
+    );
+  });
+
+  it("does not enforce segments when they are unknown", () => {
+    const result = setupWithAmount(
+      { amountSent: 50 },
+      { amountBounds: { min: 1, max: 500, noLiquidity: false } },
+    );
+
+    expect(result.isEnabled).toBe(true);
+  });
+});

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -4,6 +4,8 @@ import type {
   RateResponse,
   RateSide,
   V2RateQuoteResponse,
+  V2MarketOffer,
+  MarketsPayload,
   InstitutionProps,
   PubkeyResponse,
   VerifyAccountPayload,
@@ -450,6 +452,153 @@ export const fetchRate = async ({
     console.error("Error fetching rate:", error);
     throw error;
   }
+};
+
+// The order book is refreshed by a polling hook and can be read by more than
+// one consumer per tick; share one request and result so the poll interval
+// (not the consumer count) sets the request rate. The aggregator caches the
+// full book ~10s upstream, so a matching TTL here costs no freshness.
+const MARKETS_TTL_MS = 10 * 1000;
+/**
+ * The rate quote waits on the first book for a corridor, so this request has
+ * to fail rather than hang: a stalled connection would otherwise hold back the
+ * quote indefinitely. Failing lands on the unknown-book path, which quotes
+ * against the static limits exactly as before this feature existed.
+ */
+const MARKETS_TIMEOUT_MS = 8 * 1000;
+const marketsInFlight = new Map<string, Promise<V2MarketOffer[]>>();
+const marketsResult = new Map<string, { at: number; data: V2MarketOffer[] }>();
+
+function marketsCacheKey({ side, token, currency, network }: MarketsPayload) {
+  return `${side}:${token}:${currency}:${network || "*"}`;
+}
+
+/**
+ * Pulls the offer rows out of an aggregator response without assuming the
+ * exact envelope shape. The documented form is `data.book`, but a bare array
+ * or `data` as an array also resolve. An unrecognized shape yields `[]`,
+ * which callers treat as "unknown" and fall back to their static limits
+ * rather than blocking the user.
+ */
+function extractMarketOffers(raw: unknown): V2MarketOffer[] {
+  if (Array.isArray(raw)) return raw as V2MarketOffer[];
+  if (!raw || typeof raw !== "object") return [];
+
+  const container = raw as Record<string, unknown>;
+  if (Array.isArray(container.data)) return container.data as V2MarketOffer[];
+
+  const nested =
+    container.data && typeof container.data === "object"
+      ? (container.data as Record<string, unknown>)
+      : container;
+
+  for (const key of ["book", "offers", "markets"]) {
+    if (Array.isArray(nested[key])) return nested[key] as V2MarketOffer[];
+  }
+
+  const arrayValue = Object.values(nested).find((value) =>
+    Array.isArray(value),
+  );
+  return Array.isArray(arrayValue) ? (arrayValue as V2MarketOffer[]) : [];
+}
+
+/**
+ * Fetches the live provider order book for one corridor via aggregator **v2**.
+ * Used to derive the fillable amount range shown in the swap form; an empty
+ * result means "unknown", not "no liquidity".
+ */
+export const fetchMarkets = async (
+  payload: MarketsPayload,
+): Promise<V2MarketOffer[]> => {
+  const { side, token, currency, network, signal } = payload;
+  const key = marketsCacheKey(payload);
+
+  const cached = marketsResult.get(key);
+  if (cached && Date.now() - cached.at < MARKETS_TTL_MS) {
+    return cached.data;
+  }
+  const inFlight = marketsInFlight.get(key);
+  if (inFlight) return inFlight;
+
+  const startTime = Date.now();
+  const analyticsEndpoint = "/v2/markets";
+  const endpoint = `${aggregatorOriginForV2()}/v2/markets`;
+  const params: Record<string, string> = { side, fiat: currency, token };
+  if (network) params.network = network;
+
+  const request = (async () => {
+    try {
+      trackServerEvent("External API Request", {
+        service: "aggregator",
+        endpoint: analyticsEndpoint,
+        method: "GET",
+        token,
+        currency,
+        network: network ?? null,
+        side,
+      });
+
+      const response = await axios.get(endpoint, {
+        params,
+        signal,
+        timeout: MARKETS_TIMEOUT_MS,
+      });
+      const body = response.data as {
+        status?: string;
+        message?: string;
+        data?: unknown;
+      };
+
+      if (body?.status === "error") {
+        throw new Error(body.message || "Markets request failed");
+      }
+
+      const offers = extractMarketOffers(response.data);
+      marketsResult.set(key, { at: Date.now(), data: offers });
+
+      trackApiResponse(analyticsEndpoint, "GET", 200, Date.now() - startTime, {
+        service: "aggregator",
+        token,
+        currency,
+        network: network ?? null,
+        side,
+        offer_count: offers.length,
+      });
+
+      return offers;
+    } catch (error) {
+      const axiosPayloadMessage =
+        axios.isAxiosError(error) &&
+        error.response?.data &&
+        typeof (error.response.data as { message?: unknown }).message ===
+          "string"
+          ? (error.response.data as { message: string }).message
+          : null;
+
+      const errorMessage =
+        axiosPayloadMessage ??
+        (error instanceof Error ? error.message : "Unknown error");
+
+      trackServerEvent("External API Error", {
+        service: "aggregator",
+        endpoint: analyticsEndpoint,
+        method: "GET",
+        token,
+        currency,
+        network: network ?? null,
+        side,
+        error_message: errorMessage,
+        response_time_ms: Date.now() - startTime,
+      });
+
+      throw new Error(errorMessage);
+    } finally {
+      marketsInFlight.delete(key);
+    }
+  })();
+
+  marketsInFlight.set(key, request);
+  return request;
 };
 
 /**

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -35,7 +35,10 @@ import {
   initialSwapModeForHomeForm,
   swapModeFromSideParam,
   networkSupportsOnramp,
+  isOnrampFiatCurrencyCode,
 } from "../utils";
+import { useMarketLiquidity } from "../hooks/useMarketLiquidity";
+import { fillableQuoteAmount } from "../lib/marketLiquidity";
 import { toAggregatorToken } from "../lib/token-symbol";
 import { mapReportAndAct } from "../lib/toastMappedError";
 import { reportClientError } from "../lib/sentry.client";
@@ -323,6 +326,25 @@ export function MainPageContent() {
   /** On-ramp (fiat→crypto): rates API `buy` side */
   const isOnrampRate = swapMode === "onramp";
 
+  // Live provider capacity for the current corridor. Owned here rather than in
+  // the form because the rate request below also has to know it: quoting an
+  // amount no provider can fill only earns a "no provider" error that the form
+  // already states more usefully. Passed down through `stateProps` so both
+  // read one poll.
+  const { envelope: liquidity, isLoading: isLoadingLiquidity } =
+    useMarketLiquidity({
+      enabled:
+        Boolean(token) &&
+        Boolean(currency) &&
+        (!isOnrampRate ||
+          (isOnrampFiatCurrencyCode(currency) &&
+            networkSupportsOnramp(selectedNetwork.chain))),
+      side: isOnrampRate ? "buy" : "sell",
+      token,
+      currency,
+      networkName: selectedNetwork.chain.name,
+    });
+
   const { setTransactionFormSwapMode } = useHomeTransactionFormMode();
   const { refreshStatus } = useKYC();
   const prevStepForKycRefreshRef = useRef<string | null>(null);
@@ -402,6 +424,8 @@ export function MainPageContent() {
     setIsFetchingRate,
     rateError,
     setRateError,
+
+    liquidity,
 
     institutions,
     setInstitutions,
@@ -653,6 +677,23 @@ export function MainPageContent() {
       // Only fetch rate if at least one amount is greater than 0
       if (!amountSent && !amountReceived) return;
 
+      // Nothing in this corridor is quotable. The form already says so
+      // ("No liquidity available for X on Y right now"), and a request would
+      // only add the aggregator's own no-provider error on top. An unknown
+      // book leaves this false, so an outage still quotes as before.
+      if (liquidity && !liquidity.viable) {
+        setRateError(null);
+        setIsFetchingRate(false);
+        return;
+      }
+
+      // The corridor's first book is still in flight — true only until it
+      // lands or fails, never on later polls. Quoting now would skip the
+      // clamp below and ask for whatever amount carried over from the
+      // previous corridor, which is how a tab switch used to produce a
+      // no-provider toast.
+      if (isLoadingLiquidity) return;
+
       const getRate = async (shouldUseProvider = true) => {
         setIsFetchingRate(true);
 
@@ -668,11 +709,21 @@ export function MainPageContent() {
         // Send = fiat → use computed token (amountReceived), else peg-aware probe, else 1.
         const sentN = Number(amountSent) || 0;
         const recvN = Number(amountReceived) || 0;
-        const rateQueryAmount = isOnrampRate
+        const baseQueryAmount = isOnrampRate
           ? onrampRateQueryTokenAmount(token, currency, sentN, recvN)
           : sentN > 0
             ? sentN
             : 100;
+
+        // Ask about an amount a provider will actually take: quoting one the
+        // book has already ruled out returns the aggregator's no-provider
+        // error, which toasts the same fact the field states better ("Up to X
+        // available right now"). The form still rejects what was typed.
+        const rateQueryAmount = fillableQuoteAmount(
+          liquidity,
+          sentN,
+          baseQueryAmount,
+        );
 
         const providerId =
           shouldUseProvider && lpParam && !shouldSkipProvider
@@ -783,6 +834,10 @@ export function MainPageContent() {
       isOnrampRate,
       searchParams,
       selectedNetwork,
+      // Envelope identity is stable while the numbers hold (envelopesEqual),
+      // so this re-runs when capacity actually moves, not on every poll.
+      liquidity,
+      isLoadingLiquidity,
     ],
   );
 

--- a/app/hooks/useMarketLiquidity.ts
+++ b/app/hooks/useMarketLiquidity.ts
@@ -1,0 +1,136 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchMarkets } from "../api/aggregator";
+import {
+  computeLiquidityEnvelope,
+  envelopesEqual,
+  type LiquidityEnvelope,
+} from "../lib/marketLiquidity";
+import { toAggregatorToken } from "../lib/token-symbol";
+import type { RateSide } from "../types";
+import { normalizeNetworkForRateFetch } from "../utils";
+
+/** Matches the aggregator's ~10s book cache; polling faster only adds load. */
+const POLL_INTERVAL_MS = 12_000;
+
+interface UseMarketLiquidityOptions {
+  /** Off while the corridor is incomplete or the side can't be quoted. */
+  enabled: boolean;
+  side: RateSide;
+  /** Display symbol; converted to the aggregator wire form internally. */
+  token: string;
+  currency: string;
+  /** Display network name, e.g. "Base". */
+  networkName: string;
+}
+
+interface MarketLiquidityState {
+  /** `null` means unknown — callers keep their static limits. */
+  envelope: LiquidityEnvelope | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Tracks the range of amounts providers can currently fill for one corridor,
+ * so the form's limits reflect live capacity instead of a fixed ceiling.
+ *
+ * Failures are deliberately quiet: the rate request already surfaces provider
+ * problems to the user, and this hook returning `null` simply restores the
+ * previous static-limit behavior.
+ */
+export function useMarketLiquidity({
+  enabled,
+  side,
+  token,
+  currency,
+  networkName,
+}: UseMarketLiquidityOptions): MarketLiquidityState {
+  const [envelope, setEnvelope] = useState<LiquidityEnvelope | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards a late response from overwriting a newer corridor's data. This
+  // stands in for cancellation on purpose: `fetchMarkets` dedupes concurrent
+  // callers onto one shared promise, so aborting on cleanup would cancel a
+  // request that a re-mount or a quick corridor flip-flop is about to await.
+  // The request itself is small and its result is cached for the next caller.
+  const requestSeq = useRef(0);
+  const hasEnvelopeRef = useRef(false);
+
+  const wireToken = toAggregatorToken(token);
+  const wireCurrency = (currency || "").trim().toUpperCase();
+  const wireNetwork = networkName
+    ? normalizeNetworkForRateFetch(networkName)
+    : "";
+
+  const ready = enabled && Boolean(wireToken && wireCurrency && wireNetwork);
+
+  const load = useCallback(async () => {
+    if (!ready) return;
+
+    const seq = requestSeq.current;
+    if (!hasEnvelopeRef.current) setIsLoading(true);
+
+    try {
+      const corridor = {
+        side,
+        token: wireToken,
+        currency: wireCurrency,
+        network: wireNetwork,
+      };
+      const offers = await fetchMarkets(corridor);
+      if (seq !== requestSeq.current) return;
+
+      // Re-applies the corridor client-side; see filterOffersForCorridor.
+      const next = computeLiquidityEnvelope(offers, corridor);
+      hasEnvelopeRef.current = next !== null;
+      setEnvelope((prev) => (envelopesEqual(prev, next) ? prev : next));
+      setError(null);
+    } catch (err) {
+      if (seq !== requestSeq.current) return;
+      // Keep the last good band through a transient failure; it is closer to
+      // the truth than snapping back to the static limits mid-session.
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      if (seq === requestSeq.current) setIsLoading(false);
+    }
+  }, [ready, side, wireToken, wireCurrency, wireNetwork]);
+
+  useEffect(() => {
+    // Invalidate anything still in flight for the previous corridor.
+    requestSeq.current += 1;
+    hasEnvelopeRef.current = false;
+
+    if (!ready) {
+      setEnvelope(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    // A band from the previous corridor must never validate this one.
+    setEnvelope(null);
+
+    load();
+
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") load();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      requestSeq.current += 1;
+    };
+  }, [ready, load]);
+
+  return { envelope, isLoading, error, refetch: load };
+}

--- a/app/hooks/useSwapButton.ts
+++ b/app/hooks/useSwapButton.ts
@@ -1,6 +1,7 @@
 import { usePrivy } from "@privy-io/react-auth";
 import { UseFormWatch } from "react-hook-form";
 import { useInjectedWallet } from "../context";
+import type { LiquiditySegment } from "../lib/marketLiquidity";
 import { validateWalletAddress } from "../lib/validation";
 
 /** Primary CTA when limits require upgrading verification (opens limit / KYC flow from swap). */
@@ -34,6 +35,30 @@ interface UseSwapButtonProps {
   isSwapped?: boolean; // true when in onramp mode (fiat in Send, token in Receive)
   /** Selected chain name for on-ramp wallet validation (e.g. Base, Starknet). */
   networkName?: string;
+  /**
+   * Effective Send-amount bounds from TransactionForm: static product limits,
+   * rate-derived floors and the live provider band already merged. Supplied by
+   * the caller rather than re-derived here so the CTA and the field rules can
+   * never disagree. Omitted, the legacy static floors apply.
+   */
+  amountBounds?: {
+    min: number;
+    max: number;
+    /** Fillable runs within [min, max]; absent means unknown, so not enforced. */
+    segments?: LiquiditySegment[];
+    noLiquidity: boolean;
+  };
+}
+
+/** Unknown segments must not block, so an absent list passes. */
+function fitsLiquiditySegment(
+  segments: LiquiditySegment[] | undefined,
+  amount: number,
+): boolean {
+  if (!segments?.length) return true;
+  return segments.some(
+    (segment) => amount >= segment.min && amount <= segment.max,
+  );
 }
 
 export function useSwapButton({
@@ -49,6 +74,7 @@ export function useSwapButton({
   rate,
   isSwapped = false,
   networkName = "",
+  amountBounds,
 }: UseSwapButtonProps) {
   const { authenticated } = usePrivy();
   const { isInjectedWallet, injectedReady, injectedRequested, injectedStatus } =
@@ -76,11 +102,21 @@ export function useSwapButton({
   const isInjectedConnecting =
     injectedRequested && !injectedReady && injectedStatus === "pending";
 
-  // Off-ramp: min 0.5 token. On-ramp: min fiat 0.5×rate only after receive token + rate (same as onrampFiatMin).
+  // The amount must sit within the effective bounds, which already fold the
+  // static limits, the rate-derived floor and live provider capacity together.
+  // Segments additionally reject a hole between two providers' bands, since one
+  // order is filled by one provider. Without bounds the legacy floors stand:
+  // 0.5 token off-ramp, 0.5×rate on-ramp once a receive token and rate exist.
+  const amountFloor = amountBounds?.min ?? (isSwapped ? 0.5 * Number(rate) : 0.5);
+  const amountCeiling = amountBounds?.max ?? Infinity;
+  const withinBounds =
+    !amountBounds?.noLiquidity &&
+    Number(amountSent) <= amountCeiling &&
+    fitsLiquiditySegment(amountBounds?.segments, Number(amountSent));
   const isAmountValid = isSwapped
     ? !token ||
-      (Number(rate) > 0 && Number(amountSent) >= 0.5 * Number(rate))
-    : Number(amountSent) >= 0.5;
+      (withinBounds && Number(rate) > 0 && Number(amountSent) >= amountFloor)
+    : withinBounds && Number(amountSent) >= amountFloor;
   const isCurrencySelected = Boolean(currency);
 
   const totalRequired = Number(amountSent) || 0;
@@ -101,6 +137,13 @@ export function useSwapButton({
     // Connecting needs no amount: the CTA is live as soon as the form renders.
     if (isInjectedAwaiting) return true;
     if (isInjectedConnecting) return false;
+
+    // A corridor with no fillable offers stays disabled even when the wallet
+    // is underfunded: the `hasInsufficientBalance` branch below enables
+    // "Fund wallet" unconditionally on the theory that funding fixes
+    // whatever is wrong, but funding does nothing here — no provider exists
+    // for this corridor at any amount.
+    if (amountBounds?.noLiquidity) return false;
 
     // Phone / next-tier KYC from the main CTA must work before the user picks a
     // recipient; otherwise the verify label appears on a permanently disabled button.

--- a/app/lib/marketLiquidity.ts
+++ b/app/lib/marketLiquidity.ts
@@ -1,0 +1,389 @@
+/**
+ * Turns the aggregator's provider order book (GET /v2/markets) into the range
+ * of Send-field amounts that at least one provider can actually fill.
+ *
+ * An order is assigned to a single provider, so the range is the envelope
+ * across offers — never the sum of their balances.
+ */
+
+import type { RateSide, V2MarketOffer } from "../types";
+import { formatNumberWithCommas, getCurrencySymbol } from "../utils";
+
+/** One continuous run of fillable amounts, in Send-field units. */
+export type LiquiditySegment = { min: number; max: number };
+
+export type LiquidityEnvelope = {
+  /** False when the book has rows but none can fill an order right now. */
+  viable: boolean;
+  side: RateSide;
+  /** Bounds in Send-field units: fiat on buy (onramp), token on sell (offramp). */
+  min: number | null;
+  max: number | null;
+  /**
+   * The fillable runs between `min` and `max`, ascending and non-overlapping.
+   *
+   * One order is filled by one provider, so sitting inside `[min, max]` is not
+   * on its own enough — that span is the union of every provider's band, and
+   * two providers whose bands do not meet leave a hole no single one can
+   * cover. Usually there is exactly one segment.
+   */
+  segments: LiquiditySegment[];
+  /** Cheapest fiat-per-token among viable offers. */
+  bestRate: number | null;
+  offerCount: number;
+};
+
+/** The one corridor a quote is for. The book covers every corridor at once. */
+export type LiquidityCorridor = {
+  side: RateSide;
+  /** Aggregator wire symbol, e.g. CNGN. */
+  token: string;
+  currency: string;
+  /** Normalized slug, e.g. bnb-smart-chain. */
+  network: string;
+};
+
+/** Send amounts accept at most 4 decimals, so token bounds round to the same. */
+const TOKEN_DECIMALS = 4;
+
+/**
+ * Distances below this are indistinguishable from equal. Amounts are held to
+ * four decimals, so no real difference is anywhere near this small — it exists
+ * only so binary rounding cannot turn a tie into a winner.
+ */
+const DISTANCE_EPSILON = 1e-9;
+
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function floorTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.floor(value * factor) / factor;
+}
+
+function ceilTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.ceil(value * factor) / factor;
+}
+
+function sameCode(a: unknown, b: string): boolean {
+  return typeof a === "string" && a.trim().toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Collapses overlapping and adjacent bands into the runs actually fillable.
+ *
+ * Bands join only when they overlap or sit one representable amount apart, so
+ * the join never widens with the numbers involved — a proportional tolerance
+ * would swallow a five-figure hole between bands in the millions. Inward
+ * rounding already closes a provider's own hairline seams (…–2 then
+ * 2.000999–… both land on the same integer boundary in fiat), and anything
+ * wider than the grid is a real hole that no single provider covers.
+ */
+function mergeSegments(
+  raw: LiquiditySegment[],
+  decimals: number,
+): LiquiditySegment[] {
+  const unit = 1 / 10 ** decimals;
+  const merged: LiquiditySegment[] = [];
+
+  for (const segment of [...raw].sort((a, b) => a.min - b.min)) {
+    const last = merged[merged.length - 1];
+    if (last && segment.min <= last.max + unit) {
+      if (segment.max > last.max) last.max = segment.max;
+    } else {
+      merged.push({ ...segment });
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Unfiltered, the endpoint serves every corridor it knows — both sides, all
+ * tokens, fiats and networks — in one array. The request does send filters,
+ * so this is normally a no-op; it is here so that a dropped or differently
+ * interpreted filter cannot let another corridor's depth be read as this
+ * one's.
+ */
+export function filterOffersForCorridor(
+  offers: V2MarketOffer[],
+  corridor: LiquidityCorridor,
+): V2MarketOffer[] {
+  if (!Array.isArray(offers)) return [];
+  return offers.filter(
+    (offer) =>
+      sameCode(offer.side, corridor.side) &&
+      sameCode(offer.token, corridor.token) &&
+      sameCode(offer.fiat, corridor.currency) &&
+      sameCode(offer.network, corridor.network),
+  );
+}
+
+/**
+ * How much of `offer` a single order can consume, in token units.
+ *
+ * `balance` is denominated by `balanceCurrency`: the token on buy rows (the
+ * provider pays out tokens) and the fiat on sell rows (it pays out fiat). A
+ * balance in neither denomination is left out of the cap rather than guessed
+ * at, since a misread float would silently shrink a healthy offer.
+ */
+function offerCapInTokens(
+  offer: V2MarketOffer,
+  corridor: LiquidityCorridor,
+  rate: number,
+): number | null {
+  const max = toFiniteNumber(offer.max);
+  if (max === null) return null;
+
+  const balance = toFiniteNumber(offer.balance);
+  if (balance === null) return max;
+
+  if (sameCode(offer.balanceCurrency, corridor.token)) {
+    return Math.min(max, balance);
+  }
+  if (sameCode(offer.balanceCurrency, corridor.currency)) {
+    return Math.min(max, balance / rate);
+  }
+  // Undeclared denomination: on buy the historical shape is token-denominated.
+  if (offer.balanceCurrency === undefined && corridor.side === "buy") {
+    return Math.min(max, balance);
+  }
+  return max;
+}
+
+/**
+ * @returns the fillable envelope for `corridor`, or `null` when the book says
+ * nothing usable (empty response, or numbers that fail a sanity check).
+ * Callers treat `null` as unknown and keep their static limits — an
+ * unreachable or unreadable book must never lock a user out.
+ *
+ * An entirely empty response reads as unknown rather than as an empty
+ * corridor: a filtered request legitimately returns nothing when no provider
+ * serves the pair, but so does a book that failed to populate, and the two are
+ * indistinguishable here. Erring toward unknown keeps the limits at their
+ * static values instead of disabling a corridor on ambiguous data. A response
+ * that has rows but none fillable is unambiguous and reports as non-viable.
+ */
+export function computeLiquidityEnvelope(
+  offers: V2MarketOffer[],
+  corridor: LiquidityCorridor,
+): LiquidityEnvelope | null {
+  if (!Array.isArray(offers) || offers.length === 0) return null;
+
+  const { side } = corridor;
+  const decimals = side === "buy" ? 0 : TOKEN_DECIMALS;
+  const bands: LiquiditySegment[] = [];
+  let bestRate: number | null = null;
+  let viableCount = 0;
+
+  for (const offer of filterOffersForCorridor(offers, corridor)) {
+    const offerMin = toFiniteNumber(offer.min);
+    const rate = toFiniteNumber(offer.rate);
+    if (offerMin === null || offerMin < 0) continue;
+    if (rate === null || rate <= 0) continue;
+
+    const cap = offerCapInTokens(offer, corridor, rate);
+    if (cap === null || cap < offerMin) continue;
+
+    // Convert per offer: a high-rate provider with a small cap must not
+    // inflate the fiat ceiling of a low-rate provider's band.
+    const lower = side === "buy" ? offerMin * rate : offerMin;
+    const upper = side === "buy" ? cap * rate : cap;
+
+    viableCount += 1;
+    if (bestRate === null || rate < bestRate) bestRate = rate;
+
+    // Round inward so an amount the form accepts is never rejected downstream.
+    const band = { min: ceilTo(lower, decimals), max: floorTo(upper, decimals) };
+    if (band.max > 0 && band.max >= band.min) bands.push(band);
+  }
+
+  const segments = mergeSegments(bands, decimals);
+
+  if (viableCount === 0) {
+    return {
+      viable: false,
+      side,
+      min: null,
+      max: null,
+      segments: [],
+      bestRate: null,
+      offerCount: 0,
+    };
+  }
+
+  // Offers were viable but every band rounded away to nothing.
+  if (segments.length === 0) return null;
+
+  return {
+    viable: true,
+    side,
+    min: segments[0].min,
+    max: segments[segments.length - 1].max,
+    segments,
+    bestRate,
+    offerCount: viableCount,
+  };
+}
+
+/** True when a single provider can fill exactly `amount`. */
+export function isAmountFillable(
+  envelope: LiquidityEnvelope | null,
+  amount: number,
+): boolean {
+  if (!envelope?.viable || envelope.segments.length === 0) return true;
+  if (!Number.isFinite(amount)) return true;
+  return envelope.segments.some(
+    (segment) => amount >= segment.min && amount <= segment.max,
+  );
+}
+
+/**
+ * @returns the fillable amount closest to `amount`, or null when there is no
+ * live band to steer toward. An amount already fillable is returned unchanged.
+ *
+ * Ties go to the larger amount — someone who asked for more is better served
+ * by rounding up to the next band than down into the previous one.
+ */
+export function nearestFillableAmount(
+  envelope: LiquidityEnvelope | null,
+  amount: number,
+): number | null {
+  if (!envelope?.viable || envelope.segments.length === 0) return null;
+  if (!Number.isFinite(amount)) return null;
+
+  let nearest: number | null = null;
+  let shortest = Infinity;
+
+  for (const segment of envelope.segments) {
+    const candidate = Math.min(Math.max(amount, segment.min), segment.max);
+    const distance = Math.abs(candidate - amount);
+    // Equidistance has to be judged with a tolerance: 0.3 is mathematically
+    // as far from 0.2 as from 0.4, but not in binary, and an exact comparison
+    // would quietly hand those cases to the lower band.
+    if (
+      distance < shortest - DISTANCE_EPSILON ||
+      (Math.abs(distance - shortest) <= DISTANCE_EPSILON &&
+        nearest !== null &&
+        candidate > nearest)
+    ) {
+      nearest = candidate;
+      shortest = distance;
+    }
+  }
+
+  return nearest;
+}
+
+/**
+ * Rescales a rate-quote amount onto the nearest amount a provider will take.
+ *
+ * The rates endpoint answers per amount, so asking about an amount outside
+ * every band returns a no-provider error rather than a rate — which would put
+ * a raw backend string in front of the user for a state the form already
+ * explains, and leave both amount fields with nothing to convert by. Quoting
+ * the nearest fillable amount instead keeps a rate on screen while the form
+ * goes on rejecting what was actually typed.
+ *
+ * `sentAmount` is in Send-field units (fiat on buy, token on sell) because
+ * that is what the envelope describes, while `queryAmount` is in token units
+ * either way — so the correction applies as a ratio rather than a swap.
+ *
+ * @returns `queryAmount` unchanged when the book is unknown, when the amount
+ * is already fillable, or when rescaling would round it away to nothing.
+ */
+export function fillableQuoteAmount(
+  envelope: LiquidityEnvelope | null,
+  sentAmount: number,
+  queryAmount: number,
+): number {
+  if (!(sentAmount > 0) || !Number.isFinite(queryAmount)) return queryAmount;
+  if (isAmountFillable(envelope, sentAmount)) return queryAmount;
+
+  const nearest = nearestFillableAmount(envelope, sentAmount);
+  if (nearest === null) return queryAmount;
+
+  const rescaled = Number(
+    ((queryAmount * nearest) / sentAmount).toFixed(TOKEN_DECIMALS),
+  );
+  return rescaled > 0 ? rescaled : queryAmount;
+}
+
+/** True when two envelopes carry the same information, to avoid re-render churn. */
+export function envelopesEqual(
+  a: LiquidityEnvelope | null,
+  b: LiquidityEnvelope | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.viable === b.viable &&
+    a.side === b.side &&
+    a.min === b.min &&
+    a.max === b.max &&
+    a.bestRate === b.bestRate &&
+    a.offerCount === b.offerCount &&
+    a.segments.length === b.segments.length &&
+    a.segments.every(
+      (segment, index) =>
+        segment.min === b.segments[index].min &&
+        segment.max === b.segments[index].max,
+    )
+  );
+}
+
+/** The Send field holds fiat on buy and the token on sell. */
+function formatSendAmount(
+  amount: number,
+  side: RateSide,
+  currency: string,
+  token: string,
+): string {
+  return side === "buy"
+    ? `${getCurrencySymbol(currency)}${formatNumberWithCommas(amount)}`
+    : `${formatNumberWithCommas(amount)} ${token}`;
+}
+
+/**
+ * Amount limits move with provider availability, so the copy is phrased as
+ * what is fillable right now rather than as a standing rule.
+ */
+export function liquidityMaxMessage(
+  amount: number,
+  side: RateSide,
+  currency: string,
+  token: string,
+): string {
+  return `Up to ${formatSendAmount(amount, side, currency, token)} available right now`;
+}
+
+export function liquidityMinMessage(
+  amount: number,
+  side: RateSide,
+  currency: string,
+  token: string,
+): string {
+  return `Minimum for available offers is ${formatSendAmount(amount, side, currency, token)}`;
+}
+
+/**
+ * Shown when an amount sits between two providers' bands: inside the overall
+ * range, yet no single provider covers it. Names the closest amount that is,
+ * since the bare fact is not actionable on its own.
+ */
+export function nearestFillableMessage(
+  amount: number,
+  side: RateSide,
+  currency: string,
+  token: string,
+): string {
+  return `Try ${formatSendAmount(amount, side, currency, token)} — the nearest amount available right now`;
+}
+
+export function noLiquidityMessage(token: string, network: string): string {
+  return `No liquidity available for ${token} on ${network} right now`;
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -41,6 +41,8 @@ import {
   getOnrampFiatMaxAmount,
   isOnrampFiatCurrencyCode,
   swapModeFromSideParam,
+  RATE_DECIMALS,
+  formatRateForDisplay,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -387,7 +389,7 @@ export const TransactionForm = ({
     }
   };
 
-  // Improved function to format number with commas while preserving decimal places
+  // Format with commas; keep up to RATE_DECIMALS fractional digits, drop trailing zeros.
   const formatNumberWithCommasForDisplay = (value: number | string): string => {
     if (value === undefined || value === null || value === "") return "";
 
@@ -401,10 +403,15 @@ export const TransactionForm = ({
     // Add commas to the integer part
     const integerPart = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
-    // Preserve the decimal part if it exists, ensuring max 4 decimal places
     if (parts.length > 1) {
-      const decimalPart = parts[1].slice(0, 4); // Limit to 4 decimal places
-      return `${integerPart}.${decimalPart}`;
+      // Preserve trailing "." while the user is typing a decimal
+      if (parts[1] === "" && valueStr.endsWith(".")) {
+        return `${integerPart}.`;
+      }
+      const decimalPart = parts[1]
+        .slice(0, RATE_DECIMALS)
+        .replace(/0+$/, "");
+      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
     }
 
     return integerPart;
@@ -598,7 +605,15 @@ export const TransactionForm = ({
   useEffect(
     function updateFormattedAmounts() {
       if (amountSent !== undefined) {
-        setFormattedSentAmount(formatNumberWithCommasForDisplay(amountSent));
+        const cleanedSent = removeCommas(formattedSentAmount);
+        // Keep "123." while editing; form number is already 123 and must not
+        // reformat back to "123" via updateFormattedAmounts.
+        const preserveTrailingDot =
+          cleanedSent.endsWith(".") &&
+          (parseFloat(cleanedSent) || 0) === Number(amountSent);
+        if (!preserveTrailingDot) {
+          setFormattedSentAmount(formatNumberWithCommasForDisplay(amountSent));
+        }
       }
 
       if (amountReceived !== undefined) {
@@ -607,6 +622,8 @@ export const TransactionForm = ({
         );
       }
     },
+    // formattedSentAmount is read only to detect an in-progress trailing "."
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [amountSent, amountReceived],
   );
 
@@ -1727,7 +1744,7 @@ export const TransactionForm = ({
                       <>
                         {isFetchingRate
                           ? "..."
-                          : formatNumberWithCommasForDisplay(rate)}{" "}
+                          : formatRateForDisplay(rate)}{" "}
                         {currency} ~ 1 {token}
                       </>
                     ) : (
@@ -1735,7 +1752,7 @@ export const TransactionForm = ({
                         1 {token} ~{" "}
                         {isFetchingRate
                           ? "..."
-                          : formatNumberWithCommasForDisplay(rate)}{" "}
+                          : formatRateForDisplay(rate)}{" "}
                         {currency}
                       </>
                     )}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -50,6 +50,14 @@ import { useWalletAddress } from "../hooks/useWalletAddress";
 import { useLoginWithScrollPin } from "../hooks/useLoginWithScrollPin";
 import { fetchSupportedCurrencyCodes } from "../api/aggregator";
 import { useCNGNRate } from "../hooks/useCNGNRate";
+import {
+  isAmountFillable,
+  liquidityMaxMessage,
+  liquidityMinMessage,
+  nearestFillableAmount,
+  nearestFillableMessage,
+  noLiquidityMessage,
+} from "../lib/marketLiquidity";
 import { useFundWalletHandler } from "../hooks/useFundWalletHandler";
 import { useShouldUseEOA } from "../hooks/useEIP7702Account";
 import {
@@ -306,6 +314,54 @@ export const TransactionForm = ({
     autoFetch: true, // Always fetch so it's available when needed
     dependencies: [selectedNetwork],
   });
+
+  // Live provider capacity for this corridor, polled once at the page level
+  // (see MainPageContent) so the limits here and the rate request there read
+  // the same book. Drives the amount limits so the form only accepts amounts a
+  // provider can actually fill; a null envelope means unknown and leaves the
+  // static limits in place.
+  const liquidity = stateProps.liquidity;
+  const noLiquidity = Boolean(liquidity && !liquidity.viable);
+
+  /**
+   * The effective Send-amount bounds: static product limits, the rate-derived
+   * floors, and the live provider band merged into one pair of numbers.
+   *
+   * Computed here rather than inside the registration effect because the CTA
+   * needs the same values. `useSwapButton` enables itself on the amount alone
+   * for an unverified user — form-wide validity is deliberately bypassed so
+   * verification stays reachable — so a floor derived independently there
+   * would let the button accept an amount the field rejects.
+   */
+  const amountBounds = useMemo(() => {
+    const liquidityMin = liquidity?.viable ? liquidity.min : null;
+    const liquidityMax = liquidity?.viable ? liquidity.max : null;
+
+    let min = 0.5;
+    let max = 10000;
+
+    if (swapMode === "onramp") {
+      const safeCurrency =
+        currency?.trim() && isOnrampFiatCurrencyCode(currency.trim())
+          ? currency.trim()
+          : "NGN";
+      max = getOnrampFiatMaxAmount(safeCurrency);
+      // The fiat floor tracks the rate, and is only enforceable once a receive
+      // token and a rate exist; 0 stands for "no floor yet".
+      min = token && rate && rate > 0 ? 0.5 * rate : 0;
+    } else if (tokensEqual(token, "cNGN") && cngnRate && cngnRate > 0) {
+      max = 50000000;
+      min = 0.5 * cngnRate;
+    }
+
+    // Live capacity replaces the static ceiling and can only raise the floor.
+    // An unknown or empty book leaves both untouched, so a markets outage
+    // degrades to the previous behavior instead of blocking the form.
+    if (liquidityMax !== null) max = liquidityMax;
+    if (liquidityMin !== null) min = Math.max(min, liquidityMin);
+
+    return { min, max, liquidityMin, liquidityMax };
+  }, [swapMode, currency, token, rate, cngnRate, liquidity]);
 
   // Determine active wallet based on migration status
   // After migration: use EOA (new wallet with funds)
@@ -638,21 +694,33 @@ export const TransactionForm = ({
         //   Formula: Receive = Send / Rate (463,284 NGN / 1400 = 330.917 USDC)
 
         if (isReceiveInputActive) {
-          // User is typing in Receive field
+          // User is typing in Receive field.
+          //
+          // `amountSent` carries the limit rules, so writing it here has to
+          // validate: without it the field keeps whatever verdict the last
+          // Send keystroke left behind — a rejected amount corrected from the
+          // Receive side keeps its error, and an amount typed only from the
+          // Receive side is never checked at all.
           if (isSwapped) {
             // Swapped: Receive = Token, so calculate Send (Currency)
             // Send = Receive * Rate (20.4 USDC * 1400 = 28,560 NGN)
             const calculatedAmount = Number(
               (Number(amountReceived) * rate).toFixed(4),
             );
-            setValue("amountSent", calculatedAmount, { shouldDirty: true });
+            setValue("amountSent", calculatedAmount, {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
           } else {
             // Not swapped: Receive = Currency, so calculate Send (Token)
             // Send = Receive / Rate (1400 NGN / 1400 = 1 USDC)
             const calculatedAmount = Number(
               (Number(amountReceived) / rate).toFixed(4),
             );
-            setValue("amountSent", calculatedAmount, { shouldDirty: true });
+            setValue("amountSent", calculatedAmount, {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
           }
         } else {
           // User is typing in Send field
@@ -717,29 +785,37 @@ export const TransactionForm = ({
   useEffect(
     function registerFieldsWithValidation() {
       async function registerFormFields() {
-        let maxAmountSentValue = 10000;
-        let minAmountSentValue = 0.5;
-
         if (swapMode === "onramp") {
-          const safeCurrency =
-            currency?.trim() && isOnrampFiatCurrencyCode(currency.trim())
-              ? currency.trim()
-              : "NGN";
-          maxAmountSentValue = getOnrampFiatMaxAmount(safeCurrency);
           setRateError(null);
         } else if (tokensEqual(token, "cNGN")) {
-          if (cngnRate && cngnRate > 0) {
-            // Valid rate available - calculate limits and clear errors
-            maxAmountSentValue = 50000000;
-            minAmountSentValue = 0.5 * cngnRate;
-            setRateError(null);
-          } else {
-            const errorMessage = cngnRateError || "No available quote";
-            setRateError(errorMessage);
-          }
+          setRateError(
+            cngnRate && cngnRate > 0
+              ? null
+              : cngnRateError || "No available quote",
+          );
         } else {
           setRateError(null);
         }
+
+        // Bounds come from amountBounds so the CTA enforces the same numbers;
+        // this effect owns only the rate-error side effects and the messages.
+        const side = swapMode === "onramp" ? "buy" : "sell";
+        const fiat = (currency || "NGN").toUpperCase();
+        const {
+          min: minAmountSentValue,
+          max: maxAmountSentValue,
+          liquidityMin,
+          liquidityMax,
+        } = amountBounds;
+
+        const maxMessage =
+          liquidityMax !== null
+            ? liquidityMaxMessage(maxAmountSentValue, side, fiat, token)
+            : `Maximum amount is ${formatNumberWithCommas(maxAmountSentValue)}`;
+        const minMessage =
+          liquidityMin !== null && minAmountSentValue === liquidityMin
+            ? liquidityMinMessage(minAmountSentValue, side, fiat, token)
+            : `Minimum amount is ${formatNumberWithCommas(minAmountSentValue)}`;
 
         formMethods.register("amountSent", {
           required: { value: true, message: "Amount is required" },
@@ -748,13 +824,13 @@ export const TransactionForm = ({
             ? {
                 min: {
                   value: minAmountSentValue,
-                  message: `Minimum amount is ${formatNumberWithCommas(minAmountSentValue)}`,
+                  message: minMessage,
                 },
               }
             : {}),
           max: {
             value: maxAmountSentValue,
-            message: `Maximum amount is ${formatNumberWithCommas(maxAmountSentValue)}`,
+            message: maxMessage,
           },
           validate: {
             decimals: (value: number) => {
@@ -770,10 +846,27 @@ export const TransactionForm = ({
               // Min fiat depends on rate; only enforce once receive token is chosen and rate exists.
               if (!token || !rate || rate <= 0) return true;
               const n = Number(value);
-              const floor = 0.5 * rate;
+              const rateFloor = 0.5 * rate;
+              const floor = minAmountSentValue;
               if (n >= floor) return true;
-              const fiat = (currency || "NGN").toUpperCase();
-              return `Minimum amount is ${getCurrencySymbol(fiat)}${formatNumberWithCommas(floor)}`;
+              return floor > rateFloor
+                ? liquidityMinMessage(floor, "buy", fiat, token)
+                : `Minimum amount is ${getCurrencySymbol(fiat)}${formatNumberWithCommas(floor)}`;
+            },
+            liquidityGap: (value: number) => {
+              // An amount can clear both bounds and still fall between two
+              // providers' bands, which no single provider can fill.
+              const n = Number(value);
+              if (!Number.isFinite(n) || n <= 0) return true;
+              if (isAmountFillable(liquidity, n)) return true;
+              // Outside the overall band already reads as a min/max error.
+              if (liquidityMin !== null && n < liquidityMin) return true;
+              if (liquidityMax !== null && n > liquidityMax) return true;
+
+              const nearest = nearestFillableAmount(liquidity, n);
+              return nearest === null
+                ? true
+                : nearestFillableMessage(nearest, side, fiat, token);
             },
           },
         });
@@ -832,6 +925,12 @@ export const TransactionForm = ({
             shouldDirty: true,
           });
         }
+
+        // Re-registering only changes the rules; an amount typed before the
+        // limits moved keeps its stale verdict until the next keystroke.
+        if (Number(formMethods.getValues("amountSent")) > 0) {
+          formMethods.trigger("amountSent");
+        }
       }
 
       registerFormFields();
@@ -844,6 +943,8 @@ export const TransactionForm = ({
       selectedNetwork,
       cngnRate,
       cngnRateError,
+      amountBounds,
+      liquidity,
       isSwapped,
       swapMode,
       rate,
@@ -883,6 +984,12 @@ export const TransactionForm = ({
     rate,
     isSwapped,
     networkName: selectedNetwork.chain.name,
+    amountBounds: {
+      min: amountBounds.min,
+      max: amountBounds.max,
+      segments: liquidity?.viable ? liquidity.segments : undefined,
+      noLiquidity,
+    },
   });
 
   const [isPhoneVerificationOpen, setIsPhoneVerificationOpen] = useState(false);
@@ -1488,6 +1595,15 @@ export const TransactionForm = ({
                   (isWalletConnected && !isSwapped && totalRequired > balance
                     ? "Insufficient balance"
                     : null)}
+              </AnimatedComponent>
+            )}
+
+            {noLiquidity && (
+              <AnimatedComponent
+                variant={slideInOut}
+                className="!mt-0 text-xs text-orange-500 dark:text-orange-400"
+              >
+                {noLiquidityMessage(token, selectedNetwork.chain.name)}
               </AnimatedComponent>
             )}
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,4 +1,7 @@
 import type { ReactNode } from "react";
+// Type-only: erased at build, so this does not create a runtime cycle with
+// marketLiquidity.ts, which imports its wire types from here.
+import type { LiquidityEnvelope } from "./lib/marketLiquidity";
 
 export type MobileSheetView =
   | "wallet"
@@ -198,6 +201,38 @@ export type V2RateQuoteResponse = {
   sell?: V2RateQuoteSide;
 };
 
+/**
+ * One provider offer row from GET /v2/markets.
+ * `min`/`max` are the order band in token units (same units as the /v2/rates
+ * path amount); `balance` is the provider's float; `rate` is fiat per token.
+ * Numerics may arrive as strings, so parse defensively.
+ */
+export type V2MarketOffer = {
+  min?: number | string;
+  max?: number | string;
+  balance?: number | string;
+  /** Denomination of `balance`: the token on buy rows, the fiat on sell rows. */
+  balanceCurrency?: string;
+  rate?: number | string;
+  rateType?: string;
+  providerId?: string;
+  side?: string;
+  token?: string;
+  fiat?: string;
+  network?: string;
+  [key: string]: unknown;
+};
+
+export type MarketsPayload = {
+  side: RateSide;
+  /** Aggregator wire symbol, e.g. CNGN (see toAggregatorToken). */
+  token: string;
+  currency: string;
+  /** Normalized slug (see normalizeNetworkForRateFetch). Omit to query all networks. */
+  network?: string;
+  signal?: AbortSignal;
+};
+
 export type PubkeyResponse = {
   status: string;
   data: string;
@@ -330,6 +365,12 @@ export type StateProps = {
   setTransactionStatus: (status: TransactionStatusType) => void;
   rateError: string | null;
   setRateError: (error: string | null) => void;
+  /**
+   * Live provider capacity for the current corridor, or `null` when unknown.
+   * Held at the page level so the form's limits and the rate request agree on
+   * one poll's worth of truth.
+   */
+  liquidity: LiquidityEnvelope | null;
   onrampPaymentAccount: V2FiatProviderAccountDTO | null;
   setOnrampPaymentAccount: (account: V2FiatProviderAccountDTO | null) => void;
   /** Locked when the current order is created; not tied to live swapMode. */

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -2297,16 +2297,35 @@ export const getBlockFestTimeRemaining = (): number => {
 
 /**
  * On-chain quote-rate multiplier for Gateway createOrder `_rate`.
- * Matches aggregator RateScale target (×100000) so sub-par local corridors
- * (e.g. CNGN 0.998) encode distinctly from par 1.0.
+ * Matches aggregator RateScale (×1_000_000) so fee-adjusted local corridors
+ * (e.g. CNGN 0.999833) encode distinctly from par 1.0.
  */
-export const RATE_SCALE = 100000;
+export const RATE_SCALE = 1000000;
+
+/** Max fractional digits representable at {@link RATE_SCALE} (e.g. 6 for ×1_000_000). */
+export const RATE_DECIMALS = Math.floor(Math.log10(RATE_SCALE));
 
 /**
  * Packs a human quote rate for on-chain createOrder (`round(rate × RATE_SCALE)`).
  */
 export function packRate(rate: number): bigint {
   return BigInt(Math.round(rate * RATE_SCALE));
+}
+
+/**
+ * Formats a quote rate for UI using the same grid as {@link packRate}
+ * (`round(rate × RATE_SCALE) / RATE_SCALE`), with trailing zeros stripped.
+ */
+export function formatRateForDisplay(rate: number): string {
+  if (!Number.isFinite(rate)) return "";
+  const quantized = Math.round(rate * RATE_SCALE) / RATE_SCALE;
+  if (quantized === 0) return "0";
+
+  let fixed = quantized.toFixed(RATE_DECIMALS);
+  if (fixed.includes(".")) {
+    fixed = fixed.replace(/0+$/, "").replace(/\.$/, "");
+  }
+  return formatNumberWithCommas(fixed);
 }
 
 /**

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -21,6 +21,7 @@ jest.mock('@datadog/browser-rum', () => ({
 process.env.SUPABASE_URL = 'https://test.supabase.co'
 process.env.SUPABASE_SECRET_KEY = 'sb_secret_test_placeholder'
 process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'test-privy-app-id'
+process.env.NEXT_PUBLIC_AGGREGATOR_URL = 'https://aggregator.test/v1'
 process.env.INTERNAL_API_KEY = 'test-internal-api-key'
 
 // Polyfill TextEncoder/TextDecoder for Node.js environment


### PR DESCRIPTION
### Description

Release PR: promote current `main` to production (`stable`).

Includes:

- Update `RATE_SCALE` to 1,000,000 and introduce `RATE_DECIMALS` for improved rate/number formatting in TransactionForm (#655)
- Add `formatRateForDisplay` so quote rates strip trailing zeros while staying on the same grid as `packRate`

No intentional public API or contract breaking changes — display-only formatting improvements for rates and amounts in the transaction form.

### References

- #655
- Follow-up to #649 (`main` → `stable`)

### Testing

- Confirm this PR is mergeable into `stable` with no conflicts
- Smoke-test TransactionForm rate and amount display (fractional digits, trailing zeros stripped)
- Confirm existing swap quote → confirm flow still works end-to-end
- Environment: production release from `main` → `stable` (Vercel/prod deploy on merge)

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
