### PR TITLE
feat: enhance quote routing logic to avoid no route available errors for Base

### DIFF
--- a/__tests__/bridgeQuoteRouting.test.ts
+++ b/__tests__/bridgeQuoteRouting.test.ts
@@ -1,0 +1,148 @@
+/// <reference types="jest" />
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { useBridgeQuote } from "../app/hooks/bridge";
+import type { BridgeLeg } from "../app/lib/bridge";
+
+const mockNearQuote = jest.fn();
+const mockLifiQuote = jest.fn();
+
+// app/lib/bridge reaches Privy through useEIP7702Account, which ships ESM that jest cannot
+// parse. Only the execution path needs it; quote routing does not, so stub the one import.
+jest.mock("../app/hooks/useEIP7702Account", () => ({
+  get7702AuthorizedImplementationForAddress: jest.fn(),
+}));
+
+jest.mock("../app/lib/bridge", () => {
+  const actual = jest.requireActual("../app/lib/bridge");
+  return {
+    ...actual,
+    NearIntentsClient: class {
+      getQuote = (...args: unknown[]) => mockNearQuote(...args);
+    },
+    LifiClient: class {
+      getQuote = (...args: unknown[]) => mockLifiQuote(...args);
+    },
+  };
+});
+
+const EVM_ADDRESS = "0x000000000000000000000000000000000000dEaD";
+
+/**
+ * NEAR Intents' live Base list: USDC is present, USDT is not. This is the exact gap that
+ * made same-chain Base USDC -> USDT report "no conversion rail" instead of routing.
+ */
+const NEAR_TOKENS = [
+  {
+    assetId: "nep141:base-0x833589fcd6edb6e08f4c7c32d4f71b54bda02913.omft.near",
+    symbol: "USDC",
+    blockchain: "base",
+    decimals: 6,
+  },
+  {
+    assetId: "nep245:v2_1.omni.hot.tg:137_qiStmoQJDQPTebaPjgx5VBxZv6L",
+    symbol: "USDC",
+    blockchain: "pol",
+    decimals: 6,
+  },
+  {
+    assetId: "nep245:v2_1.omni.hot.tg:137_3hpYoaLtt8MP1Z2GH1U473DMRKgr",
+    symbol: "USDT",
+    blockchain: "pol",
+    decimals: 6,
+  },
+];
+
+const leg = (network: string, token: string, tokenAddress: string): BridgeLeg => ({
+  network,
+  chainId: network === "Base" ? 8453 : 137,
+  token,
+  tokenAddress,
+  decimals: 6,
+  amount: "0",
+  rawAmount: "0",
+});
+
+const BASE_USDC = leg("Base", "USDC", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+const BASE_USDT = leg("Base", "USDT", "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2");
+const POLYGON_USDT = leg("Polygon", "USDT", "0xc2132d05d31c914a87c6611c10748aeb04b58e8f");
+const BASE_ETH = leg("Base", "ETH", "");
+
+function setup(from: BridgeLeg, to: BridgeLeg, amount = "0.217639") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return renderHook(
+    () =>
+      useBridgeQuote({
+        from,
+        to,
+        amount,
+        evmAddress: EVM_ADDRESS,
+        starknetAddress: "",
+        slippageBps: 50,
+        enabled: true,
+      }),
+    {
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client }, children),
+    },
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNearQuote.mockResolvedValue({ kind: "near-deposit", amountOut: "1" });
+  mockLifiQuote.mockResolvedValue({ kind: "lifi-tx", amountOut: "1" });
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => NEAR_TOKENS,
+  }) as unknown as typeof fetch;
+});
+
+describe("useBridgeQuote engine routing", () => {
+  it("falls back to LI.FI when NEAR has no asset for a leg (Base USDT)", async () => {
+    const { result } = setup(BASE_USDC, BASE_USDT);
+
+    await waitFor(() => expect(result.current.quote).not.toBeNull());
+    expect(mockNearQuote).not.toHaveBeenCalled();
+    expect(mockLifiQuote).toHaveBeenCalledTimes(1);
+    expect(mockLifiQuote.mock.calls[0][0]).toMatchObject({
+      fromChain: 8453,
+      toChain: 8453,
+      fromToken: BASE_USDC.tokenAddress,
+      toToken: BASE_USDT.tokenAddress,
+      slippage: 0.005,
+    });
+  });
+
+  it("still uses NEAR Intents when both legs resolve", async () => {
+    const { result } = setup(BASE_USDC, POLYGON_USDT);
+
+    await waitFor(() => expect(result.current.quote).not.toBeNull());
+    expect(mockLifiQuote).not.toHaveBeenCalled();
+    expect(mockNearQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends the zero address to LI.FI for native tokens", async () => {
+    const { result } = setup(BASE_USDT, BASE_ETH);
+
+    await waitFor(() => expect(result.current.quote).not.toBeNull());
+    expect(mockLifiQuote.mock.calls[0][0]).toMatchObject({
+      fromToken: BASE_USDT.tokenAddress,
+      toToken: "0x0000000000000000000000000000000000000000",
+    });
+  });
+
+  it("reports no rail only once a quote attempt has actually run", async () => {
+    mockLifiQuote.mockResolvedValue(null);
+    const { result } = setup(BASE_USDC, BASE_USDT);
+
+    expect(result.current.isFetched).toBe(false);
+    await waitFor(() => expect(result.current.isFetched).toBe(true));
+    expect(result.current.quote).toBeNull();
+  });
+});

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -114,7 +114,6 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   const routeUnsupported =
     fromNetworkName === "Starknet" || toNetworkName === "Starknet";
 
-  const engine = from && to ? selectEngine(from, to) : null;
   const slippageBps = parseInt(
     process.env.NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS ?? "50",
     10,
@@ -154,7 +153,12 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     return undefined;
   }, [isInjectedWallet, injectedReady, injectedAddress, injectedProvider, embeddedWallet]);
 
