### PR TITLE
feat: enhance Earn feature with EVM support and LayerSwap integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,7 @@ NEXT_PUBLIC_EARN_ENABLED=false
 # EVM → Starknet Earn (LayerSwap bridge + Vesu). Requires NEXT_PUBLIC_EARN_ENABLED=true
 NEXT_PUBLIC_EVM_EARN_ENABLED=false
 LAYERSWAP_API_KEY=
+# Optional; must use HTTPS if set
 LAYERSWAP_API_BASE_URL=https://api.layerswap.io #optional
 
 NEXT_PUBLIC_TRON_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,11 @@ ENABLE_WALLET_CONTEXT_SYNC=false
 # Starknet Earn (Vesu / Starkzap): wallet Earn CTA, deposit/withdraw, activity tab
 NEXT_PUBLIC_EARN_ENABLED=false
 
+# EVM → Starknet Earn (LayerSwap bridge + Vesu). Requires NEXT_PUBLIC_EARN_ENABLED=true
+NEXT_PUBLIC_EVM_EARN_ENABLED=false
+LAYERSWAP_API_KEY=
+LAYERSWAP_API_BASE_URL=https://api.layerswap.io #optional
+
 NEXT_PUBLIC_TRON_ENABLED=false
 # Optional: custom Tron RPC URL (defaults to https://api.trongrid.io)
 # NEXT_PUBLIC_TRON_RPC_URL=

--- a/__tests__/earnChains.test.ts
+++ b/__tests__/earnChains.test.ts
@@ -1,0 +1,30 @@
+import {
+  EVM_EARN_SOURCE_CHAINS,
+  earnBridgeConfirmationCopy,
+  isEvmEarnSourceChain,
+  layerswapSourceNetwork,
+} from "../app/lib/earnChains";
+
+describe("earnChains", () => {
+  it("lists seven EVM source chains", () => {
+    expect(EVM_EARN_SOURCE_CHAINS).toHaveLength(7);
+    expect(EVM_EARN_SOURCE_CHAINS).toContain("Base");
+    expect(EVM_EARN_SOURCE_CHAINS).toContain("Scroll");
+  });
+
+  it("maps noblocks network names to LayerSwap identifiers", () => {
+    expect(layerswapSourceNetwork("Base")).toBe("BASE_MAINNET");
+    expect(layerswapSourceNetwork("BNB Smart Chain")).toBe("BSC_MAINNET");
+    expect(layerswapSourceNetwork("Lisk")).toBeUndefined();
+  });
+
+  it("recognizes supported source chains", () => {
+    expect(isEvmEarnSourceChain("Polygon")).toBe(true);
+    expect(isEvmEarnSourceChain("Starknet")).toBe(false);
+  });
+
+  it("builds bridge confirmation copy with ETA fallback", () => {
+    expect(earnBridgeConfirmationCopy()).toContain("~15 min");
+    expect(earnBridgeConfirmationCopy("~8 min")).toContain("~8 min");
+  });
+});

--- a/__tests__/earnFeature.test.ts
+++ b/__tests__/earnFeature.test.ts
@@ -1,0 +1,50 @@
+import {
+  filterEarnActivityForChain,
+  isEarnActionVisible,
+  isEarnUiVisible,
+  isEvmEarnFlow,
+} from "../app/lib/earnFeature";
+
+jest.mock("../app/lib/config", () => ({
+  __esModule: true,
+  default: {
+    earnEnabled: true,
+    evmEarnEnabled: true,
+  },
+}));
+
+describe("earnFeature", () => {
+  it("shows full earn UI on Starknet", () => {
+    expect(isEarnUiVisible("Starknet")).toBe(true);
+    expect(isEvmEarnFlow("Starknet")).toBe(false);
+  });
+
+  it("shows full earn UI on supported EVM chains when phase 2 is enabled", () => {
+    expect(isEarnUiVisible("Base")).toBe(true);
+    expect(isEvmEarnFlow("Base")).toBe(true);
+  });
+
+  it("shows earn action on Lisk (unavailable tooltip, not full UI)", () => {
+    expect(isEarnActionVisible("Lisk")).toBe(true);
+    expect(isEarnUiVisible("Lisk")).toBe(false);
+  });
+
+  it("scopes EVM-sourced activity to the source chain wallet view", () => {
+    const entries = [
+      { sourceChain: "Base", type: "deposit" as const },
+      { sourceChain: "Polygon", type: "deposit" as const },
+      { type: "deposit" as const },
+    ];
+    expect(filterEarnActivityForChain(entries, "Base")).toEqual([
+      { sourceChain: "Base", type: "deposit" },
+    ]);
+    expect(
+      filterEarnActivityForChain(entries, "Base", {
+        includeLegacyUntaggedDeposits: true,
+      }),
+    ).toHaveLength(2);
+    expect(filterEarnActivityForChain(entries, "Starknet")).toEqual([
+      { type: "deposit" },
+    ]);
+  });
+});

--- a/__tests__/earnPositionStore.test.ts
+++ b/__tests__/earnPositionStore.test.ts
@@ -3,8 +3,12 @@
  */
 import {
   addEarnSourcePosition,
+  formatUsdcBaseUnits,
+  isStaleLiveFlowClaim,
+  LIVE_FLOW_CLAIM_STALE_MS,
   readEarnSourcePosition,
   subtractEarnSourcePosition,
+  type PendingEarnBridgeJob,
 } from "../app/lib/earnPositionStore";
 
 const EVM = "0x1111111111111111111111111111111111111111";
@@ -22,6 +26,16 @@ beforeEach(() => {
     memoryStore.delete(key);
   });
   window.localStorage.clear = jest.fn(() => memoryStore.clear());
+});
+
+const baseJob = (): PendingEarnBridgeJob => ({
+  swapId: "swap-1",
+  sourceChain: "Base",
+  evmAddress: EVM,
+  starknetAddress: "0xabc",
+  requestedAmountBaseUnits: "100000",
+  receiveAmountBaseUnits: "50000",
+  createdAt: Date.now(),
 });
 
 describe("earnPositionStore accumulation", () => {
@@ -68,5 +82,46 @@ describe("earnPositionStore accumulation", () => {
 
     subtractEarnSourcePosition(EVM, "Base", "USDC", BigInt(60_000));
     expect(readEarnSourcePosition(EVM, "Base", "USDC")).toBeNull();
+  });
+
+  it("formats USDC base units above Number.MAX_SAFE_INTEGER without rounding", () => {
+    const large = BigInt("10000000000000001");
+    expect(formatUsdcBaseUnits(large)).toBe("10000000000.000001");
+
+    addEarnSourcePosition(
+      EVM,
+      {
+        sourceChain: "Base",
+        starknetAddress: "0xabc",
+        deltaBaseUnits: large,
+      },
+      "USDC",
+    );
+    expect(readEarnSourcePosition(EVM, "Base", "USDC")?.suppliedFormatted).toBe(
+      "10000000000.000001",
+    );
+  });
+});
+
+describe("isStaleLiveFlowClaim", () => {
+  it("uses claimedAt instead of createdAt when present", () => {
+    const now = Date.now();
+    const job: PendingEarnBridgeJob = {
+      ...baseJob(),
+      createdAt: now - LIVE_FLOW_CLAIM_STALE_MS - 60_000,
+      claimedByLiveFlow: true,
+      claimedAt: now - 1_000,
+    };
+    expect(isStaleLiveFlowClaim(job)).toBe(false);
+  });
+
+  it("falls back to createdAt for legacy jobs without claimedAt", () => {
+    const now = Date.now();
+    const job: PendingEarnBridgeJob = {
+      ...baseJob(),
+      createdAt: now - LIVE_FLOW_CLAIM_STALE_MS - 1_000,
+      claimedByLiveFlow: true,
+    };
+    expect(isStaleLiveFlowClaim(job)).toBe(true);
   });
 });

--- a/__tests__/earnPositionStore.test.ts
+++ b/__tests__/earnPositionStore.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  addEarnSourcePosition,
+  readEarnSourcePosition,
+  subtractEarnSourcePosition,
+} from "../app/lib/earnPositionStore";
+
+const EVM = "0x1111111111111111111111111111111111111111";
+const memoryStore = new Map<string, string>();
+
+beforeEach(() => {
+  memoryStore.clear();
+  window.localStorage.getItem = jest.fn(
+    (key: string) => memoryStore.get(key) ?? null,
+  );
+  window.localStorage.setItem = jest.fn((key: string, value: string) => {
+    memoryStore.set(key, value);
+  });
+  window.localStorage.removeItem = jest.fn((key: string) => {
+    memoryStore.delete(key);
+  });
+  window.localStorage.clear = jest.fn(() => memoryStore.clear());
+});
+
+describe("earnPositionStore accumulation", () => {
+  it("adds to an existing source position", () => {
+    addEarnSourcePosition(
+      EVM,
+      {
+        sourceChain: "Base",
+        starknetAddress: "0xabc",
+        deltaBaseUnits: BigInt(48_000),
+      },
+      "USDC",
+    );
+    addEarnSourcePosition(
+      EVM,
+      {
+        sourceChain: "Base",
+        starknetAddress: "0xabc",
+        deltaBaseUnits: BigInt(52_000),
+      },
+      "USDC",
+    );
+
+    const pos = readEarnSourcePosition(EVM, "Base", "USDC");
+    expect(pos?.suppliedBaseUnits).toBe("100000");
+    expect(pos?.suppliedFormatted).toBe("0.100000");
+  });
+
+  it("subtracts partial withdrawals and clears at zero", () => {
+    addEarnSourcePosition(
+      EVM,
+      {
+        sourceChain: "Base",
+        starknetAddress: "0xabc",
+        deltaBaseUnits: BigInt(100_000),
+      },
+      "USDC",
+    );
+
+    subtractEarnSourcePosition(EVM, "Base", "USDC", BigInt(40_000));
+    expect(readEarnSourcePosition(EVM, "Base", "USDC")?.suppliedBaseUnits).toBe(
+      "60000",
+    );
+
+    subtractEarnSourcePosition(EVM, "Base", "USDC", BigInt(60_000));
+    expect(readEarnSourcePosition(EVM, "Base", "USDC")).toBeNull();
+  });
+});

--- a/__tests__/evmEarnWalletTotal.test.ts
+++ b/__tests__/evmEarnWalletTotal.test.ts
@@ -1,0 +1,65 @@
+import {
+  evmWalletDisplayTotalUsd,
+  parseEarnDepositedUsd,
+  resolveEvmEarnWalletDisplayTotal,
+  selectedChainLiquidUsd,
+} from "../app/lib/evmEarnWalletTotal";
+import type { CrossChainBalanceEntry } from "../app/context";
+
+jest.mock("../app/lib/config", () => ({
+  __esModule: true,
+  default: {
+    earnEnabled: true,
+    evmEarnEnabled: true,
+  },
+}));
+
+function entry(chainName: string, total: number): CrossChainBalanceEntry {
+  return {
+    network: { chain: { name: chainName, id: 1 } } as CrossChainBalanceEntry["network"],
+    balances: {
+      total,
+      balances: { USDC: total },
+      rawBalances: { USDC: total },
+    },
+  };
+}
+
+describe("evmEarnWalletTotal", () => {
+  it("sums liquid and earn for EVM earn chains", () => {
+    const result = resolveEvmEarnWalletDisplayTotal({
+      chainName: "Base",
+      crossChainBalances: [entry("Base", 0.05), entry("Polygon", 1)],
+      earnDepositedUsd: 0.048,
+    });
+    expect(result.liquidUsd).toBe(0.05);
+    expect(result.displayTotalUsd).toBeCloseTo(0.098, 6);
+    expect(result.includesEarn).toBe(true);
+  });
+
+  it("does not add earn on non-earn chains", () => {
+    const result = resolveEvmEarnWalletDisplayTotal({
+      chainName: "Lisk",
+      crossChainBalances: [entry("Lisk", 0.2)],
+      earnDepositedUsd: 0.048,
+    });
+    expect(result.displayTotalUsd).toBe(0.2);
+    expect(result.includesEarn).toBe(false);
+  });
+
+  it("selectedChainLiquidUsd reads one network entry", () => {
+    expect(
+      selectedChainLiquidUsd([entry("Base", 0.05), entry("Polygon", 1)], "Base"),
+    ).toBe(0.05);
+  });
+
+  it("parseEarnDepositedUsd rejects invalid values", () => {
+    expect(parseEarnDepositedUsd("0.048")).toBe(0.048);
+    expect(parseEarnDepositedUsd("")).toBe(0);
+    expect(parseEarnDepositedUsd(undefined)).toBe(0);
+  });
+
+  it("evmWalletDisplayTotalUsd adds safely", () => {
+    expect(evmWalletDisplayTotalUsd(0.05, 0.048)).toBeCloseTo(0.098, 6);
+  });
+});

