### PR TITLE
Update TransactionStatus to handle "refunded" status for onramp transaction

### DIFF
--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1802,29 +1802,33 @@ export function TransactionStatus({
                   <p className="flex-1">Time spent</p>
                   <p className="flex-1">{timeSpentLabel}</p>
                 </div>
-                <div className="flex items-center justify-between gap-1">
-                  <p className="flex-1">Onchain receipt</p>
-                  <p className="flex-1">
-                    {transactionStatus === "expired" ||
-                    (isOnramp && transactionStatus === "refunded") ? (
-                      <span className="text-text-secondary dark:text-white/40">
-                        Not available
-                      </span>
-                    ) : (
-                      <a
-                        href={getExplorerLink(
-                          selectedNetwork.chain.name,
-                          `${orderDetails?.status === "refunded" ? orderDetails?.txHash : createdHash}`,
-                        )}
-                        className="text-lavender-500 hover:underline dark:text-lavender-500"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        View in explorer
-                      </a>
-                    )}
-                  </p>
-                </div>
+                {!(
+                  isOnramp &&
+                  ["refunded", "expired"].includes(transactionStatus)
+                ) && (
+                  <div className="flex items-center justify-between gap-1">
+                    <p className="flex-1">Onchain receipt</p>
+                    <p className="flex-1">
+                      {transactionStatus === "expired" ? (
+                        <span className="text-text-secondary dark:text-white/40">
+                          Not available
+                        </span>
+                      ) : (
+                        <a
+                          href={getExplorerLink(
+                            selectedNetwork.chain.name,
+                            `${orderDetails?.status === "refunded" ? orderDetails?.txHash : createdHash}`,
+                          )}
+                          className="text-lavender-500 hover:underline dark:text-lavender-500"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          View in explorer
+                        </a>
+                      )}
+                    </p>
+                  </div>
+                )}
                 {/* Leg 2: forward to an external wallet — show its own onchain receipt. */}
                 {isOnramp &&
                   config.onrampChainedForwardingEnabled &&

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -1805,7 +1805,8 @@ export function TransactionStatus({
                 <div className="flex items-center justify-between gap-1">
                   <p className="flex-1">Onchain receipt</p>
                   <p className="flex-1">
-                    {transactionStatus === "expired" ? (
+                    {transactionStatus === "expired" ||
+                    (isOnramp && transactionStatus === "refunded") ? (
                       <span className="text-text-secondary dark:text-white/40">
                         Not available
                       </span>


### PR DESCRIPTION

### Description

This pull request makes a small change to the `TransactionStatus` component to improve how onchain receipt availability is displayed. Now, if the transaction is an onramp and has been refunded, it will also show "Not available" for the onchain receipt, in addition to the previous handling for expired transactions.


### References




### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction status details for on-ramp transactions.
  * Hid on-chain receipt information for refunded or expired transactions.
  * Continued showing “Not available” for other expired transactions and explorer links for eligible transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->