-  const { quote, isLoading: quoteLoading, error: quoteError } = useBridgeQuote({
+  const {
+    quote,
+    isLoading: quoteLoading,
+    isFetched: quoteFetched,
+    error: quoteError,
+  } = useBridgeQuote({
     from,
     to,
     amount,
@@ -166,6 +170,17 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     getInjectedToken:
       isInjectedWallet && injectedReady ? getInjectedTokenPassive : undefined,
   });
+
+  // Which rail actually served the quote. Predicted from the pair while one is in flight;
+  // once a quote lands it is the source of truth, because a NEAR pair with no solver
+  // inventory (USDT on Base, any Lisk/Celo leg) falls back to LI.FI inside useBridgeQuote.
+  const engine: BridgeEngine | null = quote
+    ? quote.kind === "lifi-tx"
+      ? "lifi"
+      : "near"
+    : from && to
+      ? selectEngine(from, to)
+      : null;
 
   const { execute, isLoading: execLoading } = useBridgeExecute({
     selectedNetwork: fromNetworkObj,
@@ -312,9 +327,13 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     }
   };
 
+  // Only a quote attempt that actually ran and came back empty means no rail. A query that
+  // never ran (unauthenticated, wallet address not ready) leaves `quote` null too, and
+  // treating that as a dead route showed this error to every user before they connected.
   const noRailAvailable =
     routeUnsupported ||
-    (!quoteLoading &&
+    (quoteFetched &&
+      !quoteLoading &&
       !quoteError &&
       quote === null &&
       !!from &&

--- a/app/hooks/bridge.ts
+++ b/app/hooks/bridge.ts
@@ -29,6 +29,46 @@ const lifiClient = new LifiClient();
 // useBridgeQuote
 // ============================================================================
 
+/**
+ * LI.FI quote for a leg pair. Serves both the routes LI.FI owns outright (cNGN) and the
+ * NEAR fallback below, so the slippage rule and native-token handling live in one place.
+ * Returns null when either chain is outside LI.FI's coverage (Starknet has no chain id here).
+ */
+async function fetchLifiQuote(
+  from: BridgeLeg,
+  to: BridgeLeg,
+  rawAmount: string,
+  evmAddress: string,
+  slippageBps: number,
+  auth: BridgeAuth,
+): Promise<BridgeQuote | null> {
+  const fromChain = toLifiChainId(from.network);
+  const toChain = toLifiChainId(to.network);
+  if (!fromChain || !toChain) return null;
+
+  // Honor the configured slippage for liquid pairs; only illiquid cNGN routes need the
+  // 2% floor. Forcing 2% on every route silently widens slippage and risks value loss.
+  const isCngn =
+    from.token.toLowerCase() === "cngn" || to.token.toLowerCase() === "cngn";
+  const lifiSlippage = isCngn
+    ? Math.max(slippageBps / 10000, 0.02)
+    : slippageBps / 10000;
+
+  // Our token data uses an empty address for native tokens; LI.FI expects the zero address.
+  const lifiToken = (address: string) => address || ZERO_ADDRESS;
+
+  return lifiClient.getQuote({
+    fromChain,
+    toChain,
+    fromToken: lifiToken(from.tokenAddress),
+    toToken: lifiToken(to.tokenAddress),
+    fromAmount: rawAmount,
+    fromAddress: evmAddress,
+    toAddress: evmAddress,
+    slippage: lifiSlippage,
+  }, auth);
+}
+
 interface UseBridgeQuoteParams {
   from: BridgeLeg | null;
   to: BridgeLeg | null;
@@ -79,7 +119,12 @@ export function useBridgeQuote({
       const originAsset = resolveNearAssetId(from.token, from.network, tokenList);
       const destinationAsset = resolveNearAssetId(to.token, to.network, tokenList);
 
-      if (!originAsset || !destinationAsset) return null;
+      // NEAR Intents solvers only quote assets they hold inventory in, which leaves real
+      // gaps: no USDT on Base, and no Lisk/Celo/Tron at all. Those pairs are still routable
+      // through LI.FI's DEX aggregators, so fall back instead of reporting "no rail".
+      if (!originAsset || !destinationAsset) {
+        return fetchLifiQuote(from, to, rawAmount, evmAddress, slippageBps, auth);
+      }
 
       const addrFor = (network: string) =>
         network === "Starknet" ? starknetAddress : evmAddress;
@@ -100,28 +145,7 @@ export function useBridgeQuote({
       }, auth, { origin: from.decimals, destination: to.decimals });
     }
 
-    const fromChain = toLifiChainId(from.network);
-    const toChain = toLifiChainId(to.network);
-    if (!fromChain || !toChain) return null;
-
-    // Honor the configured slippage for liquid pairs; only illiquid cNGN routes need the
-    // 2% floor. Forcing 2% on every route silently widens slippage and risks value loss.
-    const isCngn =
-      from.token.toLowerCase() === "cngn" || to.token.toLowerCase() === "cngn";
-    const lifiSlippage = isCngn
-      ? Math.max(slippageBps / 10000, 0.02)
-      : slippageBps / 10000;
-
-    return lifiClient.getQuote({
-      fromChain,
-      toChain,
-      fromToken: from.tokenAddress,
-      toToken: to.tokenAddress,
-      fromAmount: rawAmount,
-      fromAddress: evmAddress,
-      toAddress: evmAddress,
-      slippage: lifiSlippage,
-    }, auth);
+    return fetchLifiQuote(from, to, rawAmount, evmAddress, slippageBps, auth);
   }, [from, to, amount, evmAddress, starknetAddress, slippageBps, getAccessToken, getInjectedToken]);
 
   const queryKey = useMemo(
@@ -135,7 +159,7 @@ export function useBridgeQuote({
     ? !!starknetAddress
     : !!evmAddress;
 
-  const { data: quote, isLoading, error, refetch } = useQuery({
+  const { data: quote, isLoading, isFetched, error, refetch } = useQuery({
     queryKey,
     queryFn: fetchQuote,
     enabled: enabled && !!from && !!to && parseFloat(amount || "0") > 0 && addressReady,
@@ -152,7 +176,9 @@ export function useBridgeQuote({
     },
   });
 
-  return { quote: quote ?? null, isLoading, error, refetch };
+  // `isFetched` distinguishes "both engines resolved to no route" from "the query never ran"
+  // (disabled: unauthenticated, or wallet address not ready). Only the former is a dead route.
+  return { quote: quote ?? null, isLoading, isFetched, error, refetch };
 }
 
 // ============================================================================


### PR DESCRIPTION



### Description

This pull request improves the bridge quote routing logic and its user interface feedback, ensuring that users only see "no route available" errors when a quote attempt has actually run and failed, rather than prematurely. It also refactors the quote-fetching logic to cleanly fall back to LI.FI when NEAR Intents cannot serve a route, and enhances test coverage for these routing cases.

**Bridge quote routing improvements:**

* Refactored the quote-fetching logic in `useBridgeQuote` to fall back to LI.FI when NEAR Intents lacks inventory for a given asset pair (e.g., USDT on Base, unsupported chains), ensuring more routes are available and reducing false negatives for users. [[1]](diffhunk://#diff-b064832579eb08d25e6ab81317021f046a3601d0285a92873d1d47db67b4e329L82-R127) [[2]](diffhunk://#diff-b064832579eb08d25e6ab81317021f046a3601d0285a92873d1d47db67b4e329L103-R148)
* Extracted LI.FI quote logic into a dedicated `fetchLifiQuote` function, centralizing slippage handling and native token address normalization.

**User interface and feedback enhancements:**

* Updated `BridgeForm` to distinguish between "no route available" due to an actual failed quote attempt and cases where the query never ran (e.g., wallet not connected), preventing premature error messages. This uses the new `isFetched` flag from `useBridgeQuote`. [[1]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aL157-R161) [[2]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR174-R184) [[3]](diffhunk://#diff-d5ee3e53c4c66a5edce65affab6eac80a34b70368f880f4786f595c56d8e018aR330-R336) [[4]](diffhunk://#diff-b064832579eb08d25e6ab81317021f046a3601d0285a92873d1d47db67b4e329L138-R162) [[5]](diffhunk://#diff-b064832579eb08d25e6ab81317021f046a3601d0285a92873d1d47db67b4e329L155-R181)
* Improved engine selection logic in the UI to reflect the actual source of the quote after fallback, rather than just the predicted engine.

**Testing:**

* Added comprehensive tests for bridge quote routing, including fallback scenarios and edge cases, in `bridgeQuoteRouting.test.ts`.

- Introduced a new test suite for the useBridgeQuote hook, covering various scenarios including fallback mechanisms between NEAR and LI.FI.
- Updated BridgeForm component to improve quote handling and distinguish between fetched and non-fetched states.
- Refactored bridge.ts to streamline quote fetching logic, ensuring better handling of unsupported asset pairs and slippage configurations.
- Enhanced error handling and user feedback for scenarios where no routing options are available.


### References

closes KAN-739

### Testing

<img width="1910" height="1030" alt="Screenshot 2026-08-10 at 7 55 50 am" src="https://github.com/user-attachments/assets/5512040b-64a1-4f1e-9b42-79a3666412ff" />
<img width="1910" height="1030" alt="Screenshot 2026-08-10 at 7 56 10 am" src="https://github.com/user-attachments/assets/fc33b8e3-6203-4390-998c-8fe386ee3229" />

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback to LI.FI when NEAR cannot support a selected asset.
  * Bridge engine selection now reflects the actual quote returned.
  * Added native-token handling and improved cNGN slippage support.

* **Bug Fixes**
  * Prevented premature “no route” warnings before wallet or authentication readiness.
  * Improved handling of unsuccessful quote attempts and empty results.

* **Tests**
  * Added coverage for quote routing, fallback behavior, native tokens, and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->