### PR TITLE
KAN-743: Map Bug/Task tickets to Jira custom fields (noblocks follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@ Consumer-facing crypto-to-fiat app built with Next.js. See [README.md](README.md
 
 ## Issue tracker (Jira)
 
-File new work in Jira project **KAN** ([paycrest-io.atlassian.net](https://paycrest-io.atlassian.net)), label **`noblocks`**. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) for issue types, Atlassian MCP usage, and PR linking. **Ticket spec:** [docs/agents/ticket-spec-template.md](docs/agents/ticket-spec-template.md) (Engineering Working Agreement). **PR template:** [.github/pull_request_template.md](.github/pull_request_template.md) (separate from ticket spec).
+File new work in Jira project **KAN** ([paycrest-io.atlassian.net](https://paycrest-io.atlassian.net)), label **`noblocks`**. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) for issue types, field ids, Atlassian MCP usage, and PR linking. **Ticket spec:** [docs/agents/ticket-spec-template.md](docs/agents/ticket-spec-template.md) — use the **Bug** fields *or* the **Task** fields, never both. **PR template:** [.github/pull_request_template.md](.github/pull_request_template.md) (separate from ticket spec).
 
 Do **not** use `gh issue create` or GitHub Issues for new tickets.
+
 
 ## GitHub PRs
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -12,7 +12,7 @@ Paycrest engineering issues are filed in **Jira**, not GitHub Issues.
 
 Use Jira for bugs, enhancements, chores, and vertical slices. Do **not** use `gh issue create` or GitHub issue forms for new work.
 
-**Ticket body:** use [ticket-spec-template.md](ticket-spec-template.md) (Engineering Working Agreement). **PRs** use [.github/pull_request_template.md](../../.github/pull_request_template.md) — that is separate from the ticket spec.
+**Ticket fields:** use [ticket-spec-template.md](ticket-spec-template.md) (Engineering Working Agreement). **PRs** use [.github/pull_request_template.md](../../.github/pull_request_template.md) — that is separate from the ticket spec.
 
 Architecture or process decisions: [decision-record-template.md](decision-record-template.md).
 
@@ -23,7 +23,7 @@ Architecture or process decisions: [decision-record-template.md](decision-record
 | Bug, regression, broken UX | **Bug** |
 | Enhancement, chore, vertical slice | **Task** |
 
-No Story/Epic usage for now.
+Use **only Bug or Task**. Never Story or Feature for new work. Keep Epic/Subtask for hierarchy only.
 
 ## How to create (agents / Claude Code skills)
 
@@ -31,11 +31,14 @@ Use **Atlassian MCP** tools against cloud `paycrest-io.atlassian.net`, project *
 
 Skills (`qa`, `triage`, `to-issues`): read this file before filing issues for noblocks.
 
-1. Set issue type: **Bug** or **Task** (see table above).
+1. Set issue type: **Bug** or **Task** (see table above) — never both shapes in one ticket.
 2. Set **labels:** `noblocks` (required).
-3. Title: clear, actionable summary.
-4. Description: fill [ticket-spec-template.md](ticket-spec-template.md) (user story, GIVEN/WHEN/THEN AC, money-safety if applicable).
-5. Add a **flowchart in a comment** when the change involves multi-step flows or navigation.
+3. Title (`summary`): clear, actionable.
+4. Fill **typed fields** from [ticket-spec-template.md](ticket-spec-template.md):
+   - **Task:** short `description` + `customfield_10126` (User story), `10127` (Acceptance criteria), `10128` (Tech details), `10129` (Money-safety Yes/No), optional `10130` / `10131`.
+   - **Bug:** `description` (describe the bug) + `customfield_10123` (To reproduce), `10124` (Expected behaviour), `environment`, optional `10125` (Additional context). **No** acceptance criteria on Bugs.
+5. Pass custom fields via `additional_fields` on create/edit (e.g. `{"customfield_10126": "..."}`). Money-safety is a select: `{"customfield_10129": {"value": "Yes"}}` or `"No"`.
+6. Add a **flowchart in a comment** when the change involves multi-step flows or navigation.
 
 Humans may also create tickets on the [KAN board](https://paycrest-io.atlassian.net/jira/software/projects/KAN/boards/1).
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -37,10 +37,47 @@ Skills (`qa`, `triage`, `to-issues`): read this file before filing issues for no
 4. Fill **typed fields** from [ticket-spec-template.md](ticket-spec-template.md):
    - **Task:** short `description` + `customfield_10126` (User story), `10127` (Acceptance criteria), `10128` (Tech details), `10129` (Money-safety Yes/No), optional `10130` / `10131`.
    - **Bug:** `description` (describe the bug) + `customfield_10123` (To reproduce), `10124` (Expected behaviour), `environment`, optional `10125` (Additional context). **No** acceptance criteria on Bugs.
-5. Pass custom fields via `additional_fields` on create/edit (e.g. `{"customfield_10126": "..."}`). Money-safety is a select — always send the option object, never a bare string: `{"customfield_10129": {"value": "Yes"}}` or `{"customfield_10129": {"value": "No"}}`.
-6. Add a **flowchart in a comment** when the change involves multi-step flows or navigation.
+5. Put custom fields in the tool's field bag: `additional_fields` on `createJiraIssue`, `fields` on `editJiraIssue`.
+6. **Format the values** — see [Field formats (ADF)](#field-formats-adf). Rich text must be an ADF document, not Markdown; Money-safety must be an option object.
+7. Add a **flowchart in a comment** when the change involves multi-step flows or navigation.
 
 Humans may also create tickets on the [KAN board](https://paycrest-io.atlassian.net/jira/software/projects/KAN/boards/1).
+
+## Field formats (ADF)
+
+`description`, `environment` and **every** `customfield_101xx` above are **rich-text (ADF) fields**. Money-safety (`customfield_10129`) is a select. Only `summary` and `labels` take plain values.
+
+**Rich text — send ADF, never Markdown.** Set `contentFormat: "adf"` and pass a document object:
+
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    { "type": "paragraph", "content": [{ "type": "text", "text": "Plain sentence." }] },
+    {
+      "type": "bulletList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Emphasised bit", "marks": [{ "type": "strong" }] }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+- A Markdown or plain string in a rich-text custom field is either **rejected** (`Operation value must be an Atlassian Document (see the Atlassian Document Format)`) or **stored verbatim** — the ticket then shows literal `**bold**`, `- bullets`, `1.` steps and code fences instead of formatting. This is not cosmetic — it is what forced a full re-backfill of existing KAN tickets.
+- Markdown is auto-converted **only** for a tool's own `description` parameter under `contentFormat: "markdown"`. Values inside `additional_fields` / `fields` are **never** converted.
+- Use real ADF nodes instead of Markdown syntax: `bulletList` / `orderedList` + `listItem` for lists, `codeBlock` for code, `heading` for headings, `hardBreak` for line breaks, `marks: [{"type": "strong"}]` for bold, `marks: [{"type": "link", "attrs": {"href": "..."}}]` for links.
+- **Money-safety** is the one non-text field — send the option object, never a bare string: `{"customfield_10129": {"value": "Yes"}}` or `{"customfield_10129": {"value": "No"}}`.
+- After writing, read the issue back (`responseContentFormat: "markdown"`) and confirm the field renders as formatted text rather than raw markers.
 
 ## PR ↔ Jira linking
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -12,7 +12,7 @@ Paycrest engineering issues are filed in **Jira**, not GitHub Issues.
 
 Use Jira for bugs, enhancements, chores, and vertical slices. Do **not** use `gh issue create` or GitHub issue forms for new work.
 
-**Ticket fields:** use [ticket-spec-template.md](ticket-spec-template.md) (Engineering Working Agreement). **PRs** use [.github/pull_request_template.md](../../.github/pull_request_template.md) — that is separate from the ticket spec.
+**Ticket fields:** use [ticket-spec-template.md](ticket-spec-template.md). **PRs** use [.github/pull_request_template.md](../../.github/pull_request_template.md) — that is separate from the ticket spec.
 
 Architecture or process decisions: [decision-record-template.md](decision-record-template.md).
 
@@ -37,7 +37,7 @@ Skills (`qa`, `triage`, `to-issues`): read this file before filing issues for no
 4. Fill **typed fields** from [ticket-spec-template.md](ticket-spec-template.md):
    - **Task:** short `description` + `customfield_10126` (User story), `10127` (Acceptance criteria), `10128` (Tech details), `10129` (Money-safety Yes/No), optional `10130` / `10131`.
    - **Bug:** `description` (describe the bug) + `customfield_10123` (To reproduce), `10124` (Expected behaviour), `environment`, optional `10125` (Additional context). **No** acceptance criteria on Bugs.
-5. Pass custom fields via `additional_fields` on create/edit (e.g. `{"customfield_10126": "..."}`). Money-safety is a select: `{"customfield_10129": {"value": "Yes"}}` or `"No"`.
+5. Pass custom fields via `additional_fields` on create/edit (e.g. `{"customfield_10126": "..."}`). Money-safety is a select — always send the option object, never a bare string: `{"customfield_10129": {"value": "Yes"}}` or `{"customfield_10129": {"value": "No"}}`.
 6. Add a **flowchart in a comment** when the change involves multi-step flows or navigation.
 
 Humans may also create tickets on the [KAN board](https://paycrest-io.atlassian.net/jira/software/projects/KAN/boards/1).

--- a/docs/agents/ticket-spec-template.md
+++ b/docs/agents/ticket-spec-template.md
@@ -1,6 +1,6 @@
 # Ticket / Spec template (Jira KAN)
 
-Fill **typed Jira fields** (not one markdown dump in Description). The ticket is the single source of truth — no spec, no build. Add a **flowchart in a Jira comment** when the change touches multi-step wallet or swap flows.
+Fill **typed Jira fields** (not one markdown dump in Description). The ticket is the single source of truth — no spec, no build. Add a **flowchart in a Jira comment** when the change involves multi-step flows or navigation.
 
 **Label:** `noblocks` (required)
 
@@ -24,7 +24,7 @@ Use for issue type **Task** only. Set fields via Atlassian MCP `additional_field
 | User story | `customfield_10126` | yes |
 | Acceptance criteria | `customfield_10127` | yes |
 | Tech details | `customfield_10128` | yes |
-| Money-safety | `customfield_10129` (`Yes` / `No`) | yes |
+| Money-safety | `customfield_10129` (select: `{"value": "Yes"}` / `{"value": "No"}`) | yes |
 | Notes / assumptions | `customfield_10130` | no |
 | Open questions | `customfield_10131` | no |
 

--- a/docs/agents/ticket-spec-template.md
+++ b/docs/agents/ticket-spec-template.md
@@ -1,18 +1,42 @@
 # Ticket / Spec template (Jira KAN)
 
-Copy this into the **Jira ticket description** when creating work for the noblocks repo. The ticket is the single source of truth — no spec, no build. Add a **flowchart in a Jira comment** when the change touches multi-step wallet or swap flows.
+Fill **typed Jira fields** (not one markdown dump in Description). The ticket is the single source of truth — no spec, no build. Add a **flowchart in a Jira comment** when the change touches multi-step wallet or swap flows.
 
 **Label:** `noblocks` (required)
 
+**Choose exactly one issue type.** Do **not** mix Bug fields with Task fields. Do **not** use Story or Feature.
+
+| Jira issue type | Use this section |
+|-----------------|------------------|
+| **Task** (enhancement, chore, vertical slice) | [Task](#task) |
+| **Bug** (regression, broken UX) | [Bug](#bug) |
+
 ---
 
-## User Story
+## Task
+
+Use for issue type **Task** only. Set fields via Atlassian MCP `additional_fields` (and `description` for the short overview).
+
+| Field | Jira field id | Required |
+|-------|---------------|----------|
+| Summary (title) | `summary` | yes |
+| Description (short overview only) | `description` | no |
+| User story | `customfield_10126` | yes |
+| Acceptance criteria | `customfield_10127` | yes |
+| Tech details | `customfield_10128` | yes |
+| Money-safety | `customfield_10129` (`Yes` / `No`) | yes |
+| Notes / assumptions | `customfield_10130` | no |
+| Open questions | `customfield_10131` | no |
+
+### Description
+
+Short what/why overview only. Full user POV goes in **User story**.
+
+### User story (`customfield_10126`)
 
 Add the details of this issue from the user's POV.
 
----
-
-## Acceptance Criteria
+### Acceptance criteria (`customfield_10127`)
 
 Include at least one **failure-case** scenario, not only the happy path.
 
@@ -24,47 +48,60 @@ Include at least one **failure-case** scenario, not only the happy path.
    **WHEN** …
    **THEN** …
 
----
-
-## Tech Details
+### Tech details (`customfield_10128`)
 
 - Next.js App Router pages / layouts / API routes affected
 - Wallet connection, signing, or chain-switch flows
 - Env vars, Privy/wallet config, or aggregator API integration
 - Database migrations (expand/contract if applicable)
 
----
 
-## Money-safety
+### Money-safety (`customfield_10129`)
 
 - Touches swap, send, quote, or balance flows that move user funds? **Yes / No**
 - If **Yes**: second human reviewer required before prod; call out failure cases in acceptance criteria.
 - UI-only, analytics, or non-transactional changes: usually **No**.
 
----
 
-## Notes / Assumptions
+### Notes / assumptions (`customfield_10130`)
 
 - Assumptions that must stay true for this change to remain correct.
 
----
-
-## Open Questions
+### Open questions (`customfield_10131`)
 
 - …
 
 ---
 
-## Bug tickets (shorter variant)
+## Bug
 
-For **Bug** issue type, use at minimum:
+Use for issue type **Bug** only. Do **not** set Task fields (no User story, Acceptance criteria, Tech details, Money-safety, Notes, or Open questions). Put money-safety notes under **Expected behaviour** when relevant.
 
-**Describe the bug** — what is wrong (failed swap, wrong quote, etc.).
+| Field | Jira field id | Required |
+|-------|---------------|----------|
+| Summary (title) | `summary` | yes |
+| Description (describe the bug) | `description` | no |
+| To reproduce | `customfield_10123` | yes |
+| Expected behaviour | `customfield_10124` | yes |
+| Environment | `environment` | yes |
+| Additional context | `customfield_10125` | no |
 
-**To reproduce** — URL, wallet, chain, steps.
+### Description
 
-**Expected** — correct behavior.
+What is wrong. Include enough technical context for an engineer to start.
 
-**Environment** — staging vs production, browser, network.
+### To reproduce (`customfield_10123`)
 
-**Acceptance criteria** — **GIVEN / WHEN / THEN** for the fix, including one regression check.
+Steps, IDs, URL, wallet/account, chain (if relevant).
+
+### Expected behaviour (`customfield_10124`)
+
+Correct behavior. If the bug is on a money-moving path, state **Money-safety: Yes** (second human reviewer before prod) here.
+
+### Environment (`environment`)
+
+Staging vs production, browser, network, currency, host (as applicable).
+
+### Additional context (`customfield_10125`)
+
+Logs, links, screenshots notes, or other context.

--- a/docs/agents/ticket-spec-template.md
+++ b/docs/agents/ticket-spec-template.md
@@ -6,6 +6,8 @@ Fill **typed Jira fields** (not one markdown dump in Description). The ticket is
 
 **Choose exactly one issue type.** Do **not** mix Bug fields with Task fields. Do **not** use Story or Feature.
 
+**Field format:** every field below except `summary` and Money-safety is **rich text (ADF)** — send `contentFormat: "adf"` with a `{"type": "doc", ...}` object. Markdown strings are rejected or stored literally, so `**bold**` and list markers end up visible in the ticket. See [issue-tracker.md](issue-tracker.md#field-formats-adf).
+
 | Jira issue type | Use this section |
 |-----------------|------------------|
 | **Task** (enhancement, chore, vertical slice) | [Task](#task) |
@@ -15,7 +17,7 @@ Fill **typed Jira fields** (not one markdown dump in Description). The ticket is
 
 ## Task
 
-Use for issue type **Task** only. Set fields via Atlassian MCP `additional_fields` (and `description` for the short overview).
+Use for issue type **Task** only. Set fields via Atlassian MCP — `additional_fields` on create, `fields` on edit — with `contentFormat: "adf"` for every rich-text value.
 
 | Field | Jira field id | Required |
 |-------|---------------|----------|


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-743

### Description

Follow-up to the merged KAN-743 migration ([#665](https://github.com/paycrest/noblocks/pull/665)). Maps Bug/Task tickets onto the typed Jira custom fields so agents and contributors stop dumping everything into Description.

- Updates `docs/agents/ticket-spec-template.md` to fill typed KAN fields (Bug: To reproduce / Expected behaviour / Environment / Additional context; Task: User story / Acceptance criteria / Tech details / Money-safety / Notes / Open questions) instead of one markdown Description body.
- Updates `docs/agents/issue-tracker.md` with field IDs for Atlassian MCP `additional_fields`, and keeps Bug vs Task mutually exclusive (no Story/Feature).
- Tweaks `AGENTS.md` to point at the field-based ticket spec.

Docs-only change; no runtime code touched. Local unrelated WIP on these docs was stashed and is not included.

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### Testing

Documentation-only change — no runtime paths affected.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Jira guidance by distinguishing ticket and pull request templates.
  * Required new work to use exactly one issue type: Bug or Task.
  * Added structured fields and guidance for Task tickets, including user stories, acceptance criteria, technical details, assumptions, open questions, and money-safety considerations.
  * Added dedicated Bug ticket fields for reproduction steps, expected behavior, environment, and context.
  * Acceptance criteria must include a failure case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->