--- a/__tests__/layerswapExecute.test.ts
+++ b/__tests__/layerswapExecute.test.ts
@@ -1,0 +1,35 @@
+import { base } from "viem/chains";
+import { buildLayerswapDepositBatchCalls } from "../app/lib/layerswapExecute";
+
+jest.mock("../app/lib/erc20Allowance", () => ({
+  needsGatewayApproval: jest.fn().mockResolvedValue(false),
+}));
+
+describe("buildLayerswapDepositBatchCalls", () => {
+  it("does not attach native value for ERC-20 deposit actions", async () => {
+    const calls = await buildLayerswapDepositBatchCalls({
+      chain: base,
+      rpcUrl: "https://rpc.example",
+      fromAddress: "0x2222222222222222222222222222222222222222",
+      tokenAmountBaseUnits: BigInt(50_000),
+      depositActions: [
+        {
+          type: "transfer",
+          to_address: "0x3333333333333333333333333333333333333333",
+          amount: 0.05,
+          amount_in_base_units: "50000",
+          order: 0,
+          call_data: "0xdeadbeef",
+          token: {
+            contract: "0x1111111111111111111111111111111111111111",
+            symbol: "USDC",
+            decimals: 6,
+          },
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.value).toBe(BigInt(0));
+  });
+});

--- a/__tests__/layerswapRouteAuth.test.ts
+++ b/__tests__/layerswapRouteAuth.test.ts
@@ -1,0 +1,27 @@
+import { swapBelongsToUser } from "../app/lib/layerswapAddressMatch";
+
+describe("swapBelongsToUser Starknet canonicalization", () => {
+  const padded =
+    "0x0000000000000000000000000000000000000000000000000000000000001234";
+  const short = "0x1234";
+
+  it("matches padded LayerSwap addresses to canonical user addresses", () => {
+    expect(
+      swapBelongsToUser({
+        linkedEvmAddresses: [],
+        starknetAddresses: [padded],
+        sourceAddress: short,
+      }),
+    ).toBe(true);
+  });
+
+  it("matches canonical addresses in either direction", () => {
+    expect(
+      swapBelongsToUser({
+        linkedEvmAddresses: [],
+        starknetAddresses: [short],
+        destinationAddress: padded,
+      }),
+    ).toBe(true);
+  });
+});

--- a/__tests__/layerswapStarknetExecute.test.ts
+++ b/__tests__/layerswapStarknetExecute.test.ts
@@ -1,0 +1,26 @@
+import { layerswapDepositActionsToStarknetCalls } from "../app/lib/layerswap";
+
+describe("layerswapDepositActionsToStarknetCalls", () => {
+  it("parses LayerSwap Starknet JSON call_data", () => {
+    const calls = layerswapDepositActionsToStarknetCalls([
+      {
+        type: "transfer",
+        to_address: "0xdepository",
+        amount: 0.05,
+        amount_in_base_units: "50000",
+        order: 0,
+        call_data: JSON.stringify([
+          {
+            contractAddress:
+              "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb",
+            entrypoint: "transfer",
+            calldata: ["0x1", "50000", "0"],
+          },
+        ]),
+      },
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.entrypoint).toBe("transfer");
+    expect(calls[0]?.calldata).toEqual(["0x1", "50000", "0"]);
+  });
+});

--- a/__tests__/layerswapValidation.test.ts
+++ b/__tests__/layerswapValidation.test.ts
@@ -1,0 +1,43 @@
+import {
+  parseLayerswapAmountBody,
+  parseLayerswapAmountParam,
+} from "../app/lib/layerswapValidation";
+import { resolveLayerswapApiBaseUrl } from "../app/lib/layerswapConfig";
+
+describe("parseLayerswapAmountParam", () => {
+  it("accepts valid positive amounts", () => {
+    expect(parseLayerswapAmountParam("0.1")).toBe(0.1);
+    expect(parseLayerswapAmountParam("1")).toBe(1);
+  });
+
+  it("rejects partial parse strings", () => {
+    expect(parseLayerswapAmountParam("1abc")).toBeNull();
+  });
+
+  it("rejects non-finite values", () => {
+    expect(parseLayerswapAmountParam("Infinity")).toBeNull();
+    expect(parseLayerswapAmountParam("-1")).toBeNull();
+    expect(parseLayerswapAmountParam("0")).toBeNull();
+  });
+});
+
+describe("parseLayerswapAmountBody", () => {
+  it("rejects invalid body amounts", () => {
+    expect(parseLayerswapAmountBody("1abc")).toBeNull();
+    expect(parseLayerswapAmountBody(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe("resolveLayerswapApiBaseUrl", () => {
+  it("strips trailing slashes and requires https", () => {
+    expect(resolveLayerswapApiBaseUrl("https://api.layerswap.io/")).toBe(
+      "https://api.layerswap.io",
+    );
+  });
+
+  it("falls back when http is configured", () => {
+    expect(resolveLayerswapApiBaseUrl("http://evil.example")).toBe(
+      "https://api.layerswap.io",
+    );
+  });
+});

--- a/app/api/earn/layerswap/quote/route.ts
+++ b/app/api/earn/layerswap/quote/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { getLayerswapApiKey, layerswapGetQuote } from "@/app/lib/layerswap";
+import { layerswapSourceNetwork } from "@/app/lib/earnChains";
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const apiKey = getLayerswapApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "LayerSwap is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const sourceChain = request.nextUrl.searchParams.get("sourceChain") || "";
+  const amount = parseFloat(request.nextUrl.searchParams.get("amount") || "0");
+  const destinationAddress =
+    request.nextUrl.searchParams.get("destinationAddress") || "";
+
+  const sourceNetwork = layerswapSourceNetwork(sourceChain);
+  if (!sourceNetwork || !destinationAddress || !(amount > 0)) {
+    return NextResponse.json(
+      { error: "sourceChain, amount, and destinationAddress are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const quote = await layerswapGetQuote({
+      apiKey,
+      sourceNetwork,
+      amount,
+      destinationAddress,
+    });
+    return NextResponse.json({ success: true, quote });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Quote failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/earn/layerswap/quote/route.ts
+++ b/app/api/earn/layerswap/quote/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withRateLimit } from "@/app/lib/rate-limit";
 import { getLayerswapApiKey, layerswapGetQuote } from "@/app/lib/layerswap";
 import { layerswapSourceNetwork } from "@/app/lib/earnChains";
+import { parseLayerswapAmountParam } from "@/app/lib/layerswapValidation";
 
 export const GET = withRateLimit(async (request: NextRequest) => {
   const apiKey = getLayerswapApiKey();
@@ -13,12 +14,14 @@ export const GET = withRateLimit(async (request: NextRequest) => {
   }
 
   const sourceChain = request.nextUrl.searchParams.get("sourceChain") || "";
-  const amount = parseFloat(request.nextUrl.searchParams.get("amount") || "0");
+  const amount = parseLayerswapAmountParam(
+    request.nextUrl.searchParams.get("amount"),
+  );
   const destinationAddress =
     request.nextUrl.searchParams.get("destinationAddress") || "";
 
   const sourceNetwork = layerswapSourceNetwork(sourceChain);
-  if (!sourceNetwork || !destinationAddress || !(amount > 0)) {
+  if (!sourceNetwork || !destinationAddress || amount === null) {
     return NextResponse.json(
       { error: "sourceChain, amount, and destinationAddress are required" },
       { status: 400 },

--- a/app/api/earn/layerswap/starknet-deposit/route.ts
+++ b/app/api/earn/layerswap/starknet-deposit/route.ts
@@ -111,10 +111,28 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       maxFee,
     );
 
-    const txReceipt = await account.waitForTransaction(result.transaction_hash);
+    let txReceipt;
+    try {
+      txReceipt = await account.waitForTransaction(result.transaction_hash, {
+        retries: 60,
+        retryInterval: 5_000,
+      });
+    } catch {
+      return NextResponse.json(
+        {
+          error:
+            "Transaction submitted but confirmation timed out. Check the explorer.",
+          transactionHash: result.transaction_hash,
+        },
+        { status: 502 },
+      );
+    }
     if (!txReceipt.isSuccess()) {
       return NextResponse.json(
-        { error: "LayerSwap Starknet deposit reverted on-chain" },
+        {
+          error: "LayerSwap Starknet deposit reverted on-chain",
+          transactionHash: result.transaction_hash,
+        },
         { status: 500 },
       );
     }

--- a/app/api/earn/layerswap/starknet-deposit/route.ts
+++ b/app/api/earn/layerswap/starknet-deposit/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyJWT } from "@/app/lib/jwt";
+import {
+  DEFAULT_PRIVY_CONFIG,
+  STARKNET_READY_ACCOUNT_CLASSHASH,
+} from "@/app/lib/config";
+import {
+  applySafetyMargin,
+  buildReadyAccount,
+  getStarknetWallet,
+  setupPaymaster,
+} from "@/app/lib/starknet";
+import type { LayerswapDepositAction } from "@/app/lib/layerswap";
+import { layerswapDepositActionsToStarknetCalls } from "@/app/lib/layerswap";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiError,
+  trackApiRequest,
+  trackApiResponse,
+} from "@/app/lib/server-analytics";
+
+const ROUTE = "/api/earn/layerswap/starknet-deposit";
+
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+
+  try {
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return NextResponse.json(
+        { error: "Missing or invalid authorization header" },
+        { status: 401 },
+      );
+    }
+
+    const token = authHeader.substring(7);
+    const { payload } = await verifyJWT(token, DEFAULT_PRIVY_CONFIG);
+    const authUserId = payload.sub || payload.userId;
+    if (!authUserId) {
+      return NextResponse.json(
+        { error: "Invalid token: missing user ID" },
+        { status: 401 },
+      );
+    }
+
+    trackApiRequest(request, ROUTE, "POST", { privy_user_id: authUserId });
+
+    const body = await request.json();
+    const {
+      walletId,
+      publicKey,
+      classHash: clientClassHash,
+      origin: clientOrigin,
+      depositActions,
+    } = body as {
+      walletId?: string;
+      publicKey?: string;
+      classHash?: string;
+      origin?: string;
+      depositActions?: LayerswapDepositAction[];
+    };
+
+    if (!walletId || !publicKey) {
+      return NextResponse.json(
+        { error: "Missing walletId or publicKey" },
+        { status: 400 },
+      );
+    }
+    if (!depositActions?.length) {
+      return NextResponse.json(
+        { error: "depositActions are required" },
+        { status: 400 },
+      );
+    }
+
+    const classHash = clientClassHash || STARKNET_READY_ACCOUNT_CLASSHASH;
+    const origin = clientOrigin || request.headers.get("origin") || undefined;
+
+    const { publicKey: walletPublicKey } = await getStarknetWallet(walletId);
+
+    const paymasterCfg = await setupPaymaster();
+    const { paymasterRpc, isSponsored, gasToken } = paymasterCfg;
+
+    const { account } = await buildReadyAccount({
+      walletId,
+      publicKey: walletPublicKey,
+      classHash,
+      userJwt: token,
+      userId: authUserId,
+      origin,
+      paymasterRpc,
+    });
+
+    const calls = layerswapDepositActionsToStarknetCalls(depositActions);
+    const paymasterDetails: any = isSponsored
+      ? { feeMode: { mode: "sponsored" as const } }
+      : { feeMode: { mode: "default" as const, gasToken } };
+
+    let maxFee: any = undefined;
+    if (!isSponsored) {
+      const est = await account.estimatePaymasterTransactionFee(
+        calls,
+        paymasterDetails,
+      );
+      maxFee = applySafetyMargin(est.suggested_max_fee_in_gas_token);
+    }
+
+    const result = await account.executePaymasterTransaction(
+      calls,
+      paymasterDetails,
+      maxFee,
+    );
+
+    const txReceipt = await account.waitForTransaction(result.transaction_hash);
+    if (!txReceipt.isSuccess()) {
+      return NextResponse.json(
+        { error: "LayerSwap Starknet deposit reverted on-chain" },
+        { status: 500 },
+      );
+    }
+
+    const responseTime = Date.now() - startTime;
+    trackApiResponse(ROUTE, "POST", 200, responseTime, {
+      privy_user_id: authUserId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      transactionHash: result.transaction_hash,
+    });
+  } catch (error: unknown) {
+    const err =
+      error instanceof Error ? error : new Error("Starknet deposit failed");
+    trackApiError(request, ROUTE, "POST", err, 500);
+    return NextResponse.json(
+      { error: err.message || "Starknet deposit failed" },
+      { status: 500 },
+    );
+  }
+});

--- a/app/api/earn/layerswap/swap/route.ts
+++ b/app/api/earn/layerswap/swap/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  getLayerswapApiKey,
+  layerswapCreateEarnSwap,
+} from "@/app/lib/layerswap";
+
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const apiKey = getLayerswapApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "LayerSwap is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.json();
+  const {
+    sourceChain,
+    amount,
+    destinationAddress,
+    sourceAddress,
+    refundAddress,
+  } = body as {
+    sourceChain?: string;
+    amount?: number;
+    destinationAddress?: string;
+    sourceAddress?: string;
+    refundAddress?: string;
+  };
+
+  if (!sourceChain || !destinationAddress || !(Number(amount) > 0)) {
+    return NextResponse.json(
+      { error: "sourceChain, amount, and destinationAddress are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const prepared = await layerswapCreateEarnSwap({
+      apiKey,
+      sourceChainName: sourceChain,
+      amount: Number(amount),
+      destinationAddress,
+      sourceAddress,
+      refundAddress,
+    });
+    return NextResponse.json({ success: true, ...prepared });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Swap creation failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/earn/layerswap/swap/route.ts
+++ b/app/api/earn/layerswap/swap/route.ts
@@ -4,6 +4,12 @@ import {
   getLayerswapApiKey,
   layerswapCreateEarnSwap,
 } from "@/app/lib/layerswap";
+import { parseLayerswapAmountBody } from "@/app/lib/layerswapValidation";
+import {
+  assertEvmAddressOwnedByUser,
+  assertStarknetAddressOwnedByUser,
+  requireLayerswapAuth,
+} from "@/app/lib/layerswapRouteAuth";
 
 export const POST = withRateLimit(async (request: NextRequest) => {
   const apiKey = getLayerswapApiKey();
@@ -14,33 +20,76 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     );
   }
 
-  const body = await request.json();
+  const authResult = await requireLayerswapAuth(request);
+  if (!authResult.ok) return authResult.response;
+  const { auth } = authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
   const {
     sourceChain,
     amount,
     destinationAddress,
     sourceAddress,
     refundAddress,
-  } = body as {
+    walletId,
+  } = (body ?? {}) as {
     sourceChain?: string;
-    amount?: number;
+    amount?: number | string;
     destinationAddress?: string;
     sourceAddress?: string;
     refundAddress?: string;
+    walletId?: string;
   };
 
-  if (!sourceChain || !destinationAddress || !(Number(amount) > 0)) {
+  const parsedAmount = parseLayerswapAmountBody(amount);
+  if (!sourceChain || !destinationAddress || parsedAmount === null) {
     return NextResponse.json(
       { error: "sourceChain, amount, and destinationAddress are required" },
       { status: 400 },
     );
   }
+  if (!walletId) {
+    return NextResponse.json({ error: "walletId is required" }, { status: 400 });
+  }
+  if (!sourceAddress) {
+    return NextResponse.json({ error: "sourceAddress is required" }, { status: 400 });
+  }
 
   try {
+    const [evmOwned, starknetOwned] = await Promise.all([
+      assertEvmAddressOwnedByUser(auth.userId, sourceAddress),
+      assertStarknetAddressOwnedByUser(
+        auth.userId,
+        walletId,
+        destinationAddress,
+      ),
+    ]);
+    if (!evmOwned) {
+      return NextResponse.json(
+        { error: "sourceAddress does not belong to the authenticated user" },
+        { status: 403 },
+      );
+    }
+    if (!starknetOwned) {
+      return NextResponse.json(
+        {
+          error:
+            "destinationAddress does not belong to the authenticated user",
+        },
+        { status: 403 },
+      );
+    }
+
     const prepared = await layerswapCreateEarnSwap({
       apiKey,
       sourceChainName: sourceChain,
-      amount: Number(amount),
+      amount: parsedAmount,
       destinationAddress,
       sourceAddress,
       refundAddress,

--- a/app/api/earn/layerswap/swap/status/route.ts
+++ b/app/api/earn/layerswap/swap/status/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withRateLimit } from "@/app/lib/rate-limit";
 import { getLayerswapApiKey, layerswapGetSwap } from "@/app/lib/layerswap";
+import { STARKNET_READY_ACCOUNT_CLASSHASH } from "@/app/lib/config";
+import { collectLinkedEvmAddressesForPrivyUserId } from "@/app/lib/privy";
+import {
+  requireLayerswapAuth,
+  swapBelongsToUser,
+} from "@/app/lib/layerswapRouteAuth";
+import { computeReadyAddress, getStarknetWallet } from "@/app/lib/starknet";
 
 export const GET = withRateLimit(async (request: NextRequest) => {
   const apiKey = getLayerswapApiKey();
@@ -11,14 +18,52 @@ export const GET = withRateLimit(async (request: NextRequest) => {
     );
   }
 
+  const authResult = await requireLayerswapAuth(request);
+  if (!authResult.ok) return authResult.response;
+  const { auth } = authResult;
+
   const swapId = request.nextUrl.searchParams.get("id") || "";
+  const walletId = request.nextUrl.searchParams.get("walletId") || "";
   if (!swapId) {
     return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+  if (!walletId) {
+    return NextResponse.json({ error: "walletId is required" }, { status: 400 });
   }
 
   try {
     const data = await layerswapGetSwap({ apiKey, swapId });
-    return NextResponse.json({ success: true, ...data });
+    const linkedEvm = await collectLinkedEvmAddressesForPrivyUserId(auth.userId);
+
+    const { publicKey } = await getStarknetWallet(walletId);
+    const starknetAddress = computeReadyAddress(
+      publicKey,
+      STARKNET_READY_ACCOUNT_CLASSHASH,
+    );
+
+    const allowed = swapBelongsToUser({
+      linkedEvmAddresses: linkedEvm,
+      starknetAddresses: [starknetAddress],
+      sourceAddress: data.swap?.source_address,
+      destinationAddress: data.swap?.destination_address,
+    });
+    if (!allowed) {
+      return NextResponse.json({ error: "Swap not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      swap: {
+        id: data.swap.id,
+        status: data.swap.status,
+        fail_reason: data.swap.fail_reason ?? null,
+      },
+      quote: data.quote
+        ? {
+            receive_amount: data.quote.receive_amount,
+          }
+        : undefined,
+    });
   } catch (e) {
     const message = e instanceof Error ? e.message : "Swap lookup failed";
     return NextResponse.json({ error: message }, { status: 502 });

--- a/app/api/earn/layerswap/swap/status/route.ts
+++ b/app/api/earn/layerswap/swap/status/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { getLayerswapApiKey, layerswapGetSwap } from "@/app/lib/layerswap";
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const apiKey = getLayerswapApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "LayerSwap is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const swapId = request.nextUrl.searchParams.get("id") || "";
+  if (!swapId) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  try {
+    const data = await layerswapGetSwap({ apiKey, swapId });
+    return NextResponse.json({ success: true, ...data });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Swap lookup failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/earn/layerswap/withdraw-quote/route.ts
+++ b/app/api/earn/layerswap/withdraw-quote/route.ts
@@ -5,6 +5,7 @@ import {
   LAYERSWAP_STARKNET_NETWORK,
   layerswapSourceNetwork,
 } from "@/app/lib/earnChains";
+import { parseLayerswapAmountParam } from "@/app/lib/layerswapValidation";
 
 export const GET = withRateLimit(async (request: NextRequest) => {
   const apiKey = getLayerswapApiKey();
@@ -17,12 +18,14 @@ export const GET = withRateLimit(async (request: NextRequest) => {
 
   const destinationChain =
     request.nextUrl.searchParams.get("destinationChain") || "";
-  const amount = parseFloat(request.nextUrl.searchParams.get("amount") || "0");
+  const amount = parseLayerswapAmountParam(
+    request.nextUrl.searchParams.get("amount"),
+  );
   const destinationAddress =
     request.nextUrl.searchParams.get("destinationAddress") || "";
 
   const destinationNetwork = layerswapSourceNetwork(destinationChain);
-  if (!destinationNetwork || !destinationAddress || !(amount > 0)) {
+  if (!destinationNetwork || !destinationAddress || amount === null) {
     return NextResponse.json(
       {
         error:

--- a/app/api/earn/layerswap/withdraw-quote/route.ts
+++ b/app/api/earn/layerswap/withdraw-quote/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { getLayerswapApiKey, layerswapGetQuote } from "@/app/lib/layerswap";
+import {
+  LAYERSWAP_STARKNET_NETWORK,
+  layerswapSourceNetwork,
+} from "@/app/lib/earnChains";
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const apiKey = getLayerswapApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "LayerSwap is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const destinationChain =
+    request.nextUrl.searchParams.get("destinationChain") || "";
+  const amount = parseFloat(request.nextUrl.searchParams.get("amount") || "0");
+  const destinationAddress =
+    request.nextUrl.searchParams.get("destinationAddress") || "";
+
+  const destinationNetwork = layerswapSourceNetwork(destinationChain);
+  if (!destinationNetwork || !destinationAddress || !(amount > 0)) {
+    return NextResponse.json(
+      {
+        error:
+          "destinationChain, amount, and destinationAddress are required",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const quote = await layerswapGetQuote({
+      apiKey,
+      sourceNetwork: LAYERSWAP_STARKNET_NETWORK,
+      destinationNetwork,
+      amount,
+      destinationAddress,
+    });
+    return NextResponse.json({ success: true, quote });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Quote failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/earn/layerswap/withdraw-swap/route.ts
+++ b/app/api/earn/layerswap/withdraw-swap/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  getLayerswapApiKey,
+  layerswapCreateEarnWithdrawSwap,
+} from "@/app/lib/layerswap";
+
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const apiKey = getLayerswapApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "LayerSwap is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.json();
+  const {
+    destinationChain,
+    amount,
+    destinationAddress,
+    sourceAddress,
+    refundAddress,
+  } = body as {
+    destinationChain?: string;
+    amount?: number;
+    destinationAddress?: string;
+    sourceAddress?: string;
+    refundAddress?: string;
+  };
+
+  if (!destinationChain || !destinationAddress || !(Number(amount) > 0)) {
+    return NextResponse.json(
+      {
+        error:
+          "destinationChain, amount, and destinationAddress are required",
+      },
+      { status: 400 },
+    );
+  }
+  if (!sourceAddress) {
+    return NextResponse.json(
+      { error: "sourceAddress (Starknet) is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const prepared = await layerswapCreateEarnWithdrawSwap({
+      apiKey,
+      destinationChainName: destinationChain,
+      amount: Number(amount),
+      destinationAddress,
+      sourceAddress,
+      refundAddress,
+    });
+    return NextResponse.json({ success: true, ...prepared });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Swap creation failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/earn/layerswap/withdraw-swap/route.ts
+++ b/app/api/earn/layerswap/withdraw-swap/route.ts
@@ -4,6 +4,12 @@ import {
   getLayerswapApiKey,
   layerswapCreateEarnWithdrawSwap,
 } from "@/app/lib/layerswap";
+import { parseLayerswapAmountBody } from "@/app/lib/layerswapValidation";
+import {
+  assertEvmAddressOwnedByUser,
+  assertStarknetAddressOwnedByUser,
+  requireLayerswapAuth,
+} from "@/app/lib/layerswapRouteAuth";
 
 export const POST = withRateLimit(async (request: NextRequest) => {
   const apiKey = getLayerswapApiKey();
@@ -14,22 +20,35 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     );
   }
 
-  const body = await request.json();
+  const authResult = await requireLayerswapAuth(request);
+  if (!authResult.ok) return authResult.response;
+  const { auth } = authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
   const {
     destinationChain,
     amount,
     destinationAddress,
     sourceAddress,
     refundAddress,
-  } = body as {
+    walletId,
+  } = (body ?? {}) as {
     destinationChain?: string;
-    amount?: number;
+    amount?: number | string;
     destinationAddress?: string;
     sourceAddress?: string;
     refundAddress?: string;
+    walletId?: string;
   };
 
-  if (!destinationChain || !destinationAddress || !(Number(amount) > 0)) {
+  const parsedAmount = parseLayerswapAmountBody(amount);
+  if (!destinationChain || !destinationAddress || parsedAmount === null) {
     return NextResponse.json(
       {
         error:
@@ -44,12 +63,35 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       { status: 400 },
     );
   }
+  if (!walletId) {
+    return NextResponse.json({ error: "walletId is required" }, { status: 400 });
+  }
 
   try {
+    const [starknetOwned, evmOwned] = await Promise.all([
+      assertStarknetAddressOwnedByUser(auth.userId, walletId, sourceAddress),
+      assertEvmAddressOwnedByUser(auth.userId, destinationAddress),
+    ]);
+    if (!starknetOwned) {
+      return NextResponse.json(
+        { error: "sourceAddress does not belong to the authenticated user" },
+        { status: 403 },
+      );
+    }
+    if (!evmOwned) {
+      return NextResponse.json(
+        {
+          error:
+            "destinationAddress does not belong to the authenticated user",
+        },
+        { status: 403 },
+      );
+    }
+
     const prepared = await layerswapCreateEarnWithdrawSwap({
       apiKey,
       destinationChainName: destinationChain,
-      amount: Number(amount),
+      amount: parsedAmount,
       destinationAddress,
       sourceAddress,
       refundAddress,

--- a/app/components/EarnActivityPanel.tsx
+++ b/app/components/EarnActivityPanel.tsx
@@ -10,6 +10,7 @@ import {
   type EarnToken,
 } from "../hooks/useEarnHandler";
 import { classNames, getRelativeDate } from "../utils";
+import { filterEarnActivityForChain } from "../lib/earnFeature";
 import { EarnDisclosureBanner } from "./EarnDisclosureBanner";
 
 const TOKEN_DECIMALS = 6;
@@ -68,13 +69,29 @@ const Divider = () => (
 interface Props {
   onSelectActivity?: (entry: EarnActivityEntry) => void;
   showDisclosureBanner?: boolean;
+  /** When set, activity is scoped to this wallet view (EVM source chain or Starknet). */
+  chainName?: string;
+  /** Include untagged legacy deposits when this chain has an EVM source position. */
+  includeLegacyUntaggedDeposits?: boolean;
 }
 
 export const EarnActivityPanel: React.FC<Props> = ({
   onSelectActivity,
   showDisclosureBanner = true,
+  chainName,
+  includeLegacyUntaggedDeposits = false,
 }) => {
   const { positions, activity, refreshAllPositions } = useEarnHandler();
+
+  const scopedActivity = useMemo(
+    () =>
+      chainName
+        ? filterEarnActivityForChain(activity, chainName, {
+            includeLegacyUntaggedDeposits,
+          })
+        : activity,
+    [activity, chainName, includeLegacyUntaggedDeposits],
+  );
 
   useEffect(() => {
     void refreshAllPositions();
@@ -84,20 +101,19 @@ export const EarnActivityPanel: React.FC<Props> = ({
     return () => clearInterval(id);
   }, [refreshAllPositions]);
 
-  // Show a "Currently supplied" card per token where supplied > 0 (option b).
-  const suppliedTokens = useMemo<EarnToken[]>(
-    () =>
-      EARN_TOKENS.filter(
-        (t) => safeBigInt(positions[t]?.suppliedBaseUnits) > BigInt("0"),
-      ),
-    [positions],
-  );
+  // Show a "Currently supplied" card per token where supplied > 0 (Starknet earn only).
+  const suppliedTokens = useMemo<EarnToken[]>(() => {
+    if (chainName && chainName !== "Starknet") return [];
+    return EARN_TOKENS.filter(
+      (t) => safeBigInt(positions[t]?.suppliedBaseUnits) > BigInt("0"),
+    );
+  }, [positions, chainName]);
 
   // Group activity by relative date label (Today / Yesterday / N days ago …),
   // newest group first. Mirrors the Transactions tab grouping.
   const groupedActivity = useMemo(() => {
     const groups = new Map<string, EarnActivityEntry[]>();
-    for (const entry of activity) {
+    for (const entry of scopedActivity) {
       const label = getRelativeDate(new Date(entry.timestamp));
       const bucket = groups.get(label);
       if (bucket) bucket.push(entry);
@@ -106,7 +122,7 @@ export const EarnActivityPanel: React.FC<Props> = ({
     return Array.from(groups, ([label, entries]) => ({ label, entries })).sort(
       (a, b) => b.entries[0].timestamp - a.entries[0].timestamp,
     );
-  }, [activity]);
+  }, [scopedActivity]);
 
   return (
     <div className="space-y-6">

--- a/app/components/EarnBridgeTracker.tsx
+++ b/app/components/EarnBridgeTracker.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useEarnBridgeStatusTracker } from "../hooks/useEarnBridgeStatusTracker";
+
+/** Mount once inside app providers to resume in-flight EVM earn bridges. */
+export function EarnBridgeTracker() {
+  useEarnBridgeStatusTracker();
+  return null;
+}

--- a/app/components/EarnDisclosureBanner.tsx
+++ b/app/components/EarnDisclosureBanner.tsx
@@ -1,37 +1,38 @@
-"use client";
-
-import { InformationSquareIcon } from "hugeicons-react";
-import { EARN_LEARN_MORE_URL } from "../lib/earnConsent";
-import { classNames } from "../utils";
-
-interface EarnDisclosureBannerProps {
-  className?: string;
-}
-
-export const EarnDisclosureBanner: React.FC<EarnDisclosureBannerProps> = ({
-  className,
-}) => (
-  <div
-    className={classNames(
-      "flex items-start gap-2 rounded-xl border-[0.3px] border-border-light bg-accent-gray px-2 py-3 dark:border-white/10 dark:bg-white/5",
-      className,
-    )}
-  >
-    <InformationSquareIcon
-      className="mt-0.5 size-4 shrink-0 text-outline-gray dark:text-white/50"
-      aria-hidden
-    />
-    <p className="text-sm font-normal leading-5 text-text-secondary dark:text-white/50">
-      Your Earn balance is held in the Vesu protocol on Starknet. These funds
-      are outside the control of Noblocks.{" "}
-      <a
-        href={EARN_LEARN_MORE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="font-medium text-lavender-500 hover:text-lavender-600"
-      >
-        Learn more
-      </a>
-    </p>
-  </div>
-);
+"use client";
+
+import { InformationSquareIcon } from "hugeicons-react";
+import { EARN_LEARN_MORE_URL } from "../lib/earnConsent";
+import { classNames } from "../utils";
+
+interface EarnDisclosureBannerProps {
+  className?: string;
+}
+
+export const EarnDisclosureBanner: React.FC<EarnDisclosureBannerProps> = ({
+  className,
+}) => (
+  <div
+    className={classNames(
+      "flex items-start gap-2 rounded-xl border-[0.3px] border-border-light bg-accent-gray px-2 py-3 dark:border-white/10 dark:bg-white/5",
+      className,
+    )}
+  >
+    <InformationSquareIcon
+      className="mt-0.5 size-4 shrink-0 text-outline-gray dark:text-white/50"
+      aria-hidden
+    />
+    <p className="text-sm font-normal leading-5 text-text-secondary dark:text-white/50">
+      Your Earn balance is held in the Vesu protocol on Starknet. These funds
+      are outside the control of Noblocks.{" "}
+      <a
+        href={EARN_LEARN_MORE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-lavender-500 hover:text-lavender-600"
+      >
+        Learn more
+      </a>
+    </p>
+  </div>
+);
+

--- a/app/components/EarnSourcePositionCard.tsx
+++ b/app/components/EarnSourcePositionCard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEarnSourcePosition } from "../hooks/useEarnSourcePosition";
+import { EARN_STARKNET_DISCLOSURE } from "../lib/earnChains";
+import { classNames } from "../utils";
+
+interface EarnSourcePositionCardProps {
+  evmAddress: string;
+  sourceChain: string;
+  className?: string;
+}
+
+export function EarnSourcePositionCard({
+  evmAddress,
+  sourceChain,
+  className,
+}: EarnSourcePositionCardProps) {
+  const position = useEarnSourcePosition(evmAddress, sourceChain, "USDC");
+  if (!position) return null;
+
+  const supplied = parseFloat(position.suppliedFormatted || "0");
+  if (!(supplied > 0)) return null;
+
+  return (
+    <div
+      className={classNames(
+        "rounded-xl border border-border-light bg-accent-gray px-3 py-3 dark:border-white/10 dark:bg-white/5",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium text-text-body dark:text-white">
+          Earn · {supplied.toFixed(2)} USDC
+        </p>
+        {position.supplyApy != null && (
+          <span className="text-xs text-lavender-500">
+            {(position.supplyApy * 100).toFixed(2)}% APY
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-text-secondary dark:text-white/50">
+        {EARN_STARKNET_DISCLOSURE}
+      </p>
+    </div>
+  );
+}
+

--- a/app/components/EarnUnavailableModal.tsx
+++ b/app/components/EarnUnavailableModal.tsx
@@ -1,49 +1,32 @@
 "use client";
 
-import Image from "next/image";
 import { Coins01Icon } from "hugeicons-react";
 import { AnimatedModal } from "./AnimatedComponents";
 import { primaryBtnClasses } from "./Styles";
-import { networks } from "../mocks";
-import { getNetworkImageUrl } from "../utils";
-import { useActualTheme } from "../hooks/useActualTheme";
-
-const starknetNetwork = networks.find((n) => n.chain.name === "Starknet");
 
 interface EarnUnavailableModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-/** Shown when the manager opens Earn while on a network other than Starknet. */
+/** Shown when the user opens Earn on a network without full earn support. */
 export const EarnUnavailableModal = ({
   isOpen,
   onClose,
 }: EarnUnavailableModalProps) => {
-  const isDark = useActualTheme();
-
   return (
     <AnimatedModal isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col items-center gap-10 py-6 text-center">
         <div className="flex flex-col items-center gap-4">
-          <div className="relative flex size-[72px] shrink-0 items-center justify-center rounded-full bg-accent-gray text-gray-900 dark:bg-white/5 dark:text-white">
+          <div className="flex size-[72px] shrink-0 items-center justify-center rounded-full bg-accent-gray text-gray-900 dark:bg-white/5 dark:text-white">
             <Coins01Icon className="size-6" strokeWidth={2} />
-            {starknetNetwork && (
-              <Image
-                src={getNetworkImageUrl(starknetNetwork, isDark)}
-                alt="Starknet"
-                width={32}
-                height={32}
-                className="absolute -bottom-1 -right-1 size-8 rounded-full"
-              />
-            )}
           </div>
           <div className="flex flex-col items-center gap-2">
             <p className="text-lg font-semibold text-text-body dark:text-white">
-              Earn is currently available on Starknet.
+              Earn is currently not available on this network.
             </p>
             <p className="max-w-[19rem] text-sm text-text-secondary dark:text-white/50">
-              Switch your wallet to Starknet to start earning on your USDC.
+              Switch your wallet to another network to start earning on your USDC.
             </p>
           </div>
         </div>

--- a/app/components/EarnWalletForm.tsx
+++ b/app/components/EarnWalletForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useWallets } from "@privy-io/react-auth";
 import {
   ArrowLeft02Icon,
   Cancel01Icon,
@@ -9,12 +10,15 @@ import {
   Wallet01Icon,
 } from "hugeicons-react";
 import { toast } from "sonner";
-import { useBalance } from "../context";
+import { useBalance, useNetwork } from "../context";
 import {
   useEarnAvailableTokens,
   useEarnHandler,
   type EarnToken,
 } from "../hooks/useEarnHandler";
+import { useEvmEarnHandler } from "../hooks/useEvmEarnHandler";
+import { useEarnSourcePosition } from "../hooks/useEarnSourcePosition";
+import { isEvmEarnFlow } from "../lib/earnFeature";
 import { classNames } from "../utils";
 import { FormDropdown } from "./FormDropdown";
 import { primaryBtnClasses } from "./Styles";
@@ -56,6 +60,10 @@ function formatPercent(decimal: number | null): string {
   return `${(decimal * 100).toFixed(2)}%`;
 }
 
+function humanToBaseUnits(amount: number): bigint {
+  return BigInt(Math.round(amount * 1_000_000));
+}
+
 export const EarnWalletForm: React.FC<{
   onClose: () => void;
   showBackButton?: boolean;
@@ -69,9 +77,40 @@ export const EarnWalletForm: React.FC<{
   initialTab = "deposit",
   layout = "modal",
 }) => {
-  const { allBalances, refreshBalance } = useBalance();
+  const { allBalances, refreshBalance, crossChainBalances } = useBalance();
+  const { selectedNetwork } = useNetwork();
+  const { wallets } = useWallets();
   const { positions, refreshPosition, deposit, withdraw } = useEarnHandler();
-  const { tokens: availableEarnTokens } = useEarnAvailableTokens();
+  const {
+    confirmationCopy,
+    withdrawConfirmationCopy,
+    fetchQuote,
+    fetchWithdrawQuote,
+    depositFromEvm,
+    withdrawToEvm,
+    isEvmEarnChain,
+    quote,
+    quoteLoading,
+    withdrawQuote,
+    withdrawQuoteLoading,
+  } = useEvmEarnHandler();
+  const { tokens: availableEarnTokensRaw } = useEarnAvailableTokens();
+
+  const chainName = selectedNetwork.chain.name;
+  const isEvmFlow = isEvmEarnFlow(chainName);
+  const evmAddress = wallets
+    .find((w) => w.walletClientType === "privy")
+    ?.address?.toLowerCase();
+  const sourcePosition = useEarnSourcePosition(
+    isEvmFlow ? evmAddress : undefined,
+    chainName,
+    "USDC",
+  );
+
+  const availableEarnTokens = useMemo(
+    () => (isEvmFlow ? (["USDC"] as EarnToken[]) : availableEarnTokensRaw),
+    [isEvmFlow, availableEarnTokensRaw],
+  );
 
   const tokenDropdownItems = useMemo(
     () =>
@@ -94,24 +133,41 @@ export const EarnWalletForm: React.FC<{
   } | null>(null);
 
   const walletBalanceUnit: number = token
-    ? ((allBalances.starknetWallet?.balances?.[token] as number | undefined) ??
-      0)
+    ? isEvmFlow
+      ? ((crossChainBalances
+          .find((e) => e.network.chain.name === chainName)
+          ?.balances.balances?.[token] as number | undefined) ?? 0)
+      : ((allBalances.starknetWallet?.balances?.[token] as number | undefined) ??
+        0)
     : 0;
   const walletBalanceBaseUnits: bigint = token
-    ? (allBalances.starknetWallet?.balancesInWei?.[token] ?? BigInt("0"))
+    ? isEvmFlow
+      ? (crossChainBalances.find((e) => e.network.chain.name === chainName)
+          ?.balances.balancesInWei?.[token] ?? BigInt("0"))
+      : (allBalances.starknetWallet?.balancesInWei?.[token] ?? BigInt("0"))
     : BigInt("0");
 
   const position = token ? positions[token] : null;
   const suppliedBaseUnits: bigint = useMemo(() => {
+    if (isEvmFlow) {
+      if (!sourcePosition) return BigInt("0");
+      try {
+        return BigInt(sourcePosition.suppliedBaseUnits);
+      } catch {
+        return BigInt("0");
+      }
+    }
     if (!position) return BigInt("0");
     try {
       return BigInt(position.suppliedBaseUnits);
     } catch {
       return BigInt("0");
     }
-  }, [position]);
+  }, [isEvmFlow, sourcePosition, position]);
 
-  const apy = position?.supplyApy ?? null;
+  const apy = isEvmFlow
+    ? (sourcePosition?.supplyApy ?? null)
+    : (position?.supplyApy ?? null);
 
   const form = useForm<{ amount: string }>({ mode: "onChange" });
   const {
@@ -129,15 +185,39 @@ export const EarnWalletForm: React.FC<{
     [amountString],
   );
 
-  // Live earnings projection on the entered amount
+  useEffect(() => {
+    if (!isEvmFlow || tab !== "deposit" || !amountString) return;
+    const human = parseFloat(amountString);
+    if (!(human > 0)) return;
+    const id = window.setTimeout(() => {
+      void fetchQuote(human);
+    }, 400);
+    return () => clearTimeout(id);
+  }, [amountString, fetchQuote, isEvmFlow, tab]);
+
+  useEffect(() => {
+    if (!isEvmFlow || tab !== "withdraw" || !amountString) return;
+    const human = parseFloat(amountString);
+    if (!(human > 0)) return;
+    const id = window.setTimeout(() => {
+      void fetchWithdrawQuote(human);
+    }, 400);
+    return () => clearTimeout(id);
+  }, [amountString, fetchWithdrawQuote, isEvmFlow, tab]);
+
+  // Live earnings projection on the entered amount (EVM deposits use post-bridge receive amount).
   const projection = useMemo(() => {
-    if (!parsedAmount || !apy)
+    const basis =
+      isEvmFlow && tab === "deposit" && quote?.receive_amount != null
+        ? humanToBaseUnits(quote.receive_amount)
+        : parsedAmount;
+    if (!basis || !apy)
       return { yearly: BigInt("0"), monthly: BigInt("0") };
-    const yearlyMicro = (parsedAmount * BigInt(Math.round(apy * 1_000_000))) /
+    const yearlyMicro = (basis * BigInt(Math.round(apy * 1_000_000))) /
       BigInt("1000000");
     const monthlyMicro = yearlyMicro / BigInt("12");
     return { yearly: yearlyMicro, monthly: monthlyMicro };
-  }, [parsedAmount, apy]);
+  }, [parsedAmount, apy, isEvmFlow, tab, quote?.receive_amount]);
 
   // Poll the position (and embedded supply APR) while the modal is open so
   // the rate stays in sync with the live pool instead of the once-on-open value.
@@ -209,16 +289,25 @@ export const EarnWalletForm: React.FC<{
     setSubmitting(true);
     const toastId = toast.loading(
       tab === "deposit"
-        ? `Depositing ${token} to Vesu pool…`
-        : `Withdrawing ${token} from Vesu pool…`,
+        ? isEvmFlow
+          ? "Bridging USDC to Vesu on Starknet…"
+          : `Depositing ${token} to Vesu pool…`
+        : isEvmFlow
+          ? `Withdrawing USDC to ${chainName}…`
+          : `Withdrawing ${token} from Vesu pool…`,
     );
 
     try {
       const useMax = tab === "withdraw" && parsed === suppliedBaseUnits;
+      const txContext = isEvmFlow ? { sourceChain: chainName } : undefined;
       const result =
-        tab === "deposit"
-          ? await deposit(token, parsed)
-          : await withdraw(token, useMax ? "max" : parsed);
+        tab === "deposit" && isEvmFlow
+          ? await depositFromEvm(parseFloat(amount))
+          : tab === "deposit"
+            ? await deposit(token, parsed, txContext)
+            : tab === "withdraw" && isEvmFlow
+              ? await withdrawToEvm({ amountBaseUnits: parsed, useMax })
+              : await withdraw(token, useMax ? "max" : parsed, txContext);
 
       // Dismiss the loading toast — the inline success view replaces it,
       // mirroring TransferForm.tsx's renderSuccessView pattern.
@@ -249,8 +338,12 @@ export const EarnWalletForm: React.FC<{
     const title = type === "deposit" ? "Deposit successful" : "Withdrawal successful";
     const description =
       type === "deposit"
-        ? `${amountFormatted} ${succToken} has been successfully deposited into the Vesu pool.`
-        : `${amountFormatted} ${succToken} has been successfully withdrawn from the Vesu pool.`;
+        ? isEvmFlow
+          ? `${amountFormatted} ${succToken} is being supplied to Vesu on Starknet after bridging from ${chainName}.`
+          : `${amountFormatted} ${succToken} has been successfully deposited into the Vesu pool.`
+        : isEvmFlow
+          ? `${amountFormatted} ${succToken} is bridging back to your ${chainName} wallet.`
+          : `${amountFormatted} ${succToken} has been successfully withdrawn from the Vesu pool.`;
     return (
       <div className="space-y-6 pt-4">
         <CheckmarkCircle01Icon className="mx-auto size-10" color="#39C65D" />
@@ -291,7 +384,9 @@ export const EarnWalletForm: React.FC<{
   const screenTitle = tab === "deposit" ? "Deposit" : "Withdraw";
   const screenSubtitle =
     tab === "deposit"
-      ? "Supply USDC or USDT to a Vesu lending pool"
+      ? isEvmFlow
+        ? "Bridge USDC to Vesu on Starknet"
+        : "Supply USDC or USDT to a Vesu lending pool"
       : "Withdraw USDC or USDT from your Vesu lending pool";
 
   return (
@@ -435,6 +530,52 @@ export const EarnWalletForm: React.FC<{
 
         {errors.amount && (
           <p className="text-xs text-red-500">{errors.amount.message}</p>
+        )}
+        {isEvmFlow && tab === "withdraw" && amountEntered && (
+          <div className="space-y-1">
+            <p className="text-xs text-text-secondary dark:text-white/50">
+              {withdrawConfirmationCopy}
+            </p>
+            {withdrawQuoteLoading && (
+              <p className="text-xs text-text-secondary dark:text-white/50">
+                Fetching bridge quote…
+              </p>
+            )}
+            {!withdrawQuoteLoading && withdrawQuote?.receive_amount != null && (
+              <p className="text-xs text-text-secondary dark:text-white/50">
+                Estimated on {chainName} after bridge fees:{" "}
+                <span className="font-medium text-text-body dark:text-white">
+                  ~{withdrawQuote.receive_amount.toFixed(4)} USDC
+                </span>
+              </p>
+            )}
+          </div>
+        )}
+        {isEvmFlow && tab === "deposit" && amountEntered && (
+          <div className="space-y-1">
+            <p className="text-xs text-text-secondary dark:text-white/50">
+              {confirmationCopy}
+            </p>
+            {quoteLoading && (
+              <p className="text-xs text-text-secondary dark:text-white/50">
+                Fetching bridge quote…
+              </p>
+            )}
+            {!quoteLoading && quote?.receive_amount != null && (
+              <p className="text-xs text-text-secondary dark:text-white/50">
+                Estimated on Starknet after bridge fees:{" "}
+                <span className="font-medium text-text-body dark:text-white">
+                  ~{quote.receive_amount.toFixed(4)} USDC
+                </span>
+                {quote.total_fee != null && quote.total_fee > 0 && (
+                  <>
+                    {" "}
+                    (fees ~{quote.total_fee.toFixed(4)} USDC)
+                  </>
+                )}
+              </p>
+            )}
+          </div>
         )}
       </div>
 

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -44,7 +44,8 @@ import { EarnUnavailableModal } from "./EarnUnavailableModal";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 import ProfileView from "./ProfileView";
 import { useEarnAccess } from "../hooks/useEarnAccess";
-import { isEarnActionVisible, isEarnUiVisible } from "../lib/earnFeature";
+import { isEarnActionVisible, isEarnUiVisible, isEvmEarnFlow } from "../lib/earnFeature";
+import { useEvmWalletDisplayTotal } from "../hooks/useEvmWalletDisplayTotal";
 import { isReferralEnabled } from "../utils";
 import { isBridgeUiVisible } from "../lib/bridgeFeature";
 import { BridgeForm } from "./bridge/BridgeForm";
@@ -181,6 +182,19 @@ export const MobileDropdown = ({
     selectedNetwork.chain.name,
   );
 
+  const embeddedEvmAddress =
+    selectedNetwork.chain.name !== "Starknet" &&
+    selectedNetwork.chain.name !== "Tron"
+      ? walletAddress?.toLowerCase()
+      : undefined;
+
+  const { displayTotalUsd: evmEarnWalletTotalUsd, includesEarn: walletTotalIncludesEarn } =
+    useEvmWalletDisplayTotal({
+      chainName: selectedNetwork.chain.name,
+      crossChainBalances: sortedCrossChainBalances,
+      evmAddress: embeddedEvmAddress,
+    });
+
   const handleNetworkSwitchWrapper = (network: Network) => {
     if (currentStep !== STEPS.FORM) {
       toast.error("Cannot switch networks during an active transaction");
@@ -306,7 +320,12 @@ export const MobileDropdown = ({
     }
   };
 
-  const walletBalanceUsd = crossChainTotal ?? 0;
+  const walletBalanceUsd = walletTotalIncludesEarn
+    ? evmEarnWalletTotalUsd
+    : selectedNetwork.chain.name === "Starknet"
+      ? (allBalances.starknetWallet?.total ?? 0)
+      : (crossChainTotal ?? 0);
+  const isEvmEarn = isEvmEarnFlow(selectedNetwork.chain.name);
 
   return (
     <>
@@ -373,6 +392,8 @@ export const MobileDropdown = ({
                           showEarnUi={showEarnUi}
                           showEarnAction={showEarnAction}
                           walletBalanceUsd={walletBalanceUsd}
+                          embeddedEvmAddress={embeddedEvmAddress}
+                          isEvmEarn={isEvmEarn}
                           onEarn={() =>
                             requestEarnAccess("earn-hub", onEarnAccessAction)
                           }

--- a/app/components/MobileDropdown.tsx
+++ b/app/components/MobileDropdown.tsx
@@ -40,10 +40,11 @@ import { FundWalletForm } from "./FundWalletForm";
 import { TransferForm } from "./TransferForm";
 import { EarnWalletForm } from "./EarnWalletForm";
 import { EarnConsentModal } from "./EarnConsentModal";
+import { EarnUnavailableModal } from "./EarnUnavailableModal";
 import { CopyAddressWarningModal } from "./CopyAddressWarningModal";
 import ProfileView from "./ProfileView";
 import { useEarnAccess } from "../hooks/useEarnAccess";
-import { isEarnUiVisible } from "../lib/earnFeature";
+import { isEarnActionVisible, isEarnUiVisible } from "../lib/earnFeature";
 import { isReferralEnabled } from "../utils";
 import { isBridgeUiVisible } from "../lib/bridgeFeature";
 import { BridgeForm } from "./bridge/BridgeForm";
@@ -69,6 +70,8 @@ export const MobileDropdown = ({
   const [isNetworkListOpen, setIsNetworkListOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
+  const [isEarnUnavailableModalOpen, setIsEarnUnavailableModalOpen] =
+    useState(false);
 
   const { selectedNetwork, setSelectedNetwork } = useNetwork();
   const { currentStep } = useStep();
@@ -287,6 +290,7 @@ export const MobileDropdown = ({
   const { client } = useSmartWallets();
 
   const showEarnUi = isEarnUiVisible(selectedNetwork.chain.name);
+  const showEarnAction = isEarnActionVisible(selectedNetwork.chain.name);
   const {
     isConsentModalOpen: isEarnConsentModalOpen,
     requestEarnAccess,
@@ -367,9 +371,13 @@ export const MobileDropdown = ({
                           onRefreshBalance={refreshBalance}
                           isRefreshing={isRefreshing}
                           showEarnUi={showEarnUi}
+                          showEarnAction={showEarnAction}
                           walletBalanceUsd={walletBalanceUsd}
                           onEarn={() =>
                             requestEarnAccess("earn-hub", onEarnAccessAction)
+                          }
+                          onEarnUnavailable={() =>
+                            setIsEarnUnavailableModalOpen(true)
                           }
                           onSelectTransaction={(tx) => {
                             setSelectedTransaction(tx);
@@ -499,6 +507,11 @@ export const MobileDropdown = ({
               isOpen={isEarnConsentModalOpen}
               onClose={dismissEarnConsent}
               onAccepted={() => handleEarnConsentAccepted(onEarnAccessAction)}
+            />
+
+            <EarnUnavailableModal
+              isOpen={isEarnUnavailableModalOpen}
+              onClose={() => setIsEarnUnavailableModalOpen(false)}
             />
 
             <CopyAddressWarningModal

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -63,7 +63,8 @@ import { useCNGNRate } from "../hooks/useCNGNRate";
 import { EarnConsentModal } from "./EarnConsentModal";
 import { EarnUnavailableModal } from "./EarnUnavailableModal";
 import { useEarnAccess } from "../hooks/useEarnAccess";
-import { isEarnEnabled, isEarnUiVisible } from "../lib/earnFeature";
+import { isEarnEnabled, isEarnActionVisible, isEarnUiVisible, isEvmEarnFlow } from "../lib/earnFeature";
+import { EarnSourcePositionCard } from "./EarnSourcePositionCard";
 import { isReferralEnabled, formatTokenAmount } from "../utils";
 import { isBridgeUiVisible } from "../lib/bridgeFeature";
 import { BridgeForm } from "./bridge/BridgeForm";
@@ -101,10 +102,10 @@ const EarnUnavailableTooltip = ({
         />
         <div className="relative rounded-2xl border border-border-light bg-white p-2.5 pr-9 shadow-lg dark:border-white/10 dark:bg-[#2c2c2c]">
           <p className="text-[11px] font-medium leading-5 text-text-body dark:text-white">
-            Earn is currently available on Starknet.
+            Earn is currently not available on this network.
           </p>
           <p className="mt-[3px] text-[10px] leading-[13px] text-text-secondary dark:text-white/50">
-            Switch your wallet to Starknet to start earning on your USDC.
+            Switch your wallet to another network to start earning on your USDC.
           </p>
           <button
             type="button"
@@ -250,6 +251,11 @@ export const WalletDetails = () => {
   }, [activeWallet?.address, fetchTransactions, resolveAuth]);
 
   const showEarnUi = isEarnUiVisible(selectedNetwork.chain.name);
+  const showEarnAction = isEarnActionVisible(selectedNetwork.chain.name);
+  const isEvmEarn = isEvmEarnFlow(selectedNetwork.chain.name);
+  const embeddedEvmAddress = wallets
+    .find((w) => w.walletClientType === "privy")
+    ?.address?.toLowerCase();
 
   const onEarnAccessAction = (action: "earn-modal" | "earn-tab" | "earn-hub") => {
     if (action === "earn-hub" || action === "earn-modal") {
@@ -594,7 +600,7 @@ export const WalletDetails = () => {
                                 </span>
                               </button>
                             )}
-                            {!isInjectedWallet && isEarnEnabled() && (
+                            {!isInjectedWallet && showEarnAction && (
                               <div
                                 className="relative flex flex-1 flex-col items-center"
                                 onMouseEnter={() =>
@@ -607,7 +613,7 @@ export const WalletDetails = () => {
                                   title={
                                     showEarnUi
                                       ? "Earn yield on USDC via Vesu"
-                                      : "Earn is currently available on Starknet"
+                                      : "Earn is currently not available on this network."
                                   }
                                   onClick={() => {
                                     if (showEarnUi) {
@@ -897,6 +903,12 @@ export const WalletDetails = () => {
                                     </div>
                                   );
                                 })
+                              )}
+                              {isEvmEarn && embeddedEvmAddress && (
+                                <EarnSourcePositionCard
+                                  evmAddress={embeddedEvmAddress}
+                                  sourceChain={selectedNetwork.chain.name}
+                                />
                               )}
                             </motion.div>
                           ) : (

--- a/app/components/WalletDetails.tsx
+++ b/app/components/WalletDetails.tsx
@@ -65,6 +65,7 @@ import { EarnUnavailableModal } from "./EarnUnavailableModal";
 import { useEarnAccess } from "../hooks/useEarnAccess";
 import { isEarnEnabled, isEarnActionVisible, isEarnUiVisible, isEvmEarnFlow } from "../lib/earnFeature";
 import { EarnSourcePositionCard } from "./EarnSourcePositionCard";
+import { useEvmWalletDisplayTotal } from "../hooks/useEvmWalletDisplayTotal";
 import { isReferralEnabled, formatTokenAmount } from "../utils";
 import { isBridgeUiVisible } from "../lib/bridgeFeature";
 import { BridgeForm } from "./bridge/BridgeForm";
@@ -257,6 +258,13 @@ export const WalletDetails = () => {
     .find((w) => w.walletClientType === "privy")
     ?.address?.toLowerCase();
 
+  const { displayTotalUsd: evmEarnWalletTotalUsd, includesEarn: walletTotalIncludesEarn } =
+    useEvmWalletDisplayTotal({
+      chainName: selectedNetwork.chain.name,
+      crossChainBalances,
+      evmAddress: embeddedEvmAddress,
+    });
+
   const onEarnAccessAction = (action: "earn-modal" | "earn-tab" | "earn-hub") => {
     if (action === "earn-hub" || action === "earn-modal") {
       setSidebarView("earn");
@@ -387,6 +395,8 @@ export const WalletDetails = () => {
             <BalanceSkeleton />
           ) : selectedNetwork.chain.name === "Starknet" ? (
             <p>{formatCurrency(activeBalance?.total ?? 0, "USD", "en-US")}</p>
+          ) : walletTotalIncludesEarn ? (
+            <p>{formatCurrency(evmEarnWalletTotalUsd, "USD", "en-US")}</p>
           ) : (
             <p>{formatCurrency(crossChainTotal, "USD", "en-US")}</p>
           )}
@@ -517,8 +527,8 @@ export const WalletDetails = () => {
                           <div className="text-2xl font-medium text-text-body dark:text-white">
                             {showBalanceSkeleton ? (
                               <BalanceSkeleton className="w-24" />
-                            ) : showEarnUi ? (
-                              formatCurrency(crossChainTotal, "USD", "en-US")
+                            ) : walletTotalIncludesEarn ? (
+                              formatCurrency(evmEarnWalletTotalUsd, "USD", "en-US")
                             ) : selectedNetwork.chain.name === "Starknet" ? (
                               formatCurrency(activeBalance?.total ?? 0, "USD", "en-US")
                             ) : (

--- a/app/components/wallet-mobile-modal/EarnHubView.tsx
+++ b/app/components/wallet-mobile-modal/EarnHubView.tsx
@@ -2,12 +2,17 @@
 
 import React, { useEffect, useMemo } from "react";
 import { ArrowLeft02Icon, Cancel01Icon, Setting07Icon } from "hugeicons-react";
+import { useWallets } from "@privy-io/react-auth";
 import {
   EARN_TOKENS,
   useEarnHandler,
   type EarnActivityEntry,
   type EarnToken,
 } from "../../hooks/useEarnHandler";
+import { useEarnSourcePosition } from "../../hooks/useEarnSourcePosition";
+import { useNetwork } from "../../context/NetworksContext";
+import { isEvmEarnFlow } from "../../lib/earnFeature";
+import { EARN_STARKNET_DISCLOSURE } from "../../lib/earnChains";
 import { EarnDisclosureBanner } from "../EarnDisclosureBanner";
 import { EarnActivityPanel } from "../EarnActivityPanel";
 
@@ -74,7 +79,21 @@ export const EarnHubView: React.FC<EarnHubViewProps> = ({
   onWithdraw,
   onSelectActivity,
 }) => {
+  const { selectedNetwork } = useNetwork();
+  const { wallets } = useWallets();
   const { positions, refreshAllPositions } = useEarnHandler();
+
+  const chainName = selectedNetwork.chain.name;
+  const isEvmFlow = isEvmEarnFlow(chainName);
+  const evmAddress = wallets
+    .find((w) => w.walletClientType === "privy")
+    ?.address?.toLowerCase();
+
+  const sourcePosition = useEarnSourcePosition(
+    isEvmFlow ? evmAddress : undefined,
+    chainName,
+    "USDC",
+  );
 
   useEffect(() => {
     void refreshAllPositions();
@@ -84,20 +103,34 @@ export const EarnHubView: React.FC<EarnHubViewProps> = ({
     return () => clearInterval(id);
   }, [refreshAllPositions]);
 
-  const suppliedTokens = useMemo<EarnToken[]>(
-    () =>
-      EARN_TOKENS.filter(
-        (t) => safeBigInt(positions[t]?.suppliedBaseUnits) > BigInt("0"),
-      ),
-    [positions],
-  );
+  const suppliedTokens = useMemo<EarnToken[]>(() => {
+    if (isEvmFlow) {
+      return sourcePosition &&
+        safeBigInt(sourcePosition.suppliedBaseUnits) > BigInt("0")
+        ? (["USDC"] as EarnToken[])
+        : [];
+    }
+    return EARN_TOKENS.filter(
+      (t) => safeBigInt(positions[t]?.suppliedBaseUnits) > BigInt("0"),
+    );
+  }, [isEvmFlow, sourcePosition, positions]);
 
-  const hasWithdrawableBalance = suppliedTokens.length > 0;
+  const hasEvmSourcePosition =
+    isEvmFlow &&
+    sourcePosition != null &&
+    safeBigInt(sourcePosition.suppliedBaseUnits) > BigInt("0");
+
+  const hasWithdrawableBalance =
+    suppliedTokens.length > 0 || hasEvmSourcePosition;
 
   const primaryToken = suppliedTokens[0] ?? null;
   const primaryPosition = primaryToken ? positions[primaryToken] : null;
-  const primarySupplied = safeBigInt(primaryPosition?.suppliedBaseUnits);
-  const primaryApy = primaryPosition?.supplyApy ?? null;
+  const primarySupplied = isEvmFlow
+    ? safeBigInt(sourcePosition?.suppliedBaseUnits)
+    : safeBigInt(primaryPosition?.suppliedBaseUnits);
+  const primaryApy = isEvmFlow
+    ? (sourcePosition?.supplyApy ?? null)
+    : (primaryPosition?.supplyApy ?? null);
   const { monthly, yearly } = projectEarnings(primarySupplied, primaryApy);
 
   return (
@@ -172,7 +205,15 @@ export const EarnHubView: React.FC<EarnHubViewProps> = ({
           </div>
         ) : (
           <p className="text-sm text-text-secondary dark:text-white/50">
-            No funds in Earn yet. Deposit USDC or USDT to start earning.
+            {isEvmFlow
+              ? "No funds in Earn yet. Deposit USDC to bridge to Vesu on Starknet."
+              : "No funds in Earn yet. Deposit USDC or USDT to start earning."}
+          </p>
+        )}
+
+        {isEvmFlow && primarySupplied > BigInt("0") && (
+          <p className="text-xs text-text-secondary dark:text-white/50">
+            {EARN_STARKNET_DISCLOSURE}
           </p>
         )}
 
@@ -204,6 +245,8 @@ export const EarnHubView: React.FC<EarnHubViewProps> = ({
         <EarnActivityPanel
           showDisclosureBanner={false}
           onSelectActivity={onSelectActivity}
+          chainName={chainName}
+          includeLegacyUntaggedDeposits={hasEvmSourcePosition}
         />
       </div>
     </div>

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import { PiCheck } from "react-icons/pi";
@@ -15,6 +15,7 @@ import {
   ArrowUpRight01Icon,
   CoinsSwapIcon,
   Coins01Icon,
+  InformationCircleIcon,
 } from "hugeicons-react";
 import { CrossChainBalanceSkeleton } from "../BalanceSkeleton";
 import {
@@ -63,7 +64,9 @@ interface WalletViewProps {
   onRefreshBalance: () => void;
   isRefreshing?: boolean;
   showEarnUi?: boolean;
+  showEarnAction?: boolean;
   onEarn?: () => void;
+  onEarnUnavailable?: () => void;
   walletBalanceUsd?: number;
   onSelectTransaction?: (tx: TransactionHistory) => void;
   onViewReferrals?: () => void;
@@ -93,7 +96,9 @@ export const WalletView: React.FC<WalletViewProps> = ({
   onRefreshBalance,
   isRefreshing = false,
   showEarnUi = false,
+  showEarnAction = false,
   onEarn,
+  onEarnUnavailable,
   walletBalanceUsd = 0,
   onSelectTransaction,
   onViewReferrals,
@@ -102,12 +107,6 @@ export const WalletView: React.FC<WalletViewProps> = ({
   const { isEmbed } = useEmbed();
   const [walletTab, setWalletTab] = useState<WalletTab>("balances");
   const [isAddressCopied, setIsAddressCopied] = useState(false);
-
-  useEffect(() => {
-    if (showEarnUi && selectedNetwork.chain.name !== "Starknet") {
-      setWalletTab("balances");
-    }
-  }, [showEarnUi, selectedNetwork.chain.name]);
 
   const handleCopyInCard = async () => {
     handleCopyAddress();
@@ -437,18 +436,27 @@ export const WalletView: React.FC<WalletViewProps> = ({
                     </span>
                   </button>
                 )}
-                {!isInjectedWallet && showEarnUi && (
+                {!isInjectedWallet && showEarnAction && (
                   <button
                     type="button"
-                    title="Earn yield on USDC via Vesu"
-                    onClick={onEarn}
+                    title={
+                      showEarnUi
+                        ? "Earn yield on USDC via Vesu"
+                        : "Earn is currently not available on this network."
+                    }
+                    onClick={() =>
+                      showEarnUi ? onEarn?.() : onEarnUnavailable?.()
+                    }
                     className="group flex flex-1 flex-col items-center gap-2"
                   >
                     <span className="flex size-[60px] items-center justify-center rounded-full bg-accent-gray text-gray-900 transition-all group-hover:scale-[0.98] group-hover:bg-[#EBEBEF] group-active:scale-95 dark:bg-white/5 dark:text-white dark:group-hover:bg-white/10">
                       <Coins01Icon className="size-6" strokeWidth={2} />
                     </span>
-                    <span className="text-sm font-medium text-text-body dark:text-white">
+                    <span className="flex items-center gap-1 text-sm font-medium text-text-body dark:text-white">
                       Earn
+                      {!showEarnUi && (
+                        <InformationCircleIcon className="size-4 text-text-secondary dark:text-white/50" />
+                      )}
                     </span>
                   </button>
                 )}

--- a/app/components/wallet-mobile-modal/WalletView.tsx
+++ b/app/components/wallet-mobile-modal/WalletView.tsx
@@ -32,6 +32,7 @@ import TransactionList from "../transaction/TransactionList";
 import type { Network, TransactionHistory } from "../../types";
 import { isReferralEnabled, formatTokenAmount } from "../../utils";
 import { ReferralCTA } from "../ReferralCTA";
+import { EarnSourcePositionCard } from "../EarnSourcePositionCard";
 
 const Divider = () => (
   <div className="w-full border border-dashed border-[#EBEBEF] dark:border-[#FFFFFF1A]" />
@@ -68,6 +69,8 @@ interface WalletViewProps {
   onEarn?: () => void;
   onEarnUnavailable?: () => void;
   walletBalanceUsd?: number;
+  embeddedEvmAddress?: string;
+  isEvmEarn?: boolean;
   onSelectTransaction?: (tx: TransactionHistory) => void;
   onViewReferrals?: () => void;
 }
@@ -100,6 +103,8 @@ export const WalletView: React.FC<WalletViewProps> = ({
   onEarn,
   onEarnUnavailable,
   walletBalanceUsd = 0,
+  embeddedEvmAddress,
+  isEvmEarn = false,
   onSelectTransaction,
   onViewReferrals,
 }) => {
@@ -298,6 +303,13 @@ export const WalletView: React.FC<WalletViewProps> = ({
               </div>
             );
           })
+        )}
+
+        {isEvmEarn && embeddedEvmAddress && (
+          <EarnSourcePositionCard
+            evmAddress={embeddedEvmAddress}
+            sourceChain={selectedNetwork.chain.name}
+          />
         )}
 
       </div>

--- a/app/hooks/useEarnBridgeStatusTracker.ts
+++ b/app/hooks/useEarnBridgeStatusTracker.ts
@@ -1,0 +1,191 @@
+"use client";
+
+
+
+import { useEffect, useRef } from "react";
+
+import { usePrivy } from "@privy-io/react-auth";
+
+import { useStarknet } from "../context/StarknetContext";
+
+import { useEarnHandler } from "./useEarnHandler";
+
+import {
+
+  isLayerswapSuccessStatus,
+
+  isLayerswapTerminalStatus,
+
+} from "../lib/layerswap";
+
+import {
+
+  loadPendingEarnBridges,
+
+  pendingBridgeReceiveBaseUnits,
+
+  savePendingEarnBridges,
+
+  writeEarnSourcePosition,
+
+} from "../lib/earnPositionStore";
+
+
+
+/**
+
+ * Resumes in-flight EVM → Starknet earn bridges after refresh and completes
+
+ * Vesu deposit once LayerSwap reports success.
+
+ */
+
+export function useEarnBridgeStatusTracker() {
+
+  const { getAccessToken } = usePrivy();
+
+  const { ensureWalletExists } = useStarknet();
+
+  const { deposit, refreshPosition } = useEarnHandler();
+
+  const runningRef = useRef(false);
+
+
+
+  useEffect(() => {
+
+    const tick = async () => {
+
+      if (runningRef.current) return;
+
+      const pending = loadPendingEarnBridges();
+
+      if (pending.length === 0) return;
+
+
+
+      runningRef.current = true;
+
+      try {
+
+        const token = await getAccessToken();
+
+        if (!token) return;
+
+
+
+        await ensureWalletExists();
+
+
+
+        const remaining = [];
+
+        for (const job of pending) {
+
+          try {
+
+            const res = await fetch(
+
+              `/api/earn/layerswap/swap/status?id=${encodeURIComponent(job.swapId)}`,
+
+            );
+
+            const data = await res.json();
+
+            const status = data.swap?.status as string | undefined;
+
+            if (!status || !isLayerswapTerminalStatus(status as any)) {
+
+              remaining.push(job);
+
+              continue;
+
+            }
+
+            if (!isLayerswapSuccessStatus(status as any)) {
+
+              continue;
+
+            }
+
+
+
+            let receiveBaseUnits = pendingBridgeReceiveBaseUnits(job);
+
+            const quotedReceive = data.quote?.receive_amount;
+
+            if (typeof quotedReceive === "number" && quotedReceive > 0) {
+
+              receiveBaseUnits = BigInt(Math.round(quotedReceive * 1_000_000));
+
+            }
+
+            if (receiveBaseUnits <= BigInt(0)) {
+
+              remaining.push(job);
+
+              continue;
+
+            }
+
+
+
+            await deposit("USDC", receiveBaseUnits, {
+              sourceChain: job.sourceChain,
+            });
+
+            writeEarnSourcePosition(
+
+              job.evmAddress,
+
+              {
+
+                sourceChain: job.sourceChain,
+
+                starknetAddress: job.starknetAddress,
+
+                suppliedBaseUnits: receiveBaseUnits.toString(),
+
+                suppliedFormatted: (Number(receiveBaseUnits) / 1e6).toFixed(6),
+
+                supplyApy: null,
+
+              },
+
+              "USDC",
+
+            );
+
+            await refreshPosition("USDC");
+
+          } catch {
+
+            remaining.push(job);
+
+          }
+
+        }
+
+        savePendingEarnBridges(remaining);
+
+      } finally {
+
+        runningRef.current = false;
+
+      }
+
+    };
+
+
+
+    void tick();
+
+    const id = window.setInterval(() => void tick(), 15_000);
+
+    return () => clearInterval(id);
+
+  }, [getAccessToken, ensureWalletExists, deposit, refreshPosition]);
+
+}
+
+

--- a/app/hooks/useEarnBridgeStatusTracker.ts
+++ b/app/hooks/useEarnBridgeStatusTracker.ts
@@ -1,191 +1,102 @@
 "use client";
 
-
-
 import { useEffect, useRef } from "react";
-
 import { usePrivy } from "@privy-io/react-auth";
-
 import { useStarknet } from "../context/StarknetContext";
-
 import { useEarnHandler } from "./useEarnHandler";
-
 import {
-
   isLayerswapSuccessStatus,
-
   isLayerswapTerminalStatus,
-
 } from "../lib/layerswap";
-
 import {
-
+  addEarnSourcePosition,
+  isStaleLiveFlowClaim,
   loadPendingEarnBridges,
-
   pendingBridgeReceiveBaseUnits,
-
   savePendingEarnBridges,
-
-  writeEarnSourcePosition,
-
 } from "../lib/earnPositionStore";
 
-
-
 /**
-
  * Resumes in-flight EVM → Starknet earn bridges after refresh and completes
-
  * Vesu deposit once LayerSwap reports success.
-
  */
-
 export function useEarnBridgeStatusTracker() {
-
   const { getAccessToken } = usePrivy();
-
-  const { ensureWalletExists } = useStarknet();
-
+  const { ensureWalletExists, walletId } = useStarknet();
   const { deposit, refreshPosition } = useEarnHandler();
-
   const runningRef = useRef(false);
 
-
-
   useEffect(() => {
-
     const tick = async () => {
-
       if (runningRef.current) return;
-
       const pending = loadPendingEarnBridges();
-
       if (pending.length === 0) return;
 
-
-
       runningRef.current = true;
-
       try {
-
         const token = await getAccessToken();
-
-        if (!token) return;
-
-
+        if (!token || !walletId) return;
 
         await ensureWalletExists();
 
-
-
         const remaining = [];
-
         for (const job of pending) {
+          if (job.claimedByLiveFlow && !isStaleLiveFlowClaim(job)) {
+            remaining.push(job);
+            continue;
+          }
 
           try {
-
             const res = await fetch(
-
-              `/api/earn/layerswap/swap/status?id=${encodeURIComponent(job.swapId)}`,
-
+              `/api/earn/layerswap/swap/status?id=${encodeURIComponent(job.swapId)}&walletId=${encodeURIComponent(walletId)}`,
+              { headers: { Authorization: `Bearer ${token}` } },
             );
-
             const data = await res.json();
-
             const status = data.swap?.status as string | undefined;
-
             if (!status || !isLayerswapTerminalStatus(status as any)) {
-
               remaining.push(job);
-
               continue;
-
             }
-
             if (!isLayerswapSuccessStatus(status as any)) {
-
               continue;
-
             }
-
-
 
             let receiveBaseUnits = pendingBridgeReceiveBaseUnits(job);
-
             const quotedReceive = data.quote?.receive_amount;
-
             if (typeof quotedReceive === "number" && quotedReceive > 0) {
-
               receiveBaseUnits = BigInt(Math.round(quotedReceive * 1_000_000));
-
             }
-
             if (receiveBaseUnits <= BigInt(0)) {
-
               remaining.push(job);
-
               continue;
-
             }
-
-
 
             await deposit("USDC", receiveBaseUnits, {
               sourceChain: job.sourceChain,
             });
 
-            writeEarnSourcePosition(
-
+            addEarnSourcePosition(
               job.evmAddress,
-
               {
-
                 sourceChain: job.sourceChain,
-
                 starknetAddress: job.starknetAddress,
-
-                suppliedBaseUnits: receiveBaseUnits.toString(),
-
-                suppliedFormatted: (Number(receiveBaseUnits) / 1e6).toFixed(6),
-
-                supplyApy: null,
-
+                deltaBaseUnits: receiveBaseUnits,
               },
-
               "USDC",
-
             );
-
             await refreshPosition("USDC");
-
           } catch {
-
             remaining.push(job);
-
           }
-
         }
-
         savePendingEarnBridges(remaining);
-
       } finally {
-
         runningRef.current = false;
-
       }
-
     };
 
-
-
     void tick();
-
     const id = window.setInterval(() => void tick(), 15_000);
-
     return () => clearInterval(id);
-
-  }, [getAccessToken, ensureWalletExists, deposit, refreshPosition]);
-
+  }, [getAccessToken, ensureWalletExists, deposit, refreshPosition, walletId]);
 }
-
-

--- a/app/hooks/useEarnHandler.ts
+++ b/app/hooks/useEarnHandler.ts
@@ -68,6 +68,13 @@ export interface EarnActivityEntry {
   amountBaseUnits: string;
   /** When the user kicked it off — milliseconds since epoch. */
   timestamp: number;
+  /** EVM source chain for bridged earn txs; omitted for native Starknet earn. */
+  sourceChain?: string;
+}
+
+export interface EarnTxContext {
+  /** EVM network display name (e.g. "Base") when the tx was initiated. */
+  sourceChain?: string;
 }
 
 const ACTIVITY_PREFIX = "earn_activity_";
@@ -114,6 +121,9 @@ function normalizeActivity(raw: any): EarnActivityEntry | null {
     token,
     amountBaseUnits: String(raw.amountBaseUnits ?? "0"),
     timestamp: Number(raw.timestamp) || Date.now(),
+    ...(typeof raw.sourceChain === "string" && raw.sourceChain
+      ? { sourceChain: raw.sourceChain }
+      : {}),
   };
 }
 
@@ -248,6 +258,7 @@ export function useEarnHandler() {
     async (
       token: EarnToken,
       amountBaseUnits: bigint,
+      context?: EarnTxContext,
     ): Promise<{ txHash: string }> => {
       if (!walletId || !publicKey || !address) {
         throw new Error("Starknet wallet not ready");
@@ -280,6 +291,7 @@ export function useEarnHandler() {
         token,
         amountBaseUnits: amountBaseUnits.toString(),
         timestamp: Date.now(),
+        ...(context?.sourceChain ? { sourceChain: context.sourceChain } : {}),
       });
       return { txHash };
     },
@@ -290,6 +302,7 @@ export function useEarnHandler() {
     async (
       token: EarnToken,
       amountBaseUnits: bigint | "max",
+      context?: EarnTxContext,
     ): Promise<{ txHash: string }> => {
       if (!walletId || !publicKey || !address) {
         throw new Error("Starknet wallet not ready");
@@ -327,6 +340,7 @@ export function useEarnHandler() {
           ? (positions[token]?.suppliedBaseUnits ?? "0")
           : (amountBaseUnits as bigint).toString(),
         timestamp: Date.now(),
+        ...(context?.sourceChain ? { sourceChain: context.sourceChain } : {}),
       });
       return { txHash };
     },

--- a/app/hooks/useEarnSourcePosition.ts
+++ b/app/hooks/useEarnSourcePosition.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  readEarnSourcePosition,
+  type EarnSourcePosition,
+} from "../lib/earnPositionStore";
+
+const EARN_SYNC_EVENT = "noblocks:earn-sync";
+
+/**
+ * Reactive read of an EVM-sourced earn position for a specific source chain.
+ */
+export function useEarnSourcePosition(
+  evmAddress: string | undefined,
+  sourceChain: string,
+  token: string,
+): EarnSourcePosition | null {
+  const [position, setPosition] = useState<EarnSourcePosition | null>(() =>
+    evmAddress ? readEarnSourcePosition(evmAddress, sourceChain, token) : null,
+  );
+
+  useEffect(() => {
+    if (!evmAddress) {
+      setPosition(null);
+      return;
+    }
+    const hydrate = () => {
+      setPosition(readEarnSourcePosition(evmAddress, sourceChain, token));
+    };
+    hydrate();
+    window.addEventListener(EARN_SYNC_EVENT, hydrate);
+    return () => window.removeEventListener(EARN_SYNC_EVENT, hydrate);
+  }, [evmAddress, sourceChain, token]);
+
+  return position;
+}

--- a/app/hooks/useEvmEarnHandler.ts
+++ b/app/hooks/useEvmEarnHandler.ts
@@ -23,15 +23,17 @@ import { executeBatchCalls } from "../lib/bridge";
 import { useDelegationContractAuth } from "./useEIP7702Account";
 import { getRpcUrl } from "../utils";
 import {
+  addEarnSourcePosition,
   clearEarnSourcePosition,
   loadPendingEarnBridges,
+  patchPendingEarnBridge,
   pendingBridgeReceiveBaseUnits,
   savePendingEarnBridges,
-  writeEarnSourcePosition,
+  subtractEarnSourcePosition,
+  upsertPendingEarnBridge,
   type PendingEarnBridgeJob,
 } from "../lib/earnPositionStore";
 
-const USDC_DECIMALS = 6;
 const USDC_FACTOR = BigInt("1000000");
 
 function humanToBaseUnits(amount: number): bigint {
@@ -125,11 +127,13 @@ export function useEvmEarnHandler() {
   );
 
   const pollSwapUntilComplete = useCallback(
-    async (swapId: string) => {
+    async (swapId: string, accessToken: string) => {
+      if (!walletId) throw new Error("Starknet wallet not ready");
       for (let i = 0; i < 120; i++) {
         await new Promise((r) => setTimeout(r, 10_000));
         const res = await fetch(
-          `/api/earn/layerswap/swap/status?id=${encodeURIComponent(swapId)}`,
+          `/api/earn/layerswap/swap/status?id=${encodeURIComponent(swapId)}&walletId=${encodeURIComponent(walletId)}`,
+          { headers: { Authorization: `Bearer ${accessToken}` } },
         );
         const data = await res.json();
         if (!res.ok) continue;
@@ -143,7 +147,7 @@ export function useEvmEarnHandler() {
       }
       throw new Error("Bridge timed out");
     },
-    [],
+    [walletId],
   );
 
   const depositFromEvm = useCallback(
@@ -155,7 +159,7 @@ export function useEvmEarnHandler() {
         throw new Error("Earn is not supported on this network");
       }
       await ensureWalletExists();
-      if (!starknetAddress) {
+      if (!starknetAddress || !walletId) {
         throw new Error("Starknet wallet not ready");
       }
 
@@ -164,13 +168,17 @@ export function useEvmEarnHandler() {
 
       const createRes = await fetch("/api/earn/layerswap/swap", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
         body: JSON.stringify({
           sourceChain,
           amount: amountHuman,
           destinationAddress: starknetAddress,
           sourceAddress: evmAddress,
           refundAddress: evmAddress,
+          walletId,
         }),
       });
       const created = await createRes.json();
@@ -185,24 +193,6 @@ export function useEvmEarnHandler() {
         throw new Error("Invalid LayerSwap response");
       }
 
-      const chain = selectedNetwork.chain as Chain;
-      const rpcUrl = getRpcUrl(chain.name);
-      const calls = await buildLayerswapDepositBatchCalls({
-        chain,
-        rpcUrl: rpcUrl ?? "",
-        fromAddress: evmAddress,
-        tokenAmountBaseUnits: humanToBaseUnits(amountHuman),
-        depositActions,
-      });
-      const txHash = await executeBatchCalls({
-        chain,
-        calls,
-        getAccessToken,
-        embeddedWallet,
-        signDelegationAuthorization,
-        gasLimit: 800_000,
-      });
-
       const receiveAmount = created.quote?.receive_amount ?? amountHuman;
       const receiveBaseUnits = humanToBaseUnits(receiveAmount);
       const requestedBaseUnits = humanToBaseUnits(amountHuman);
@@ -215,23 +205,43 @@ export function useEvmEarnHandler() {
         requestedAmountBaseUnits: requestedBaseUnits.toString(),
         receiveAmountBaseUnits: receiveBaseUnits.toString(),
         createdAt: Date.now(),
+        claimedByLiveFlow: false,
       };
-      savePendingEarnBridges([...loadPendingEarnBridges(), job]);
+      upsertPendingEarnBridge(job);
 
-      await pollSwapUntilComplete(swapId);
+      const chain = selectedNetwork.chain as Chain;
+      const rpcUrl = getRpcUrl(chain.name);
+      const calls = await buildLayerswapDepositBatchCalls({
+        chain,
+        rpcUrl: rpcUrl ?? "",
+        fromAddress: evmAddress,
+        tokenAmountBaseUnits: requestedBaseUnits,
+        depositActions,
+      });
+
+      patchPendingEarnBridge(swapId, { claimedByLiveFlow: true });
+
+      const txHash = await executeBatchCalls({
+        chain,
+        calls,
+        getAccessToken,
+        embeddedWallet,
+        signDelegationAuthorization,
+        gasLimit: 800_000,
+      });
+
+      await pollSwapUntilComplete(swapId, accessToken);
 
       const { txHash: vesuTxHash } = await vesuDeposit("USDC", receiveBaseUnits, {
         sourceChain,
       });
 
-      writeEarnSourcePosition(
+      addEarnSourcePosition(
         evmAddress,
         {
           sourceChain: sourceChain as EvmEarnSourceChain,
           starknetAddress,
-          suppliedBaseUnits: receiveBaseUnits.toString(),
-          suppliedFormatted: receiveAmount.toFixed(6),
-          supplyApy: null,
+          deltaBaseUnits: receiveBaseUnits,
         },
         "USDC",
       );
@@ -249,6 +259,7 @@ export function useEvmEarnHandler() {
       sourceChain,
       ensureWalletExists,
       starknetAddress,
+      walletId,
       getAccessToken,
       selectedNetwork.chain,
       signDelegationAuthorization,
@@ -291,13 +302,17 @@ export function useEvmEarnHandler() {
 
       const createRes = await fetch("/api/earn/layerswap/withdraw-swap", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
         body: JSON.stringify({
           destinationChain: sourceChain,
           amount: bridgeHuman,
           destinationAddress: evmAddress,
           sourceAddress: starknetAddress,
           refundAddress: starknetAddress,
+          walletId,
         }),
       });
       const created = await createRes.json();
@@ -330,9 +345,18 @@ export function useEvmEarnHandler() {
         throw new Error(deposited?.error || "LayerSwap Starknet deposit failed");
       }
 
-      await pollSwapUntilComplete(swapId);
+      await pollSwapUntilComplete(swapId, accessToken);
 
-      clearEarnSourcePosition(evmAddress, sourceChain, "USDC");
+      if (useMax) {
+        clearEarnSourcePosition(evmAddress, sourceChain, "USDC");
+      } else {
+        subtractEarnSourcePosition(
+          evmAddress,
+          sourceChain,
+          "USDC",
+          amountBaseUnits,
+        );
+      }
       await refreshPosition("USDC");
 
       return {

--- a/app/hooks/useEvmEarnHandler.ts
+++ b/app/hooks/useEvmEarnHandler.ts
@@ -1,0 +1,371 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePrivy, useWallets } from "@privy-io/react-auth";
+import type { Chain } from "viem";
+import { useNetwork } from "../context/NetworksContext";
+import { useStarknet } from "../context/StarknetContext";
+import { useEarnHandler } from "./useEarnHandler";
+import {
+  earnBridgeConfirmationCopy,
+  earnBridgeWithdrawCopy,
+  type EvmEarnSourceChain,
+  isEvmEarnSourceChain,
+} from "../lib/earnChains";
+import {
+  isLayerswapSuccessStatus,
+  isLayerswapTerminalStatus,
+  type LayerswapDepositAction,
+  type LayerswapQuote,
+} from "../lib/layerswap";
+import { buildLayerswapDepositBatchCalls } from "../lib/layerswapExecute";
+import { executeBatchCalls } from "../lib/bridge";
+import { useDelegationContractAuth } from "./useEIP7702Account";
+import { getRpcUrl } from "../utils";
+import {
+  clearEarnSourcePosition,
+  loadPendingEarnBridges,
+  pendingBridgeReceiveBaseUnits,
+  savePendingEarnBridges,
+  writeEarnSourcePosition,
+  type PendingEarnBridgeJob,
+} from "../lib/earnPositionStore";
+
+const USDC_DECIMALS = 6;
+const USDC_FACTOR = BigInt("1000000");
+
+function humanToBaseUnits(amount: number): bigint {
+  return BigInt(Math.round(amount * 1_000_000));
+}
+
+function baseUnitsToHuman(units: bigint): number {
+  return Number(units) / 1_000_000;
+}
+
+export function useEvmEarnHandler() {
+  const { getAccessToken } = usePrivy();
+  const { wallets } = useWallets();
+  const { selectedNetwork } = useNetwork();
+  const {
+    walletId,
+    publicKey,
+    address: starknetAddress,
+    ensureWalletExists,
+  } = useStarknet();
+  const {
+    deposit: vesuDeposit,
+    withdraw: vesuWithdraw,
+    refreshPosition,
+  } = useEarnHandler();
+  const { signDelegationAuthorization } = useDelegationContractAuth();
+
+  const [quote, setQuote] = useState<LayerswapQuote | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [withdrawQuote, setWithdrawQuote] = useState<LayerswapQuote | null>(
+    null,
+  );
+  const [withdrawQuoteLoading, setWithdrawQuoteLoading] = useState(false);
+
+  const embeddedWallet = wallets.find((w) => w.walletClientType === "privy");
+  const evmAddress = embeddedWallet?.address?.toLowerCase();
+  const sourceChain = selectedNetwork.chain.name;
+
+  const confirmationCopy = earnBridgeConfirmationCopy(
+    quote?.avg_completion_time,
+  );
+  const withdrawConfirmationCopy = earnBridgeWithdrawCopy(
+    withdrawQuote?.avg_completion_time,
+    sourceChain,
+  );
+
+  const fetchQuote = useCallback(
+    async (amountHuman: number) => {
+      if (!isEvmEarnSourceChain(sourceChain) || !starknetAddress) return null;
+      if (!(amountHuman > 0)) {
+        setQuote(null);
+        return null;
+      }
+      setQuoteLoading(true);
+      try {
+        const res = await fetch(
+          `/api/earn/layerswap/quote?sourceChain=${encodeURIComponent(sourceChain)}&amount=${encodeURIComponent(String(amountHuman))}&destinationAddress=${encodeURIComponent(starknetAddress)}`,
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || "Quote failed");
+        setQuote(data.quote as LayerswapQuote);
+        return data.quote as LayerswapQuote;
+      } finally {
+        setQuoteLoading(false);
+      }
+    },
+    [sourceChain, starknetAddress],
+  );
+
+  const fetchWithdrawQuote = useCallback(
+    async (amountHuman: number) => {
+      if (!isEvmEarnSourceChain(sourceChain) || !evmAddress) return null;
+      if (!(amountHuman > 0)) {
+        setWithdrawQuote(null);
+        return null;
+      }
+      setWithdrawQuoteLoading(true);
+      try {
+        const res = await fetch(
+          `/api/earn/layerswap/withdraw-quote?destinationChain=${encodeURIComponent(sourceChain)}&amount=${encodeURIComponent(String(amountHuman))}&destinationAddress=${encodeURIComponent(evmAddress)}`,
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || "Quote failed");
+        setWithdrawQuote(data.quote as LayerswapQuote);
+        return data.quote as LayerswapQuote;
+      } finally {
+        setWithdrawQuoteLoading(false);
+      }
+    },
+    [sourceChain, evmAddress],
+  );
+
+  const pollSwapUntilComplete = useCallback(
+    async (swapId: string) => {
+      for (let i = 0; i < 120; i++) {
+        await new Promise((r) => setTimeout(r, 10_000));
+        const res = await fetch(
+          `/api/earn/layerswap/swap/status?id=${encodeURIComponent(swapId)}`,
+        );
+        const data = await res.json();
+        if (!res.ok) continue;
+        const status = data.swap?.status as string | undefined;
+        if (status && isLayerswapTerminalStatus(status as any)) {
+          if (!isLayerswapSuccessStatus(status as any)) {
+            throw new Error(data.swap?.fail_reason || "Bridge failed");
+          }
+          return;
+        }
+      }
+      throw new Error("Bridge timed out");
+    },
+    [],
+  );
+
+  const depositFromEvm = useCallback(
+    async (amountHuman: number): Promise<{ txHash: string; swapId: string }> => {
+      if (!embeddedWallet || !evmAddress) {
+        throw new Error("EVM wallet not ready");
+      }
+      if (!isEvmEarnSourceChain(sourceChain)) {
+        throw new Error("Earn is not supported on this network");
+      }
+      await ensureWalletExists();
+      if (!starknetAddress) {
+        throw new Error("Starknet wallet not ready");
+      }
+
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Authentication required");
+
+      const createRes = await fetch("/api/earn/layerswap/swap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceChain,
+          amount: amountHuman,
+          destinationAddress: starknetAddress,
+          sourceAddress: evmAddress,
+          refundAddress: evmAddress,
+        }),
+      });
+      const created = await createRes.json();
+      if (!createRes.ok) {
+        throw new Error(created?.error || "Failed to create bridge swap");
+      }
+
+      const depositActions = (created.deposit_actions ||
+        []) as LayerswapDepositAction[];
+      const swapId = created.swap?.id as string;
+      if (!swapId || depositActions.length === 0) {
+        throw new Error("Invalid LayerSwap response");
+      }
+
+      const chain = selectedNetwork.chain as Chain;
+      const rpcUrl = getRpcUrl(chain.name);
+      const calls = await buildLayerswapDepositBatchCalls({
+        chain,
+        rpcUrl: rpcUrl ?? "",
+        fromAddress: evmAddress,
+        tokenAmountBaseUnits: humanToBaseUnits(amountHuman),
+        depositActions,
+      });
+      const txHash = await executeBatchCalls({
+        chain,
+        calls,
+        getAccessToken,
+        embeddedWallet,
+        signDelegationAuthorization,
+        gasLimit: 800_000,
+      });
+
+      const receiveAmount = created.quote?.receive_amount ?? amountHuman;
+      const receiveBaseUnits = humanToBaseUnits(receiveAmount);
+      const requestedBaseUnits = humanToBaseUnits(amountHuman);
+
+      const job: PendingEarnBridgeJob = {
+        swapId,
+        sourceChain: sourceChain as EvmEarnSourceChain,
+        evmAddress,
+        starknetAddress,
+        requestedAmountBaseUnits: requestedBaseUnits.toString(),
+        receiveAmountBaseUnits: receiveBaseUnits.toString(),
+        createdAt: Date.now(),
+      };
+      savePendingEarnBridges([...loadPendingEarnBridges(), job]);
+
+      await pollSwapUntilComplete(swapId);
+
+      const { txHash: vesuTxHash } = await vesuDeposit("USDC", receiveBaseUnits, {
+        sourceChain,
+      });
+
+      writeEarnSourcePosition(
+        evmAddress,
+        {
+          sourceChain: sourceChain as EvmEarnSourceChain,
+          starknetAddress,
+          suppliedBaseUnits: receiveBaseUnits.toString(),
+          suppliedFormatted: receiveAmount.toFixed(6),
+          supplyApy: null,
+        },
+        "USDC",
+      );
+      await refreshPosition("USDC");
+
+      savePendingEarnBridges(
+        loadPendingEarnBridges().filter((j) => j.swapId !== swapId),
+      );
+
+      return { txHash: vesuTxHash || txHash, swapId };
+    },
+    [
+      embeddedWallet,
+      evmAddress,
+      sourceChain,
+      ensureWalletExists,
+      starknetAddress,
+      getAccessToken,
+      selectedNetwork.chain,
+      signDelegationAuthorization,
+      pollSwapUntilComplete,
+      vesuDeposit,
+      refreshPosition,
+    ],
+  );
+
+  const withdrawToEvm = useCallback(
+    async (params: {
+      amountBaseUnits: bigint;
+      useMax?: boolean;
+    }): Promise<{ txHash: string; swapId: string }> => {
+      const { amountBaseUnits, useMax = false } = params;
+      if (amountBaseUnits <= BigInt(0)) {
+        throw new Error("Withdraw amount must be greater than zero");
+      }
+      if (!embeddedWallet || !evmAddress) {
+        throw new Error("EVM wallet not ready");
+      }
+      if (!isEvmEarnSourceChain(sourceChain)) {
+        throw new Error("Earn is not supported on this network");
+      }
+      await ensureWalletExists();
+      if (!starknetAddress || !walletId || !publicKey) {
+        throw new Error("Starknet wallet not ready");
+      }
+
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Authentication required");
+
+      const bridgeHuman = baseUnitsToHuman(amountBaseUnits);
+
+      const { txHash: vesuTxHash } = await vesuWithdraw(
+        "USDC",
+        useMax ? "max" : amountBaseUnits,
+        { sourceChain },
+      );
+
+      const createRes = await fetch("/api/earn/layerswap/withdraw-swap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          destinationChain: sourceChain,
+          amount: bridgeHuman,
+          destinationAddress: evmAddress,
+          sourceAddress: starknetAddress,
+          refundAddress: starknetAddress,
+        }),
+      });
+      const created = await createRes.json();
+      if (!createRes.ok) {
+        throw new Error(created?.error || "Failed to create withdraw bridge");
+      }
+
+      const depositActions = (created.deposit_actions ||
+        []) as LayerswapDepositAction[];
+      const swapId = created.swap?.id as string;
+      if (!swapId || depositActions.length === 0) {
+        throw new Error("Invalid LayerSwap withdraw response");
+      }
+
+      const depositRes = await fetch("/api/earn/layerswap/starknet-deposit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          walletId,
+          publicKey,
+          depositActions,
+          origin: window.location.origin,
+        }),
+      });
+      const deposited = await depositRes.json();
+      if (!depositRes.ok || !deposited?.success) {
+        throw new Error(deposited?.error || "LayerSwap Starknet deposit failed");
+      }
+
+      await pollSwapUntilComplete(swapId);
+
+      clearEarnSourcePosition(evmAddress, sourceChain, "USDC");
+      await refreshPosition("USDC");
+
+      return {
+        txHash: deposited.transactionHash || vesuTxHash,
+        swapId,
+      };
+    },
+    [
+      embeddedWallet,
+      evmAddress,
+      sourceChain,
+      ensureWalletExists,
+      starknetAddress,
+      walletId,
+      publicKey,
+      getAccessToken,
+      vesuWithdraw,
+      pollSwapUntilComplete,
+      refreshPosition,
+    ],
+  );
+
+  return {
+    quote,
+    quoteLoading,
+    withdrawQuote,
+    withdrawQuoteLoading,
+    confirmationCopy,
+    withdrawConfirmationCopy,
+    fetchQuote,
+    fetchWithdrawQuote,
+    depositFromEvm,
+    withdrawToEvm,
+    isEvmEarnChain: isEvmEarnSourceChain(sourceChain),
+  };
+}

--- a/app/hooks/useEvmEarnHandler.ts
+++ b/app/hooks/useEvmEarnHandler.ts
@@ -219,7 +219,10 @@ export function useEvmEarnHandler() {
         depositActions,
       });
 
-      patchPendingEarnBridge(swapId, { claimedByLiveFlow: true });
+      patchPendingEarnBridge(swapId, {
+        claimedByLiveFlow: true,
+        claimedAt: Date.now(),
+      });
 
       const txHash = await executeBatchCalls({
         chain,

--- a/app/hooks/useEvmWalletDisplayTotal.ts
+++ b/app/hooks/useEvmWalletDisplayTotal.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import type { CrossChainBalanceEntry } from "../context";
+import {
+  parseEarnDepositedUsd,
+  resolveEvmEarnWalletDisplayTotal,
+} from "../lib/evmEarnWalletTotal";
+import { isEvmEarnFlow } from "../lib/earnFeature";
+import { useEarnSourcePosition } from "./useEarnSourcePosition";
+
+/**
+ * Selected-chain wallet total for Phase 2 EVM earn: liquid on-chain + Vesu
+ * position sourced from that chain (localStorage).
+ */
+export function useEvmWalletDisplayTotal(params: {
+  chainName: string;
+  crossChainBalances: CrossChainBalanceEntry[];
+  evmAddress?: string;
+}): {
+  liquidUsd: number;
+  earnDepositedUsd: number;
+  displayTotalUsd: number;
+  includesEarn: boolean;
+} {
+  const { chainName, crossChainBalances, evmAddress } = params;
+  const isEvmEarn = isEvmEarnFlow(chainName);
+  const position = useEarnSourcePosition(
+    isEvmEarn ? evmAddress : undefined,
+    chainName,
+    "USDC",
+  );
+  const earnDepositedUsd = isEvmEarn
+    ? parseEarnDepositedUsd(position?.suppliedFormatted)
+    : 0;
+
+  const { liquidUsd, displayTotalUsd, includesEarn } =
+    resolveEvmEarnWalletDisplayTotal({
+      chainName,
+      crossChainBalances,
+      earnDepositedUsd,
+    });
+
+  return { liquidUsd, earnDepositedUsd, displayTotalUsd, includesEarn };
+}

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -1,4 +1,5 @@
 import { Config, JWTProviderConfig } from "@/app/types";
+import { resolveLayerswapApiBaseUrl } from "./layerswapConfig";
 
 /** EIP-7702 delegation contract (ProviderBatchCallAndSponsor) per chain. */
 export const DELEGATION_CONTRACT_BY_CHAIN: Record<number, string> = {
@@ -84,8 +85,9 @@ const config: Config = {
   embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
   /** Server-side LayerSwap API key (EVM earn bridge). */
   layerswapApiKey: (process.env.LAYERSWAP_API_KEY || "").trim(),
-  layerswapApiBaseUrl:
-    (process.env.LAYERSWAP_API_BASE_URL || "https://api.layerswap.io").trim(),
+  layerswapApiBaseUrl: resolveLayerswapApiBaseUrl(
+    process.env.LAYERSWAP_API_BASE_URL,
+  ),
 };
 
 export default config;

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -68,6 +68,7 @@ const config: Config = {
   moralisBaseUrl:
     process.env.MORALIS_BASE_URL || "https://api.moralis-streams.com",
   earnEnabled: process.env.NEXT_PUBLIC_EARN_ENABLED === "true",
+  evmEarnEnabled: process.env.NEXT_PUBLIC_EVM_EARN_ENABLED === "true",
   tronEnabled: process.env.NEXT_PUBLIC_TRON_ENABLED === "true",
   referralEnabled: (process.env.NEXT_PUBLIC_REFERRAL_ENABLED || "").trim().toLowerCase() !== "false",
   bridgeEnabled: process.env.NEXT_PUBLIC_BRIDGE_ENABLED === "true",
@@ -81,6 +82,10 @@ const config: Config = {
   fantasyCampaignEnded:
     process.env.NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED === "true",
   embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
+  /** Server-side LayerSwap API key (EVM earn bridge). */
+  layerswapApiKey: (process.env.LAYERSWAP_API_KEY || "").trim(),
+  layerswapApiBaseUrl:
+    (process.env.LAYERSWAP_API_BASE_URL || "https://api.layerswap.io").trim(),
 };
 
 export default config;

--- a/app/lib/earnChains.ts
+++ b/app/lib/earnChains.ts
@@ -1,0 +1,62 @@
+/** EVM chains supported for Phase 2 Earn (USDC → LayerSwap → Starknet Vesu). */
+export const EVM_EARN_SOURCE_CHAINS = [
+  "Base",
+  "BNB Smart Chain",
+  "Arbitrum One",
+  "Polygon",
+  "Celo",
+  "Scroll",
+  "Ethereum",
+] as const;
+
+export type EvmEarnSourceChain = (typeof EVM_EARN_SOURCE_CHAINS)[number];
+
+/** Excluded from Phase 2 — LayerSwap does not bridge USDC from Lisk. */
+export const EVM_EARN_EXCLUDED_CHAINS = ["Lisk"] as const;
+
+/**
+ * Noblocks network display name → LayerSwap network identifier.
+ * LayerSwap also accepts numeric chain IDs; these names match their API docs.
+ */
+export const LAYERSWAP_SOURCE_NETWORK: Record<EvmEarnSourceChain, string> = {
+  Base: "BASE_MAINNET",
+  "BNB Smart Chain": "BSC_MAINNET",
+  "Arbitrum One": "ARBITRUM_MAINNET",
+  Polygon: "POLYGON_MAINNET",
+  Celo: "CELO_MAINNET",
+  Scroll: "SCROLL_MAINNET",
+  Ethereum: "ETHEREUM_MAINNET",
+};
+
+export const LAYERSWAP_STARKNET_NETWORK = "STARKNET_MAINNET";
+
+export const EARN_USDC_SYMBOL = "USDC";
+
+/** Deposit confirmation copy template; ETA filled from LayerSwap quote when available. */
+export function earnBridgeConfirmationCopy(etaLabel?: string): string {
+  const eta = etaLabel?.trim() || "~15 min";
+  return `Your USDC will be bridged to Vesu on Starknet · ${eta} · gasless.`;
+}
+
+/** Withdraw confirmation for EVM-sourced earn positions. */
+export function earnBridgeWithdrawCopy(etaLabel?: string, chainName?: string): string {
+  const eta = etaLabel?.trim() || "~15 min";
+  const dest = chainName?.trim() || "your source chain";
+  return `USDC will leave Vesu and bridge back to ${dest} · ${eta} · gasless.`;
+}
+
+export const EARN_STARKNET_DISCLOSURE =
+  "lives on Vesu pool, Starknet";
+
+export function isEvmEarnSourceChain(
+  chainName: string,
+): chainName is EvmEarnSourceChain {
+  return (EVM_EARN_SOURCE_CHAINS as readonly string[]).includes(chainName);
+}
+
+export function layerswapSourceNetwork(
+  chainName: string,
+): string | undefined {
+  if (!isEvmEarnSourceChain(chainName)) return undefined;
+  return LAYERSWAP_SOURCE_NETWORK[chainName];
+}

--- a/app/lib/earnFeature.ts
+++ b/app/lib/earnFeature.ts
@@ -1,10 +1,57 @@
 import config from "./config";
+import { isEvmEarnSourceChain } from "./earnChains";
 
-/** Client feature flag: Starknet Earn (Vesu / Starkzap). */
+/** Master Earn feature flag (Phase 1 + optional Phase 2). */
 export function isEarnEnabled(): boolean {
   return config.earnEnabled;
 }
 
+/** EVM → Starknet earn (LayerSwap + Vesu). */
+export function isEvmEarnEnabled(): boolean {
+  return config.earnEnabled && config.evmEarnEnabled;
+}
+
+/** Show full Earn UI (hub, deposit, position) on this chain. */
 export function isEarnUiVisible(chainName: string): boolean {
+  if (!isEarnEnabled()) return false;
+  if (chainName === "Starknet") return true;
+  return isEvmEarnEnabled() && isEvmEarnSourceChain(chainName);
+}
+
+/** Show Earn action button in wallet (including unavailable hint on unsupported chains). */
+export function isEarnActionVisible(_chainName: string): boolean {
+  return isEarnEnabled();
+}
+
+export function isEvmEarnFlow(chainName: string): boolean {
+  return isEvmEarnEnabled() && isEvmEarnSourceChain(chainName);
+}
+
+export function isStarknetEarnFlow(chainName: string): boolean {
   return isEarnEnabled() && chainName === "Starknet";
+}
+
+/** Activity scoped to the wallet view the user is on (see earn user story #4). */
+export function filterEarnActivityForChain<
+  T extends { sourceChain?: string; type?: string },
+>(
+  entries: T[],
+  chainName: string,
+  options?: { includeLegacyUntaggedDeposits?: boolean },
+): T[] {
+  if (chainName === "Starknet") {
+    return entries.filter(
+      (e) => !e.sourceChain || e.sourceChain === "Starknet",
+    );
+  }
+  if (isEvmEarnFlow(chainName)) {
+    return entries.filter(
+      (e) =>
+        e.sourceChain === chainName ||
+        (options?.includeLegacyUntaggedDeposits &&
+          !e.sourceChain &&
+          e.type === "deposit"),
+    );
+  }
+  return [];
 }

--- a/app/lib/earnPositionStore.ts
+++ b/app/lib/earnPositionStore.ts
@@ -23,16 +23,34 @@ export interface PendingEarnBridgeJob {
   createdAt: number;
   /** When true, depositFromEvm owns Vesu deposit for this job (tracker skips). */
   claimedByLiveFlow?: boolean;
+  /** Set when claimedByLiveFlow becomes true; used for stale-claim timeout. */
+  claimedAt?: number;
 }
 
 /** Stale live-flow claims fall back to the background tracker. */
 export const LIVE_FLOW_CLAIM_STALE_MS = 5 * 60 * 1000;
 
+export function liveFlowClaimStartedAt(job: PendingEarnBridgeJob): number {
+  return job.claimedAt ?? job.createdAt;
+}
+
 export function isStaleLiveFlowClaim(job: PendingEarnBridgeJob): boolean {
   return (
     Boolean(job.claimedByLiveFlow) &&
-    Date.now() - job.createdAt > LIVE_FLOW_CLAIM_STALE_MS
+    Date.now() - liveFlowClaimStartedAt(job) > LIVE_FLOW_CLAIM_STALE_MS
   );
+}
+
+const USDC_DECIMALS = 6n;
+const USDC_SCALE = 10n ** USDC_DECIMALS;
+
+/** Format 6-decimal USDC base units without lossy Number conversion. */
+export function formatUsdcBaseUnits(baseUnits: bigint): string {
+  const abs = baseUnits < BigInt(0) ? -baseUnits : baseUnits;
+  const whole = abs / USDC_SCALE;
+  const frac = abs % USDC_SCALE;
+  const sign = baseUnits < BigInt(0) ? "-" : "";
+  return `${sign}${whole}.${frac.toString().padStart(6, "0")}`;
 }
 
 export function pendingBridgeReceiveBaseUnits(
@@ -190,7 +208,7 @@ export function addEarnSourcePosition(
       sourceChain,
       starknetAddress: existing?.starknetAddress ?? starknetAddress,
       suppliedBaseUnits: next.toString(),
-      suppliedFormatted: (Number(next) / 1e6).toFixed(6),
+      suppliedFormatted: formatUsdcBaseUnits(next),
       supplyApy: existing?.supplyApy ?? supplyApy,
     },
     token,
@@ -218,7 +236,7 @@ export function subtractEarnSourcePosition(
     {
       ...existing,
       suppliedBaseUnits: next.toString(),
-      suppliedFormatted: (Number(next) / 1e6).toFixed(6),
+      suppliedFormatted: formatUsdcBaseUnits(next),
     },
     token,
   );

--- a/app/lib/earnPositionStore.ts
+++ b/app/lib/earnPositionStore.ts
@@ -21,6 +21,18 @@ export interface PendingEarnBridgeJob {
   /** @deprecated Use receiveAmountBaseUnits — kept for in-flight jobs in localStorage. */
   amountBaseUnits?: string;
   createdAt: number;
+  /** When true, depositFromEvm owns Vesu deposit for this job (tracker skips). */
+  claimedByLiveFlow?: boolean;
+}
+
+/** Stale live-flow claims fall back to the background tracker. */
+export const LIVE_FLOW_CLAIM_STALE_MS = 5 * 60 * 1000;
+
+export function isStaleLiveFlowClaim(job: PendingEarnBridgeJob): boolean {
+  return (
+    Boolean(job.claimedByLiveFlow) &&
+    Date.now() - job.createdAt > LIVE_FLOW_CLAIM_STALE_MS
+  );
 }
 
 export function pendingBridgeReceiveBaseUnits(
@@ -133,4 +145,81 @@ export function savePendingEarnBridges(jobs: PendingEarnBridgeJob[]): void {
   } catch {
     // ignore
   }
+}
+
+export function upsertPendingEarnBridge(job: PendingEarnBridgeJob): void {
+  const jobs = loadPendingEarnBridges();
+  const idx = jobs.findIndex((j) => j.swapId === job.swapId);
+  if (idx >= 0) jobs[idx] = job;
+  else jobs.push(job);
+  savePendingEarnBridges(jobs);
+}
+
+export function patchPendingEarnBridge(
+  swapId: string,
+  patch: Partial<PendingEarnBridgeJob>,
+): void {
+  savePendingEarnBridges(
+    loadPendingEarnBridges().map((j) =>
+      j.swapId === swapId ? { ...j, ...patch } : j,
+    ),
+  );
+}
+
+export function addEarnSourcePosition(
+  evmAddress: string,
+  params: {
+    sourceChain: EvmEarnSourceChain | "Starknet";
+    starknetAddress: string;
+    deltaBaseUnits: bigint;
+    supplyApy?: number | null;
+  },
+  token: string,
+): void {
+  const { sourceChain, starknetAddress, deltaBaseUnits, supplyApy = null } =
+    params;
+  if (deltaBaseUnits <= BigInt(0)) return;
+
+  const existing = readEarnSourcePosition(evmAddress, sourceChain, token);
+  const prev = existing ? BigInt(existing.suppliedBaseUnits) : BigInt(0);
+  const next = prev + deltaBaseUnits;
+
+  writeEarnSourcePosition(
+    evmAddress,
+    {
+      sourceChain,
+      starknetAddress: existing?.starknetAddress ?? starknetAddress,
+      suppliedBaseUnits: next.toString(),
+      suppliedFormatted: (Number(next) / 1e6).toFixed(6),
+      supplyApy: existing?.supplyApy ?? supplyApy,
+    },
+    token,
+  );
+}
+
+export function subtractEarnSourcePosition(
+  evmAddress: string,
+  sourceChain: string,
+  token: string,
+  deltaBaseUnits: bigint,
+): void {
+  const existing = readEarnSourcePosition(evmAddress, sourceChain, token);
+  if (!existing) return;
+
+  const prev = BigInt(existing.suppliedBaseUnits);
+  const next = prev > deltaBaseUnits ? prev - deltaBaseUnits : BigInt(0);
+  if (next <= BigInt(0)) {
+    clearEarnSourcePosition(evmAddress, sourceChain, token);
+    return;
+  }
+
+  writeEarnSourcePosition(
+    evmAddress,
+    {
+      ...existing,
+      suppliedBaseUnits: next.toString(),
+      suppliedFormatted: (Number(next) / 1e6).toFixed(6),
+    },
+    token,
+  );
 }

--- a/app/lib/earnPositionStore.ts
+++ b/app/lib/earnPositionStore.ts
@@ -41,8 +41,8 @@ export function isStaleLiveFlowClaim(job: PendingEarnBridgeJob): boolean {
   );
 }
 
-const USDC_DECIMALS = 6n;
-const USDC_SCALE = 10n ** USDC_DECIMALS;
+const USDC_SCALE = BigInt(1_000_000);
+const USDC_DECIMAL_PLACES = 6;
 
 /** Format 6-decimal USDC base units without lossy Number conversion. */
 export function formatUsdcBaseUnits(baseUnits: bigint): string {
@@ -50,7 +50,7 @@ export function formatUsdcBaseUnits(baseUnits: bigint): string {
   const whole = abs / USDC_SCALE;
   const frac = abs % USDC_SCALE;
   const sign = baseUnits < BigInt(0) ? "-" : "";
-  return `${sign}${whole}.${frac.toString().padStart(6, "0")}`;
+  return `${sign}${whole}.${frac.toString().padStart(USDC_DECIMAL_PLACES, "0")}`;
 }
 
 export function pendingBridgeReceiveBaseUnits(

--- a/app/lib/earnPositionStore.ts
+++ b/app/lib/earnPositionStore.ts
@@ -1,0 +1,136 @@
+import type { EvmEarnSourceChain } from "./earnChains";
+import type { EarnPosition } from "../hooks/useEarnHandler";
+
+const SOURCE_POSITION_PREFIX = "earn_source_position_";
+const PENDING_EARN_BRIDGE_KEY = "noblocks_pending_earn_bridges";
+
+export interface EarnSourcePosition extends EarnPosition {
+  sourceChain: EvmEarnSourceChain | "Starknet";
+  starknetAddress: string;
+}
+
+export interface PendingEarnBridgeJob {
+  swapId: string;
+  sourceChain: EvmEarnSourceChain;
+  evmAddress: string;
+  starknetAddress: string;
+  /** Amount sent on the source chain (base units). */
+  requestedAmountBaseUnits: string;
+  /** Expected Starknet receive amount after bridge fees (base units). */
+  receiveAmountBaseUnits: string;
+  /** @deprecated Use receiveAmountBaseUnits — kept for in-flight jobs in localStorage. */
+  amountBaseUnits?: string;
+  createdAt: number;
+}
+
+export function pendingBridgeReceiveBaseUnits(
+  job: PendingEarnBridgeJob,
+): bigint {
+  const raw =
+    job.receiveAmountBaseUnits ??
+    job.amountBaseUnits ??
+    job.requestedAmountBaseUnits;
+  try {
+    return BigInt(raw);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+function sourcePositionKey(
+  evmAddress: string,
+  sourceChain: string,
+  token: string,
+): string {
+  return `${SOURCE_POSITION_PREFIX}${evmAddress.toLowerCase()}_${sourceChain}_${token}`;
+}
+
+export function readEarnSourcePosition(
+  evmAddress: string,
+  sourceChain: string,
+  token: string,
+): EarnSourcePosition | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(
+      sourcePositionKey(evmAddress, sourceChain, token),
+    );
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.suppliedBaseUnits !== "string") return null;
+    return parsed as EarnSourcePosition;
+  } catch {
+    return null;
+  }
+}
+
+export function writeEarnSourcePosition(
+  evmAddress: string,
+  position: EarnSourcePosition,
+  token: string,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(
+      sourcePositionKey(evmAddress, position.sourceChain, token),
+      JSON.stringify(position),
+    );
+    window.dispatchEvent(new CustomEvent("noblocks:earn-sync"));
+  } catch {
+    // Quota — non-fatal.
+  }
+}
+
+export function clearEarnSourcePosition(
+  evmAddress: string,
+  sourceChain: string,
+  token: string,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(sourcePositionKey(evmAddress, sourceChain, token));
+    window.dispatchEvent(new CustomEvent("noblocks:earn-sync"));
+  } catch {
+    // ignore
+  }
+}
+
+export function listEarnSourcePositions(
+  evmAddress: string,
+  sourceChain?: string,
+): EarnSourcePosition[] {
+  if (typeof window === "undefined") return [];
+  const prefix = `${SOURCE_POSITION_PREFIX}${evmAddress.toLowerCase()}_`;
+  const out: EarnSourcePosition[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith(prefix)) continue;
+    if (sourceChain && !key.includes(`_${sourceChain}_`)) continue;
+    try {
+      const parsed = JSON.parse(localStorage.getItem(key) || "");
+      if (parsed?.suppliedBaseUnits) out.push(parsed as EarnSourcePosition);
+    } catch {
+      // skip
+    }
+  }
+  return out;
+}
+
+export function loadPendingEarnBridges(): PendingEarnBridgeJob[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(PENDING_EARN_BRIDGE_KEY);
+    return raw ? (JSON.parse(raw) as PendingEarnBridgeJob[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function savePendingEarnBridges(jobs: PendingEarnBridgeJob[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(PENDING_EARN_BRIDGE_KEY, JSON.stringify(jobs));
+  } catch {
+    // ignore
+  }
+}

--- a/app/lib/evmEarnWalletTotal.ts
+++ b/app/lib/evmEarnWalletTotal.ts
@@ -1,0 +1,46 @@
+import type { CrossChainBalanceEntry } from "../context";
+import { isEvmEarnFlow } from "./earnFeature";
+
+/** On-chain USD total for a single EVM network entry. */
+export function selectedChainLiquidUsd(
+  crossChainBalances: CrossChainBalanceEntry[],
+  chainName: string,
+): number {
+  const entry = crossChainBalances.find(
+    (e) => e.network.chain.name === chainName,
+  );
+  const total = entry?.balances.total;
+  return typeof total === "number" && Number.isFinite(total) ? total : 0;
+}
+
+export function parseEarnDepositedUsd(
+  suppliedFormatted?: string | null,
+): number {
+  if (!suppliedFormatted) return 0;
+  const parsed = parseFloat(suppliedFormatted);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export function evmWalletDisplayTotalUsd(
+  liquidUsd: number,
+  earnDepositedUsd: number,
+): number {
+  const total = liquidUsd + earnDepositedUsd;
+  return Number.isFinite(total) ? total : liquidUsd;
+}
+
+export function resolveEvmEarnWalletDisplayTotal(params: {
+  chainName: string;
+  crossChainBalances: CrossChainBalanceEntry[];
+  earnDepositedUsd: number;
+}): { liquidUsd: number; displayTotalUsd: number; includesEarn: boolean } {
+  const includesEarn = isEvmEarnFlow(params.chainName);
+  const liquidUsd = selectedChainLiquidUsd(
+    params.crossChainBalances,
+    params.chainName,
+  );
+  const displayTotalUsd = includesEarn
+    ? evmWalletDisplayTotalUsd(liquidUsd, params.earnDepositedUsd)
+    : liquidUsd;
+  return { liquidUsd, displayTotalUsd, includesEarn };
+}

--- a/app/lib/layerswap.ts
+++ b/app/lib/layerswap.ts
@@ -1,0 +1,277 @@
+/**
+ * LayerSwap API client (server-side). Proxied via /api/earn/layerswap/* routes.
+ */
+
+import axios from "axios";
+import type { Call } from "starknet";
+import config from "./config";
+import {
+  EARN_USDC_SYMBOL,
+  LAYERSWAP_STARKNET_NETWORK,
+  layerswapSourceNetwork,
+} from "./earnChains";
+
+export const LAYERSWAP_API_BASE = config.layerswapApiBaseUrl;
+
+/** LayerSwap API key from config (server routes only). */
+export function getLayerswapApiKey(): string {
+  return config.layerswapApiKey;
+}
+
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+export type LayerswapSwapStatus =
+  | "user_transfer_pending"
+  | "completed"
+  | "failed"
+  | "expired"
+  | "ls_transfer_pending"
+  | "pending_refund"
+  | "refunded";
+
+export interface LayerswapDepositAction {
+  type: string;
+  to_address: string;
+  amount: number;
+  amount_in_base_units: string;
+  call_data?: string | null;
+  encoded_args?: string[];
+  token?: { contract?: string | null; symbol?: string; decimals?: number };
+  order?: number;
+}
+
+export interface LayerswapQuote {
+  receive_amount: number;
+  requested_amount: number;
+  avg_completion_time?: string;
+  total_fee?: number;
+  min_receive_amount?: number;
+}
+
+export interface LayerswapPreparedSwap {
+  quote?: LayerswapQuote;
+  swap?: { id: string; status: LayerswapSwapStatus };
+  deposit_actions?: LayerswapDepositAction[];
+}
+
+export interface LayerswapApiResponse<T> {
+  data?: T;
+  error?: { code?: string; message?: string };
+}
+
+function layerswapHeaders(apiKey: string): Record<string, string> {
+  return {
+    "X-LS-APIKEY": apiKey,
+    "Content-Type": "application/json",
+  };
+}
+
+export async function layerswapGetQuote(params: {
+  apiKey: string;
+  sourceNetwork: string;
+  amount: number;
+  destinationAddress: string;
+  destinationNetwork?: string;
+}): Promise<LayerswapQuote> {
+  const { data } = await axios.get<LayerswapApiResponse<LayerswapQuote>>(
+    `${LAYERSWAP_API_BASE}/api/v2/quote`,
+    {
+      headers: layerswapHeaders(params.apiKey),
+      params: {
+        source_network: params.sourceNetwork,
+        source_token: EARN_USDC_SYMBOL,
+        destination_network:
+          params.destinationNetwork ?? LAYERSWAP_STARKNET_NETWORK,
+        destination_token: EARN_USDC_SYMBOL,
+        destination_address: params.destinationAddress,
+        amount: params.amount,
+      },
+      timeout: UPSTREAM_TIMEOUT_MS,
+      validateStatus: () => true,
+    },
+  );
+  if (data.error?.message) {
+    throw new Error(data.error.message);
+  }
+  if (!data.data) {
+    throw new Error("LayerSwap quote unavailable");
+  }
+  return data.data;
+}
+
+export async function layerswapCreateEarnSwap(params: {
+  apiKey: string;
+  sourceChainName: string;
+  amount: number;
+  destinationAddress: string;
+  sourceAddress?: string;
+  refundAddress?: string;
+}): Promise<LayerswapPreparedSwap> {
+  const sourceNetwork = layerswapSourceNetwork(params.sourceChainName);
+  if (!sourceNetwork) {
+    throw new Error(`Unsupported earn source chain: ${params.sourceChainName}`);
+  }
+
+  const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
+    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    {
+      source_network: sourceNetwork,
+      source_token: EARN_USDC_SYMBOL,
+      destination_network: LAYERSWAP_STARKNET_NETWORK,
+      destination_token: EARN_USDC_SYMBOL,
+      destination_address: params.destinationAddress,
+      amount: params.amount,
+      source_address: params.sourceAddress ?? null,
+      refund_address: params.refundAddress ?? params.sourceAddress ?? null,
+      use_depository: true,
+      use_deposit_address: false,
+      refuel: false,
+    },
+    {
+      headers: layerswapHeaders(params.apiKey),
+      timeout: UPSTREAM_TIMEOUT_MS,
+      validateStatus: () => true,
+    },
+  );
+
+  if (data.error?.message) {
+    throw new Error(data.error.message);
+  }
+  if (!data.data?.swap?.id) {
+    throw new Error("LayerSwap swap creation failed");
+  }
+  return data.data;
+}
+
+/** Starknet → EVM earn withdraw (reverse of deposit). */
+export async function layerswapCreateEarnWithdrawSwap(params: {
+  apiKey: string;
+  destinationChainName: string;
+  amount: number;
+  /** EVM address receiving bridged USDC. */
+  destinationAddress: string;
+  /** Starknet address sending USDC. */
+  sourceAddress: string;
+  refundAddress?: string;
+}): Promise<LayerswapPreparedSwap> {
+  const destinationNetwork = layerswapSourceNetwork(params.destinationChainName);
+  if (!destinationNetwork) {
+    throw new Error(
+      `Unsupported earn destination chain: ${params.destinationChainName}`,
+    );
+  }
+
+  const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
+    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    {
+      source_network: LAYERSWAP_STARKNET_NETWORK,
+      source_token: EARN_USDC_SYMBOL,
+      destination_network: destinationNetwork,
+      destination_token: EARN_USDC_SYMBOL,
+      destination_address: params.destinationAddress,
+      amount: params.amount,
+      source_address: params.sourceAddress,
+      refund_address: params.refundAddress ?? params.sourceAddress,
+      use_depository: true,
+      use_deposit_address: false,
+      refuel: false,
+    },
+    {
+      headers: layerswapHeaders(params.apiKey),
+      timeout: UPSTREAM_TIMEOUT_MS,
+      validateStatus: () => true,
+    },
+  );
+
+  if (data.error?.message) {
+    throw new Error(data.error.message);
+  }
+  if (!data.data?.swap?.id) {
+    throw new Error("LayerSwap withdraw swap creation failed");
+  }
+  return data.data;
+}
+
+export async function layerswapGetSwap(params: {
+  apiKey: string;
+  swapId: string;
+}): Promise<LayerswapPreparedSwap & { swap: NonNullable<LayerswapPreparedSwap["swap"]> }> {
+  const { data } = await axios.get<
+    LayerswapApiResponse<LayerswapPreparedSwap>
+  >(`${LAYERSWAP_API_BASE}/api/v2/swaps/${encodeURIComponent(params.swapId)}`, {
+    headers: layerswapHeaders(params.apiKey),
+    timeout: UPSTREAM_TIMEOUT_MS,
+    validateStatus: () => true,
+  });
+  if (data.error?.message) {
+    throw new Error(data.error.message);
+  }
+  if (!data.data?.swap) {
+    throw new Error("LayerSwap swap not found");
+  }
+  return data.data as LayerswapPreparedSwap & {
+    swap: NonNullable<LayerswapPreparedSwap["swap"]>;
+  };
+}
+
+export function isLayerswapTerminalStatus(
+  status: LayerswapSwapStatus,
+): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "expired" ||
+    status === "refunded"
+  );
+}
+
+export function isLayerswapSuccessStatus(status: LayerswapSwapStatus): boolean {
+  return status === "completed";
+}
+
+interface ParsedLayerswapCall {
+  contractAddress: string;
+  entrypoint: string;
+  calldata?: string[];
+}
+
+/** LayerSwap Starknet deposit_actions embed JSON calls in `call_data`. */
+export function layerswapDepositActionsToStarknetCalls(
+  depositActions: LayerswapDepositAction[],
+): Call[] {
+  const sorted = [...depositActions].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0),
+  );
+
+  const calls: Call[] = [];
+  for (const action of sorted) {
+    const raw = action.call_data?.trim();
+    if (!raw || raw === "0x") continue;
+
+    let parsed: ParsedLayerswapCall[];
+    try {
+      parsed = JSON.parse(raw) as ParsedLayerswapCall[];
+    } catch {
+      throw new Error("Invalid LayerSwap Starknet call_data");
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error("LayerSwap Starknet deposit action has no calls");
+    }
+
+    for (const c of parsed) {
+      if (!c.contractAddress || !c.entrypoint) {
+        throw new Error("LayerSwap Starknet call is missing fields");
+      }
+      calls.push({
+        contractAddress: c.contractAddress,
+        entrypoint: c.entrypoint,
+        calldata: c.calldata ?? [],
+      });
+    }
+  }
+
+  if (calls.length === 0) {
+    throw new Error("No LayerSwap Starknet deposit action to execute");
+  }
+  return calls;
+}

--- a/app/lib/layerswap.ts
+++ b/app/lib/layerswap.ts
@@ -50,7 +50,13 @@ export interface LayerswapQuote {
 
 export interface LayerswapPreparedSwap {
   quote?: LayerswapQuote;
-  swap?: { id: string; status: LayerswapSwapStatus };
+  swap?: {
+    id: string;
+    status: LayerswapSwapStatus;
+    source_address?: string | null;
+    destination_address?: string | null;
+    fail_reason?: string | null;
+  };
   deposit_actions?: LayerswapDepositAction[];
 }
 

--- a/app/lib/layerswapAddressMatch.ts
+++ b/app/lib/layerswapAddressMatch.ts
@@ -1,0 +1,66 @@
+import { normalizeStarknetAddress as canonicalizeStarknetAddress } from "../utils";
+
+const EVM_ADDRESS_LOWER = /^0x[a-f0-9]{40}$/;
+
+export function normalizeStarknetAddressForCompare(
+  address: string,
+): string | null {
+  try {
+    return canonicalizeStarknetAddress(address).toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function starknetAddressMatches(
+  candidate: string,
+  canonical: string,
+): boolean {
+  const normalizedCandidate = normalizeStarknetAddressForCompare(candidate);
+  const normalizedCanonical = normalizeStarknetAddressForCompare(canonical);
+  return (
+    normalizedCandidate !== null &&
+    normalizedCanonical !== null &&
+    normalizedCandidate === normalizedCanonical
+  );
+}
+
+export function swapBelongsToUser(params: {
+  linkedEvmAddresses: string[];
+  starknetAddresses: string[];
+  sourceAddress?: string | null;
+  destinationAddress?: string | null;
+}): boolean {
+  const { linkedEvmAddresses, starknetAddresses, sourceAddress, destinationAddress } =
+    params;
+
+  const evmSet = new Set(linkedEvmAddresses.map((a) => a.toLowerCase()));
+  const starkSet = new Set(
+    starknetAddresses
+      .map(normalizeStarknetAddressForCompare)
+      .filter((a): a is string => a !== null),
+  );
+
+  const source = sourceAddress?.trim().toLowerCase();
+  const destination = destinationAddress?.trim().toLowerCase();
+
+  if (source && EVM_ADDRESS_LOWER.test(source) && evmSet.has(source)) {
+    return true;
+  }
+  const normalizedSource = sourceAddress
+    ? normalizeStarknetAddressForCompare(sourceAddress)
+    : null;
+  if (normalizedSource && starkSet.has(normalizedSource)) {
+    return true;
+  }
+  if (destination && EVM_ADDRESS_LOWER.test(destination) && evmSet.has(destination)) {
+    return true;
+  }
+  const normalizedDestination = destinationAddress
+    ? normalizeStarknetAddressForCompare(destinationAddress)
+    : null;
+  if (normalizedDestination && starkSet.has(normalizedDestination)) {
+    return true;
+  }
+  return false;
+}

--- a/app/lib/layerswapConfig.ts
+++ b/app/lib/layerswapConfig.ts
@@ -1,0 +1,19 @@
+const DEFAULT_LAYERSWAP_API_BASE = "https://api.layerswap.io";
+
+/** Normalize LayerSwap base URL: HTTPS only, no trailing slash. */
+export function resolveLayerswapApiBaseUrl(envValue: string | undefined): string {
+  const raw = (envValue || DEFAULT_LAYERSWAP_API_BASE).trim();
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:") {
+      console.warn(
+        "LAYERSWAP_API_BASE_URL must use HTTPS; falling back to default",
+      );
+      return DEFAULT_LAYERSWAP_API_BASE;
+    }
+    const pathname = url.pathname.replace(/\/+$/, "");
+    return `${url.protocol}//${url.host}${pathname === "" ? "" : pathname}`;
+  } catch {
+    return DEFAULT_LAYERSWAP_API_BASE;
+  }
+}

--- a/app/lib/layerswapExecute.ts
+++ b/app/lib/layerswapExecute.ts
@@ -108,7 +108,16 @@ export async function buildLayerswapDepositBatchCalls(
 
     if (!hasCallData) continue;
 
-    const nativeValue = BigInt(action.amount_in_base_units || "0");
+    const isNativeAction =
+      !tokenContract || tokenContract.toLowerCase() === ZERO_ADDRESS;
+    let nativeValue = BigInt(0);
+    if (isNativeAction) {
+      try {
+        nativeValue = BigInt(action.amount_in_base_units || "0");
+      } catch {
+        throw new Error("LayerSwap deposit amount is invalid");
+      }
+    }
     calls.push({
       to: action.to_address as Address,
       value: nativeValue,

--- a/app/lib/layerswapExecute.ts
+++ b/app/lib/layerswapExecute.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  encodeFunctionData,
+  erc20Abi,
+  type Address,
+  type Chain,
+  type Hex,
+} from "viem";
+import { needsGatewayApproval } from "@/app/lib/erc20Allowance";
+import type { LayerswapDepositAction } from "@/app/lib/layerswap";
+import type { BatchCall } from "@/app/lib/providerBatch";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export interface BuildLayerswapDepositCallsParams {
+  chain: Chain;
+  rpcUrl: string;
+  fromAddress: string;
+  /** USDC amount being deposited (6 decimals), used when LayerSwap omits it on the action. */
+  tokenAmountBaseUnits: bigint;
+  depositActions: LayerswapDepositAction[];
+}
+
+function parseActionTokenAmount(
+  action: LayerswapDepositAction,
+  fallback: bigint,
+): bigint {
+  const encoded = action.encoded_args;
+  if (encoded?.length) {
+    try {
+      const last = BigInt(encoded[encoded.length - 1]!);
+      if (last > BigInt(0)) return last;
+    } catch {
+      // fall through
+    }
+  }
+  try {
+    const fromAction = BigInt(action.amount_in_base_units || "0");
+    if (fromAction > BigInt(0)) return fromAction;
+  } catch {
+    // fall through
+  }
+  return fallback;
+}
+
+/**
+ * Builds approve + depository calls for LayerSwap earn deposits.
+ * Execution must go through the sponsored EIP-7702 bundler (executeBatchCalls) —
+ * raw eth_sendTransaction through Privy corrupts ERC-20 approve via dataSuffix.
+ */
+export async function buildLayerswapDepositBatchCalls(
+  params: BuildLayerswapDepositCallsParams,
+): Promise<BatchCall[]> {
+  const {
+    chain,
+    rpcUrl,
+    fromAddress,
+    tokenAmountBaseUnits,
+    depositActions,
+  } = params;
+
+  if (!rpcUrl) {
+    throw new Error(`RPC URL not configured for ${chain.name}`);
+  }
+
+  const sorted = [...depositActions].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0),
+  );
+
+  const calls: BatchCall[] = [];
+
+  for (const action of sorted) {
+    const tokenContract = action.token?.contract?.trim();
+    const hasCallData = Boolean(action.call_data && action.call_data !== "0x");
+
+    if (
+      hasCallData &&
+      tokenContract &&
+      tokenContract.toLowerCase() !== ZERO_ADDRESS
+    ) {
+      const approvalAmount = parseActionTokenAmount(action, tokenAmountBaseUnits);
+      if (approvalAmount <= BigInt(0)) {
+        throw new Error("LayerSwap deposit amount is invalid");
+      }
+
+      const mustApprove = await needsGatewayApproval({
+        chain,
+        rpcUrl,
+        token: tokenContract,
+        owner: fromAddress,
+        spender: action.to_address,
+        required: approvalAmount,
+      });
+
+      if (mustApprove) {
+        calls.push({
+          to: tokenContract as Address,
+          value: BigInt(0),
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [action.to_address as `0x${string}`, approvalAmount],
+          }),
+        });
+      }
+    }
+
+    if (!hasCallData) continue;
+
+    const nativeValue = BigInt(action.amount_in_base_units || "0");
+    calls.push({
+      to: action.to_address as Address,
+      value: nativeValue,
+      data: action.call_data as Hex,
+    });
+  }
+
+  if (calls.length === 0) {
+    throw new Error("No LayerSwap deposit action to execute");
+  }
+
+  return calls;
+}

--- a/app/lib/layerswapRouteAuth.ts
+++ b/app/lib/layerswapRouteAuth.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { verifyJWT } from "./jwt";
 import { DEFAULT_PRIVY_CONFIG, STARKNET_READY_ACCOUNT_CLASSHASH } from "./config";
 import { collectLinkedEvmAddressesForPrivyUserId } from "./privy";
+import { starknetAddressMatches } from "./layerswapAddressMatch";
 import { computeReadyAddress, getStarknetWallet } from "./starknet";
 
 const EVM_ADDRESS_LOWER = /^0x[a-f0-9]{40}$/;
@@ -11,6 +12,8 @@ export type LayerswapAuthContext = {
   userId: string;
   token: string;
 };
+
+export { swapBelongsToUser } from "./layerswapAddressMatch";
 
 export async function requireLayerswapAuth(
   request: NextRequest,
@@ -60,10 +63,6 @@ export async function assertEvmAddressOwnedByUser(
   return linked.includes(normalized);
 }
 
-function normalizeStarknetAddress(address: string): string {
-  return address.trim().toLowerCase();
-}
-
 export async function assertStarknetAddressOwnedByUser(
   _userId: string,
   walletId: string,
@@ -73,41 +72,8 @@ export async function assertStarknetAddressOwnedByUser(
   try {
     const { publicKey } = await getStarknetWallet(walletId);
     const computed = computeReadyAddress(publicKey, STARKNET_READY_ACCOUNT_CLASSHASH);
-    return (
-      normalizeStarknetAddress(computed) ===
-      normalizeStarknetAddress(starknetAddress)
-    );
+    return starknetAddressMatches(starknetAddress, computed);
   } catch {
     return false;
   }
-}
-
-export function swapBelongsToUser(params: {
-  linkedEvmAddresses: string[];
-  starknetAddresses: string[];
-  sourceAddress?: string | null;
-  destinationAddress?: string | null;
-}): boolean {
-  const { linkedEvmAddresses, starknetAddresses, sourceAddress, destinationAddress } =
-    params;
-
-  const evmSet = new Set(linkedEvmAddresses.map((a) => a.toLowerCase()));
-  const starkSet = new Set(starknetAddresses.map(normalizeStarknetAddress));
-
-  const source = sourceAddress?.trim().toLowerCase();
-  const destination = destinationAddress?.trim().toLowerCase();
-
-  if (source && EVM_ADDRESS_LOWER.test(source) && evmSet.has(source)) {
-    return true;
-  }
-  if (source && starkSet.has(normalizeStarknetAddress(source))) {
-    return true;
-  }
-  if (destination && EVM_ADDRESS_LOWER.test(destination) && evmSet.has(destination)) {
-    return true;
-  }
-  if (destination && starkSet.has(normalizeStarknetAddress(destination))) {
-    return true;
-  }
-  return false;
 }

--- a/app/lib/layerswapRouteAuth.ts
+++ b/app/lib/layerswapRouteAuth.ts
@@ -1,0 +1,113 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { verifyJWT } from "./jwt";
+import { DEFAULT_PRIVY_CONFIG, STARKNET_READY_ACCOUNT_CLASSHASH } from "./config";
+import { collectLinkedEvmAddressesForPrivyUserId } from "./privy";
+import { computeReadyAddress, getStarknetWallet } from "./starknet";
+
+const EVM_ADDRESS_LOWER = /^0x[a-f0-9]{40}$/;
+
+export type LayerswapAuthContext = {
+  userId: string;
+  token: string;
+};
+
+export async function requireLayerswapAuth(
+  request: NextRequest,
+): Promise<
+  { ok: true; auth: LayerswapAuthContext } | { ok: false; response: NextResponse }
+> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Missing or invalid authorization header" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const { payload } = await verifyJWT(token, DEFAULT_PRIVY_CONFIG);
+    const userId = payload.sub || payload.userId;
+    if (!userId || typeof userId !== "string") {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: "Invalid token: missing user ID" },
+          { status: 401 },
+        ),
+      };
+    }
+    return { ok: true, auth: { userId, token } };
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid token" }, { status: 401 }),
+    };
+  }
+}
+
+export async function assertEvmAddressOwnedByUser(
+  userId: string,
+  address: string,
+): Promise<boolean> {
+  const normalized = address.toLowerCase();
+  if (!EVM_ADDRESS_LOWER.test(normalized)) return false;
+  const linked = await collectLinkedEvmAddressesForPrivyUserId(userId);
+  return linked.includes(normalized);
+}
+
+function normalizeStarknetAddress(address: string): string {
+  return address.trim().toLowerCase();
+}
+
+export async function assertStarknetAddressOwnedByUser(
+  _userId: string,
+  walletId: string,
+  starknetAddress: string,
+): Promise<boolean> {
+  if (!walletId || !starknetAddress) return false;
+  try {
+    const { publicKey } = await getStarknetWallet(walletId);
+    const computed = computeReadyAddress(publicKey, STARKNET_READY_ACCOUNT_CLASSHASH);
+    return (
+      normalizeStarknetAddress(computed) ===
+      normalizeStarknetAddress(starknetAddress)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function swapBelongsToUser(params: {
+  linkedEvmAddresses: string[];
+  starknetAddresses: string[];
+  sourceAddress?: string | null;
+  destinationAddress?: string | null;
+}): boolean {
+  const { linkedEvmAddresses, starknetAddresses, sourceAddress, destinationAddress } =
+    params;
+
+  const evmSet = new Set(linkedEvmAddresses.map((a) => a.toLowerCase()));
+  const starkSet = new Set(starknetAddresses.map(normalizeStarknetAddress));
+
+  const source = sourceAddress?.trim().toLowerCase();
+  const destination = destinationAddress?.trim().toLowerCase();
+
+  if (source && EVM_ADDRESS_LOWER.test(source) && evmSet.has(source)) {
+    return true;
+  }
+  if (source && starkSet.has(normalizeStarknetAddress(source))) {
+    return true;
+  }
+  if (destination && EVM_ADDRESS_LOWER.test(destination) && evmSet.has(destination)) {
+    return true;
+  }
+  if (destination && starkSet.has(normalizeStarknetAddress(destination))) {
+    return true;
+  }
+  return false;
+}

--- a/app/lib/layerswapValidation.ts
+++ b/app/lib/layerswapValidation.ts
@@ -1,0 +1,17 @@
+/** Parse a LayerSwap amount query/body param; rejects partial strings and non-finite values. */
+export function parseLayerswapAmountParam(raw: string | null): number | null {
+  if (raw === null || raw.trim() === "") return null;
+  const amount = Number(raw);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  return amount;
+}
+
+export function parseLayerswapAmountBody(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : null;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    return parseLayerswapAmountParam(value);
+  }
+  return null;
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -32,6 +32,7 @@ import { EmbedNetworkLockApplier } from "./components/EmbedNetworkLockApplier";
 import { useActualTheme } from "./hooks/useActualTheme";
 import { useDatadogRum, useMixpanel } from "./hooks/analytics/client";
 import { BlockFestClaimProvider } from "./context/BlockFestClaimContext";
+import { EarnBridgeTracker } from "./components/EarnBridgeTracker";
 
 function Providers({ children }: { children: ReactNode }) {
   const { privyAppId } = config;
@@ -123,6 +124,7 @@ function ContextProviders({ children }: { children: ReactNode }) {
                 <TokensProvider>
                   <StepProvider>
                     <BalanceProvider>
+                      <EarnBridgeTracker />
                       <TransactionsProvider>
                         <KYCProvider>
                           <BlockFestClaimProvider>

--- a/app/types.ts
+++ b/app/types.ts
@@ -484,6 +484,8 @@ export type Config = {
   moralisBaseUrl: string;
   /** Starknet Earn (Vesu via Starkzap). Requires Starknet wallet + API routes. */
   earnEnabled: boolean;
+  /** EVM → Starknet Earn via LayerSwap (Phase 2). Requires LAYERSWAP_API_KEY server-side. */
+  evmEarnEnabled: boolean;
   /** Tron network + Privy Tron wallet. Opt-in via NEXT_PUBLIC_TRON_ENABLED. */
   tronEnabled: boolean;
   /** Referral program feature flag. When false, all referral UI and API routes are disabled. */
@@ -505,6 +507,9 @@ export type Config = {
   fantasyCampaignEnded: boolean;
   /** Embeddable widget feature flag. Gates the /widget route (iframe embed for whitelisted partners). */
   embedEnabled: boolean;
+  /** LayerSwap API key (server-side only; used by /api/earn/layerswap/*). */
+  layerswapApiKey: string;
+  layerswapApiBaseUrl: string;
 };
 
 export type Network = {


### PR DESCRIPTION
### Description

Adds **Phase 2 Earn**: users on supported EVM chains (Base, Polygon, Arbitrum, etc.) can deposit USDC via LayerSwap into Vesu on Starknet, view their position on the **source chain only**, and withdraw back to that same chain — without holding ETH or STRK for gas.

**Background:** Phase 1 Earn (Starknet-native Vesu deposit/withdraw) already existed. This PR extends Earn to EVM source chains by bridging through LayerSwap while keeping the UX gasless and chain-scoped per product user stories #3–#5.

**What changed:**

- **Deposit (EVM → Vesu):** One sponsored EVM signature (EIP-7702 batch via existing bundler) for approve + LayerSwap deposit actions; background polling until bridge completes; Vesu supply on Starknet via AVNU paymaster using LayerSwap `receive_amount` (post-bridge-fee).
- **Withdraw (Vesu → source EVM):** Vesu exit on Starknet (paymaster) → LayerSwap Starknet → EVM reverse bridge (paymaster via new `/api/earn/layerswap/starknet-deposit`) → poll until funds arrive on source chain; clears chain-scoped local position.
- **Chain-scoped UX (#4):** Positions and activity are keyed/filtered by `sourceChain` (`earnPositionStore`, `useEarnSourcePosition`, `filterEarnActivityForChain`). EVM wallet views no longer show the global Starknet Vesu balance on unrelated chains.
- **LayerSwap integration:** Server client in `layerswap.ts`; six Next.js API routes under `/api/earn/layerswap/*` (quote, swap, status, withdraw-quote, withdraw-swap, starknet-deposit); config keys `layerswapApiKey` / `layerswapApiBaseUrl` in `config.ts`.
- **Bug fixes during implementation:**
  - Replaced raw Privy `eth_sendTransaction` with `executeBatchCalls` so ERC-20 approve calldata is not corrupted by `dataSuffix`.
  - Pending bridge jobs now store both `requestedAmountBaseUnits` and `receiveAmountBaseUnits` so resume/deposit uses the bridged amount, not the source send amount.
  - UI shows estimated Starknet receive and bridge fees from LayerSwap quote.

**Feature flags / env (off by default):**

- `NEXT_PUBLIC_EVM_EARN_ENABLED=true`
- `LAYERSWAP_API_KEY` (server-side)
- `LAYERSWAP_API_BASE_URL` (optional; defaults to `https://api.layerswap.io`)

**Breaking changes:** None when flags remain `false`. Starknet-native Earn behavior unchanged.

**Alternatives considered:**

- **Withdraw to Starknet wallet only** — simpler but violates user story #5; replaced with full reverse LayerSwap path.
- **Direct on-chain bridge contracts** — LayerSwap chosen for multi-chain support and existing quote/swap API.
- **Consolidated LayerSwap catch-all route** — kept one route per URL to match existing `/api/starknet/earn/*` pattern.

**API / contracts:** New internal Noblocks routes only; no aggregator or on-chain contract changes. LayerSwap fees apply on bridge (especially on small amounts).

---

### References
https://paycrest-io.atlassian.net/jira/software/projects/KAN/boards/3?selectedIssue=KAN-394

---

### Testing

**Unit tests added/updated:**

- `__tests__/earnFeature.test.ts` — feature flags, chain-scoped activity filter (incl. legacy untagged deposits)
- `__tests__/earnChains.test.ts` — supported EVM source chains / LayerSwap network map
- `__tests__/layerswapStarknetExecute.test.ts` — LayerSwap Starknet `deposit_actions` → Starknet `Call[]` parsing

**Manual E2E (Base, recommended):**

1. Set env: `NEXT_PUBLIC_EARN_ENABLED=true`, `NEXT_PUBLIC_EVM_EARN_ENABLED=true`, `LAYERSWAP_API_KEY`, paymaster + bundler keys.
2. Switch wallet to **Base** → open Earn → enter USDC amount → confirm quote shows **estimated Starknet receive** and fees.
3. Deposit → one EVM signature → wait for bridge (~15 min) → Vesu position appears on **Base only** (not Polygon/Arbitrum).
4. Switch to another EVM chain → Earn hub shows **no** Base position/activity.
5. Withdraw on Base → funds return to **Base USDC balance** (not Starknet wallet); position clears on Base; activity remains scoped.
6. Refresh mid-bridge → pending job resumes Vesu deposit with **receive** amount.

- [x] This change adds test coverage for new/changed/fixed functionality

---

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR (`.env.example` entries + unit tests)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [x] N/A — no database migration

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Earn support for eligible EVM networks, enabling USDC deposits and withdrawals through Starknet.
  * Added LayerSwap bridge quotes, estimated completion times, status tracking, confirmations, and automatic recovery of pending transfers.
  * Added source-chain balances, APY, activity filtering, wallet total updates, and network-specific availability messaging.
* **Bug Fixes**
  * Improved handling of unavailable networks, legacy activity, invalid bridge data, ownership validation, and failed transactions.
* **Tests**
  * Added coverage for supported chains, bridge flows, feature visibility, activity filtering, position tracking, authentication, and transaction preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->