### PR TITLE
fix: add liquidity band checks and toast suppression for no-provider

### DIFF
--- a/__tests__/marketLiquidity.test.ts
+++ b/__tests__/marketLiquidity.test.ts
@@ -7,11 +7,13 @@ import {
   fillableQuoteAmount,
   filterOffersForCorridor,
   isAmountFillable,
+  isSendAmountOutsideLiquidityBand,
   liquidityMaxMessage,
   liquidityMinMessage,
   nearestFillableAmount,
   nearestFillableMessage,
   noLiquidityMessage,
+  shouldSuppressNoProviderForLiquidity,
   type LiquidityCorridor,
 } from "../app/lib/marketLiquidity";
 
@@ -595,6 +597,49 @@ describe("fillableQuoteAmount", () => {
 
   it("ignores a zero or absent Send amount", () => {
     expect(fillableQuoteAmount(sellEnvelope, 0, 100)).toBe(100);
+  });
+});
+
+describe("no-provider toast suppression", () => {
+  const buyBand = (band: Record<string, unknown>) =>
+    offer(BUY_NGN_BASE, { balanceCurrency: "CNGN", rate: 1, ...band });
+
+  const envelope = computeLiquidityEnvelope(
+    [buyBand({ min: 900, max: 10_000_000, balance: 2_995_665 })],
+    BUY_NGN_BASE,
+  );
+
+  it("treats amounts above max as outside the band", () => {
+    expect(isSendAmountOutsideLiquidityBand(envelope, 10_000_000)).toBe(true);
+    expect(isSendAmountOutsideLiquidityBand(envelope, 2_995_665)).toBe(false);
+  });
+
+  it("treats amounts below min as outside the band", () => {
+    expect(isSendAmountOutsideLiquidityBand(envelope, 500)).toBe(true);
+    expect(isSendAmountOutsideLiquidityBand(envelope, 900)).toBe(false);
+  });
+
+  it("does not treat inter-provider gaps as outside the band", () => {
+    const gapEnvelope = computeLiquidityEnvelope(
+      [
+        buyBand({ providerId: "a", min: 0.5, max: 2, balance: 2 }),
+        buyBand({ providerId: "b", min: 100, max: 500, balance: 500 }),
+      ],
+      BUY_NGN_BASE,
+    );
+
+    expect(isSendAmountOutsideLiquidityBand(gapEnvelope, 50)).toBe(false);
+    expect(shouldSuppressNoProviderForLiquidity(gapEnvelope, 50)).toBe(true);
+  });
+
+  it("suppresses legacy no-provider UX when the form already explains the limit", () => {
+    expect(shouldSuppressNoProviderForLiquidity(envelope, 10_000_000)).toBe(
+      true,
+    );
+    expect(shouldSuppressNoProviderForLiquidity(envelope, 1_500_000)).toBe(
+      false,
+    );
+    expect(shouldSuppressNoProviderForLiquidity(null, 10_000_000)).toBe(false);
   });
 });
 

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -673,13 +673,19 @@ export function MainPageContent() {
     function handleRateFetch() {
       // Debounce rate fetching
       let timeoutId: NodeJS.Timeout;
+      let active = true;
 
-      if (!currency) return;
+      const invalidate = () => {
+        active = false;
+        clearTimeout(timeoutId);
+      };
 
-      if (isOnrampRate && !token) return;
+      if (!currency) return invalidate;
+
+      if (isOnrampRate && !token) return invalidate;
 
       // Only fetch rate if at least one amount is greater than 0
-      if (!amountSent && !amountReceived) return;
+      if (!amountSent && !amountReceived) return invalidate;
 
       // Nothing in this corridor is quotable. The form already says so
       // ("No liquidity available for X on Y right now"), and a request would
@@ -688,7 +694,7 @@ export function MainPageContent() {
       if (liquidity && !liquidity.viable) {
         setRateError(null);
         setIsFetchingRate(false);
-        return;
+        return invalidate;
       }
 
       // The corridor's first book is still in flight — true only until it
@@ -696,7 +702,7 @@ export function MainPageContent() {
       // clamp below and ask for whatever amount carried over from the
       // previous corridor, which is how a tab switch used to produce a
       // no-provider toast.
-      if (isLoadingLiquidity) return;
+      if (isLoadingLiquidity) return invalidate;
 
       const sentForLiquidity = Number(amountSent) || 0;
 
@@ -706,10 +712,11 @@ export function MainPageContent() {
       if (isSendAmountOutsideLiquidityBand(liquidity, sentForLiquidity)) {
         setRateError(null);
         setIsFetchingRate(false);
-        return;
+        return invalidate;
       }
 
       const getRate = async (shouldUseProvider = true) => {
+        if (!active) return;
         setIsFetchingRate(true);
 
         const lpParam =
@@ -755,9 +762,16 @@ export function MainPageContent() {
             network: normalizeNetworkForRateFetch(selectedNetwork.chain.name),
             side: isOnrampRate ? "buy" : "sell",
           });
+          if (!active) return;
           setRate(rate.data);
           setRateError(null); // Clear error on success
         } catch (error) {
+          if (!active) return;
+
+          const suppressLiquidityNoProvider =
+            isNoProviderError(error) &&
+            shouldSuppressNoProviderForLiquidity(liquidity, sentN);
+
           if (error instanceof Error) {
             if (
               shouldUseProvider &&
@@ -769,7 +783,9 @@ export function MainPageContent() {
                 phase: "provider-fallback",
                 provider: lpParam,
               });
-              toast.error(`${error.message} - defaulting to public rate`);
+              if (!suppressLiquidityNoProvider) {
+                toast.error(`${error.message} - defaulting to public rate`);
+              }
               // Track failed provider
               if (lpParam) {
                 failedProviders.current.add(lpParam);
@@ -819,10 +835,7 @@ export function MainPageContent() {
             }
           }
 
-          if (
-            isNoProviderError(error) &&
-            shouldSuppressNoProviderForLiquidity(liquidity, sentN)
-          ) {
+          if (suppressLiquidityNoProvider) {
             setRateError(null);
             return;
           }
@@ -835,7 +848,7 @@ export function MainPageContent() {
             },
           });
         } finally {
-          setIsFetchingRate(false);
+          if (active) setIsFetchingRate(false);
         }
       };
 
@@ -846,9 +859,7 @@ export function MainPageContent() {
 
       debounceFetchRate();
 
-      return () => {
-        clearTimeout(timeoutId);
-      };
+      return invalidate;
     },
     [
       amountSent,

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -38,7 +38,11 @@ import {
   isOnrampFiatCurrencyCode,
 } from "../utils";
 import { useMarketLiquidity } from "../hooks/useMarketLiquidity";
-import { fillableQuoteAmount } from "../lib/marketLiquidity";
+import {
+  fillableQuoteAmount,
+  isSendAmountOutsideLiquidityBand,
+  shouldSuppressNoProviderForLiquidity,
+} from "../lib/marketLiquidity";
 import { toAggregatorToken } from "../lib/token-symbol";
 import { mapReportAndAct } from "../lib/toastMappedError";
 import { reportClientError } from "../lib/sentry.client";
@@ -694,6 +698,17 @@ export function MainPageContent() {
       // no-provider toast.
       if (isLoadingLiquidity) return;
 
+      const sentForLiquidity = Number(amountSent) || 0;
+
+      // Above max or below min: the field already states the limit; a rate
+      // request (especially on-ramp with a token probe) often returns the
+      // aggregator's legacy no-provider string on top of that.
+      if (isSendAmountOutsideLiquidityBand(liquidity, sentForLiquidity)) {
+        setRateError(null);
+        setIsFetchingRate(false);
+        return;
+      }
+
       const getRate = async (shouldUseProvider = true) => {
         setIsFetchingRate(true);
 
@@ -803,6 +818,15 @@ export function MainPageContent() {
               }
             }
           }
+
+          if (
+            isNoProviderError(error) &&
+            shouldSuppressNoProviderForLiquidity(liquidity, sentN)
+          ) {
+            setRateError(null);
+            return;
+          }
+
           mapReportAndAct(error, {
             feature: "cngn-rate",
             onUserMessage: (userMsg) => {

--- a/app/lib/marketLiquidity.ts
+++ b/app/lib/marketLiquidity.ts
@@ -243,6 +243,36 @@ export function isAmountFillable(
 }
 
 /**
+ * True when Send amount is strictly above the corridor max or below the min.
+ * The form already surfaces `liquidityMaxMessage` / `liquidityMinMessage` for
+ * these cases; quoting them only invites a redundant no-provider toast.
+ */
+export function isSendAmountOutsideLiquidityBand(
+  envelope: LiquidityEnvelope | null,
+  amount: number,
+): boolean {
+  if (!envelope?.viable || !(amount > 0) || !Number.isFinite(amount)) {
+    return false;
+  }
+  if (envelope.max !== null && amount > envelope.max) return true;
+  if (envelope.min !== null && amount < envelope.min) return true;
+  return false;
+}
+
+/**
+ * True when the live book already explains why this Send amount cannot fill —
+ * max/min band errors and inter-provider gaps (`nearestFillableMessage`). Used
+ * to retire the legacy no-provider toast for states the form already covers.
+ */
+export function shouldSuppressNoProviderForLiquidity(
+  envelope: LiquidityEnvelope | null,
+  amount: number,
+): boolean {
+  if (!envelope?.viable || !(amount > 0)) return false;
+  return !isAmountFillable(envelope, amount);
+}
+
+/**
  * @returns the fillable amount closest to `amount`, or null when there is no
  * live band to steer toward. An amount already fillable is returned unchanged.
  *


### PR DESCRIPTION
### Description

Retires the duplicate legacy **"no provider available"** toast when the market max-liquidity check already tells the user what they can swap.

**Background:** After the market liquidity feature shipped, over-limit amounts show inline copy such as *"Up to ₦X available right now"* on the Send field. The rate-fetch path in `MainPageContent` could still call the aggregator and surface the old backend error as a Sonner toast at the same time (e.g. on-ramp NGN → USDT on Base with 10M NGN when max liquidity is ~₦1.29M).

**Changes:**
- **`marketLiquidity.ts`**
  - `isSendAmountOutsideLiquidityBand()` — true when Send is strictly above corridor max or below min (form already shows min/max messages).
  - `shouldSuppressNoProviderForLiquidity()` — true when the live book marks the Send amount as unfillable (max, min, or inter-provider gap); used to suppress the legacy toast only.
- **`MainPageContent.tsx`**
  - Skip rate requests when Send is outside the min/max band (avoids pointless aggregator calls that often return no-provider on on-ramp probe amounts).
  - On rate-fetch failure, if `isNoProviderError()` and liquidity already explains the amount, do not toast or set `rateError` — inline form validation remains the single user-facing message.
- **`marketLiquidity.test.ts`** — four tests for the new helpers.

**Impacts:** UX only in noblocks swap/on-ramp. No API, contract, or env changes. `NO_PROVIDER_FOUND` analytics and Sentry reporting for terminal attempts are unchanged; only the redundant user-facing toast is removed.

**Alternatives considered:** Only suppressing the toast without skipping the rate fetch — rejected because over-max on-ramp (especially USDT with a token probe of `1`) still triggers failing quotes. Skipping fetch for out-of-band amounts is cleaner and matches the existing pattern for non-viable corridors.

**Breaking changes:** None.


### References

https://paycrest-io.atlassian.net/jira/software/projects/KAN/boards/3?selectedIssue=KAN-734 


**Manual (recommended)**
1. Run noblocks locally with aggregator/markets configured.
2. On-ramp on **Base**, **NGN → USDT** (or the corridor from the bug report).
3. Enter an amount **above** max liquidity (e.g. 10,000,000 NGN).
4. **Expected:** Inline *"Up to ₦X available right now"* only; **no** bottom-right *"no provider available…"* toast; Swap stays disabled.
5. Enter an amount **within** limits — rate loads and no regression on normal flow.
6. Optional: off-ramp over-max on a supported corridor — same behavior (inline limit only).

**Environment:** Next.js 15 / noblocks, Node via pnpm, any modern browser.

- [x] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Send amounts that fall outside available liquidity ranges.
  * Prevented unnecessary rate requests for amounts that cannot be fulfilled.
  * Suppressed misleading “no provider” messages when liquidity limits explain the unavailable amount.

* **Tests**
  * Added coverage for liquidity boundaries, provider gaps, valid amounts, unknown liquidity, and form limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->