### PR TITLE
feat(play): implement countdown and prelaunch announcement

### DIFF
--- a/app/components/play/CampaignEnded.tsx
+++ b/app/components/play/CampaignEnded.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 /**
- * End-of-campaign announcement for Noblocks Play.
  * Shown at /play when fantasyCampaignEnded; deep links redirect here.
+ * Before PLAY_LAUNCH_AT: countdown. After: season-ended announcement.
  */
 
 import Link from "next/link";
-import { ArrowUpRight01Icon, NewTwitterIcon } from "hugeicons-react";
+import { ArrowUpRight01Icon, Clock01Icon, NewTwitterIcon } from "hugeicons-react";
+import { useCountdown } from "./hooks";
 import {
   PlayCard,
   primaryButtonClasses,
@@ -15,43 +16,121 @@ import {
 
 const X_URL = "https://x.com/noblocks_xyz";
 
-export const CampaignEnded = () => (
-  <div className="mx-auto flex w-full max-w-xl flex-col gap-6 py-6 sm:py-10">
-    <div className="space-y-3 text-center">
-      <p className="text-xs font-semibold uppercase tracking-wider text-lavender-500">
-        Noblocks Play
-      </p>
-      <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
-        This season of Noblocks Play has ended
-      </h1>
-      <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
-        Thanks for playing. Follow us on X for winners and the next campaign.
-      </p>
-    </div>
+/** Game opens Wednesday 19 August 2026, 00:00 UK (BST). */
+export const PLAY_LAUNCH_AT = "2026-08-19T00:00:00+01:00";
 
-    <PlayCard className="space-y-3 sm:p-6">
-      <p className="text-sm leading-relaxed text-text-body dark:text-white/80">
-        Noblocks Play will be back for more Premier League gameweeks — stay
-        tuned.
-      </p>
-      <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
-        <a
-          href={X_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`${primaryButtonClasses} inline-flex items-center justify-center gap-2`}
-        >
-          <NewTwitterIcon className="size-4" />
-          Follow on X
-          <ArrowUpRight01Icon className="size-4" />
-        </a>
-        <Link
-          href="/"
-          className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}
-        >
-          Back to Noblocks
-        </Link>
-      </div>
-    </PlayCard>
+const LAUNCH_LABEL = new Intl.DateTimeFormat("en-GB", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: "Europe/London",
+}).format(new Date(PLAY_LAUNCH_AT));
+
+const CountdownUnit = ({
+  value,
+  label,
+}: {
+  value: number;
+  label: string;
+}) => (
+  <div className="flex min-w-[4.5rem] flex-col items-center gap-1 rounded-xl bg-background-neutral px-3 py-3 dark:bg-white/5 sm:min-w-[5.5rem] sm:px-4 sm:py-4">
+    <span className="text-2xl font-bold tabular-nums tracking-tight text-text-body dark:text-white sm:text-3xl">
+      {String(value).padStart(2, "0")}
+    </span>
+    <span className="text-[10px] font-semibold uppercase tracking-wider text-text-secondary dark:text-white/40 sm:text-xs">
+      {label}
+    </span>
   </div>
 );
+
+export const CampaignEnded = () => {
+  const { days, hours, minutes, seconds, expired } = useCountdown(PLAY_LAUNCH_AT);
+
+  if (!expired) {
+    return (
+      <div className="mx-auto flex w-full max-w-xl flex-col gap-6 py-6 sm:py-10">
+        <div className="space-y-3 text-center">
+          <p className="text-xs font-semibold uppercase tracking-wider text-lavender-500">
+            Noblocks Play
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
+            Premier League fantasy is almost here
+          </h1>
+          <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
+            Build your squad, climb the leaderboard, and compete with friends in
+            mini-leagues. The season kicks off {LAUNCH_LABEL}.
+          </p>
+        </div>
+
+        <PlayCard className="space-y-5 sm:p-6">
+          <div className="flex items-center justify-center gap-2 text-sm font-medium text-lavender-600 dark:text-lavender-400">
+            <Clock01Icon className="size-4 shrink-0" />
+            Season starts in
+          </div>
+
+          <div className="flex justify-center gap-2 sm:gap-3">
+            <CountdownUnit value={days} label="Days" />
+            <CountdownUnit value={hours} label="Hours" />
+            <CountdownUnit value={minutes} label="Mins" />
+            <CountdownUnit value={seconds} label="Secs" />
+          </div>
+
+          <p className="text-center text-sm text-text-secondary dark:text-white/50">
+            {LAUNCH_LABEL}
+          </p>
+
+          <div className="flex justify-center pt-1">
+            <Link
+              href="/"
+              className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}
+            >
+              Back to Noblocks
+            </Link>
+          </div>
+        </PlayCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-6 py-6 sm:py-10">
+      <div className="space-y-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-wider text-lavender-500">
+          Noblocks Play
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
+          This season of Noblocks Play has ended
+        </h1>
+        <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
+          Thanks for playing. Follow us on X for winners and the next campaign.
+        </p>
+      </div>
+
+      <PlayCard className="space-y-3 sm:p-6">
+        <p className="text-sm leading-relaxed text-text-body dark:text-white/80">
+          Noblocks Play will be back for more Premier League gameweeks — stay
+          tuned.
+        </p>
+        <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
+          <a
+            href={X_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${primaryButtonClasses} inline-flex items-center justify-center gap-2`}
+          >
+            <NewTwitterIcon className="size-4" />
+            Follow on X
+            <ArrowUpRight01Icon className="size-4" />
+          </a>
+          <Link
+            href="/"
+            className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}
+          >
+            Back to Noblocks
+          </Link>
+        </div>
+      </PlayCard>
+    </div>
+  );
+};

--- a/app/components/play/CampaignEnded.tsx
+++ b/app/components/play/CampaignEnded.tsx
@@ -6,6 +6,7 @@
  */
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { ArrowUpRight01Icon, Clock01Icon, NewTwitterIcon } from "hugeicons-react";
 import { useCountdown } from "./hooks";
 import {
@@ -45,9 +46,15 @@ const CountdownUnit = ({
 );
 
 export const CampaignEnded = () => {
-  const { days, hours, minutes, seconds, expired } = useCountdown(PLAY_LAUNCH_AT);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
-  if (!expired) {
+  // Null target until mount: useCountdown stays at stable zeros (no Date.now).
+  const { days, hours, minutes, seconds, expired } = useCountdown(
+    mounted ? PLAY_LAUNCH_AT : null,
+  );
+
+  if (mounted && expired) {
     return (
       <div className="mx-auto flex w-full max-w-xl flex-col gap-6 py-6 sm:py-10">
         <div className="space-y-3 text-center">
@@ -55,32 +62,29 @@ export const CampaignEnded = () => {
             Noblocks Play
           </p>
           <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
-            Premier League fantasy is almost here
+            This season of Noblocks Play has ended
           </h1>
           <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
-            Build your squad, climb the leaderboard, and compete with friends in
-            mini-leagues. The season kicks off {LAUNCH_LABEL}.
+            Thanks for playing. Follow us on X for winners and the next campaign.
           </p>
         </div>
 
-        <PlayCard className="space-y-5 sm:p-6">
-          <div className="flex items-center justify-center gap-2 text-sm font-medium text-lavender-600 dark:text-lavender-400">
-            <Clock01Icon className="size-4 shrink-0" />
-            Season starts in
-          </div>
-
-          <div className="flex justify-center gap-2 sm:gap-3">
-            <CountdownUnit value={days} label="Days" />
-            <CountdownUnit value={hours} label="Hours" />
-            <CountdownUnit value={minutes} label="Mins" />
-            <CountdownUnit value={seconds} label="Secs" />
-          </div>
-
-          <p className="text-center text-sm text-text-secondary dark:text-white/50">
-            {LAUNCH_LABEL}
+        <PlayCard className="space-y-3 sm:p-6">
+          <p className="text-sm leading-relaxed text-text-body dark:text-white/80">
+            Noblocks Play will be back for more Premier League gameweeks — stay
+            tuned.
           </p>
-
-          <div className="flex justify-center pt-1">
+          <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
+            <a
+              href={X_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${primaryButtonClasses} inline-flex items-center justify-center gap-2`}
+            >
+              <NewTwitterIcon className="size-4" />
+              Follow on X
+              <ArrowUpRight01Icon className="size-4" />
+            </a>
             <Link
               href="/"
               className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}
@@ -100,29 +104,32 @@ export const CampaignEnded = () => {
           Noblocks Play
         </p>
         <h1 className="text-2xl font-semibold tracking-tight text-text-body dark:text-white sm:text-3xl">
-          This season of Noblocks Play has ended
+          Premier League fantasy is almost here
         </h1>
         <p className="text-sm leading-relaxed text-text-secondary dark:text-white/60 sm:text-base">
-          Thanks for playing. Follow us on X for winners and the next campaign.
+          Build your squad, climb the leaderboard, and compete with friends in
+          mini-leagues. The season kicks off {LAUNCH_LABEL}.
         </p>
       </div>
 
-      <PlayCard className="space-y-3 sm:p-6">
-        <p className="text-sm leading-relaxed text-text-body dark:text-white/80">
-          Noblocks Play will be back for more Premier League gameweeks — stay
-          tuned.
+      <PlayCard className="space-y-5 sm:p-6">
+        <div className="flex items-center justify-center gap-2 text-sm font-medium text-lavender-600 dark:text-lavender-400">
+          <Clock01Icon className="size-4 shrink-0" />
+          Season starts in
+        </div>
+
+        <div className="flex justify-center gap-2 sm:gap-3" aria-busy={!mounted}>
+          <CountdownUnit value={mounted ? days : 0} label="Days" />
+          <CountdownUnit value={mounted ? hours : 0} label="Hours" />
+          <CountdownUnit value={mounted ? minutes : 0} label="Mins" />
+          <CountdownUnit value={mounted ? seconds : 0} label="Secs" />
+        </div>
+
+        <p className="text-center text-sm text-text-secondary dark:text-white/50">
+          {LAUNCH_LABEL}
         </p>
-        <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
-          <a
-            href={X_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${primaryButtonClasses} inline-flex items-center justify-center gap-2`}
-          >
-            <NewTwitterIcon className="size-4" />
-            Follow on X
-            <ArrowUpRight01Icon className="size-4" />
-          </a>
+
+        <div className="flex justify-center pt-1">
           <Link
             href="/"
             className={`${secondaryButtonClasses} inline-flex items-center justify-center gap-2`}

--- a/app/components/play/PlayShell.tsx
+++ b/app/components/play/PlayShell.tsx
@@ -9,8 +9,9 @@
  * pushing the content right like a slide-out panel.
  * Mobile: fixed bottom tab bar.
  *
- * When campaignEnded, hide live-game nav (tabs + countdown) so /play reads
- * as an announcement; /play/admin still uses this shell without game chrome.
+ * When campaignEnded or prelaunch, hide live-game nav (tabs + countdown) so
+ * /play reads as an announcement; /play/admin still uses this shell without
+ * game chrome.
  */
 
 import { ReactNode } from "react";
@@ -38,13 +39,22 @@ export const PlayHeader = ({ right }: { right?: ReactNode }) => (
   </header>
 );
 
-const PlayFooter = ({ campaignEnded }: { campaignEnded?: boolean }) => (
+const PlayFooter = ({
+  campaignEnded = false,
+  prelaunch = false,
+}: {
+  campaignEnded?: boolean;
+  prelaunch?: boolean;
+}) => {
+  const announcementMode = campaignEnded || prelaunch;
+
+  return (
   // Mobile has the bottom tab bar instead — the footer only earns its keep
-  // on wider screens. When the campaign has ended there is no bottom bar,
-  // so show the footer at all breakpoints.
+  // on wider screens. Announcement pages have no bottom bar, so show the
+  // footer at all breakpoints.
   <footer
     className={`border-t border-border-light py-6 dark:border-white/10 ${
-      campaignEnded ? "" : "max-lg:hidden"
+      announcementMode ? "" : "max-lg:hidden"
     }`}
   >
     <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 text-xs text-text-secondary dark:text-white/40 sm:px-6">
@@ -54,7 +64,7 @@ const PlayFooter = ({ campaignEnded }: { campaignEnded?: boolean }) => (
           : "Noblocks Play · Premier League Fantasy"}
       </span>
       <span className="flex items-center gap-4">
-        {!campaignEnded && (
+        {!announcementMode && (
           <Link
             href="/play/terms"
             className="transition-colors hover:text-text-body dark:hover:text-white"
@@ -65,47 +75,55 @@ const PlayFooter = ({ campaignEnded }: { campaignEnded?: boolean }) => (
       </span>
     </div>
   </footer>
-);
+  );
+};
 
 export const PlayShell = ({
   children,
   campaignEnded = false,
+  prelaunch = false,
 }: {
   children: ReactNode;
   campaignEnded?: boolean;
-}) => (
-  <div className="flex min-h-dvh flex-col">
-    <PlayHeader />
+  /** Feature off pre-launch — countdown landing, no game chrome. */
+  prelaunch?: boolean;
+}) => {
+  const announcementMode = campaignEnded || prelaunch;
 
-    <div
-      className={`mx-auto w-full max-w-6xl flex-1 px-4 pt-4 sm:px-6 ${
-        campaignEnded ? "pb-10" : "pb-28 lg:pb-20"
-      }`}
-    >
-      {!campaignEnded && (
-        /* The ONE countdown pill: first element under the header, right-aligned
-            (all breakpoints — it is deliberately not in the header). */
-        <div className="mb-4 flex justify-end">
-          <CountdownChip />
-        </div>
-      )}
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <PlayHeader />
 
-      <div className="lg:flex lg:items-start lg:gap-6">
-        {!campaignEnded && (
-          /* Desktop: icon rail that expands IN FLOW on hover — a slide-out
-              panel that pushes the content right, never an overlay. */
-          <aside className="group hidden lg:block lg:w-[4.25rem] lg:shrink-0 lg:transition-[width] lg:duration-200 lg:ease-out lg:hover:w-56">
-            <div className="sticky top-24 overflow-hidden rounded-2xl border border-border-light bg-white shadow-sm dark:border-white/10 dark:bg-surface-overlay">
-              <PlayTabs variant="rail" />
-            </div>
-          </aside>
+      <div
+        className={`mx-auto w-full max-w-6xl flex-1 px-4 pt-4 sm:px-6 ${
+          announcementMode ? "pb-10" : "pb-28 lg:pb-20"
+        }`}
+      >
+        {!announcementMode && (
+          /* The ONE countdown pill: first element under the header, right-aligned
+              (all breakpoints — it is deliberately not in the header). */
+          <div className="mb-4 flex justify-end">
+            <CountdownChip />
+          </div>
         )}
 
-        <main className="min-w-0 flex-1">{children}</main>
-      </div>
-    </div>
+        <div className="lg:flex lg:items-start lg:gap-6">
+          {!announcementMode && (
+            /* Desktop: icon rail that expands IN FLOW on hover — a slide-out
+                panel that pushes the content right, never an overlay. */
+            <aside className="group hidden lg:block lg:w-[4.25rem] lg:shrink-0 lg:transition-[width] lg:duration-200 lg:ease-out lg:hover:w-56">
+              <div className="sticky top-24 overflow-hidden rounded-2xl border border-border-light bg-white shadow-sm dark:border-white/10 dark:bg-surface-overlay">
+                <PlayTabs variant="rail" />
+              </div>
+            </aside>
+          )}
 
-    <PlayFooter campaignEnded={campaignEnded} />
-    {!campaignEnded && <PlayTabs variant="bottom" />}
-  </div>
-);
+          <main className="min-w-0 flex-1">{children}</main>
+        </div>
+      </div>
+
+      <PlayFooter campaignEnded={campaignEnded} prelaunch={prelaunch} />
+      {!announcementMode && <PlayTabs variant="bottom" />}
+    </div>
+  );
+};

--- a/app/play/layout.tsx
+++ b/app/play/layout.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import config from "@/app/lib/config";
 import { PlayShell } from "@/app/components/play/PlayShell";
+import { CampaignEnded } from "@/app/components/play/CampaignEnded";
 
 export const metadata: Metadata = config.fantasyCampaignEnded
   ? {
-      title: "Noblocks Play — Premier League Fantasy",
+      title: "Noblocks Play — Coming soon",
       description:
-        "This season of Noblocks Play has ended. Follow Noblocks on X for winners and the next campaign.",
+        "Premier League fantasy on Noblocks launches Wednesday 19 August 2026. Build your squad and compete with friends.",
     }
   : {
       title: "Noblocks Play — Premier League Fantasy",
@@ -20,11 +21,15 @@ export default function PlayLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // Feature-flagged: pre-launch the whole surface 404s (middleware mirrors
-  // this for /api/play/*).
   if (!config.fantasyEnabled) notFound();
 
-  return (
-    <PlayShell campaignEnded={config.fantasyCampaignEnded}>{children}</PlayShell>
-  );
+  if (config.fantasyCampaignEnded) {
+    return (
+      <PlayShell prelaunch>
+        <CampaignEnded />
+      </PlayShell>
+    );
+  }
+
+  return <PlayShell>{children}</PlayShell>;
 }

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -15,7 +15,6 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { trackEvent } from "@/app/hooks/analytics/client";
-import { CampaignEnded } from "@/app/components/play/CampaignEnded";
 import { JoinModal } from "@/app/components/play/JoinModal";
 import { LeaderboardTable } from "@/app/components/play/LeaderboardTable";
 import { useJoinStatus, useLeaderboard } from "@/app/components/play/hooks";
@@ -25,7 +24,6 @@ import {
   Skeleton,
   primaryButtonClasses,
 } from "@/app/components/play/ui";
-import config from "@/app/lib/config";
 
 const ASSET = (name: string) => `/images/play-promo/${name}`;
 const HERO_PILL_BUTTON =
@@ -273,14 +271,8 @@ const LeaderboardPreview = () => {
 
 export default function PlayLandingPage() {
   useEffect(() => {
-    if (!config.fantasyCampaignEnded) {
-      trackEvent("play_landing_view");
-    }
+    trackEvent("play_landing_view");
   }, []);
-
-  if (config.fantasyCampaignEnded) {
-    return <CampaignEnded />;
-  }
 
   return (
     <div className="space-y-10 md:space-y-20 md:mt-20">


### PR DESCRIPTION


### Jira Issue

Jira Issue: <!-- e.g. https://paycrest-io.atlassian.net/browse/KAN-123 -->

### Description

- Added countdown functionality to display time remaining until the Premier League season launch.
- Updated CampaignEnded component to show a prelaunch announcement when the campaign is not yet ended.
- Modified PlayShell and PlayFooter components to handle prelaunch state, ensuring proper display of navigation and footer elements.
- Adjusted layout metadata to reflect upcoming campaign details.


### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [x] CodeRabbit / CI green


### References




### Testing

<img width="1073" height="691" alt="image" src="https://github.com/user-attachments/assets/1cb4d078-b65e-43f1-971e-9a83ec0bcc4e" />
<img width="385" height="769" alt="image" src="https://github.com/user-attachments/assets/69b766c1-f4c0-40eb-b738-ab04aaf2d214" />
<img width="385" height="769" alt="image" src="https://github.com/user-attachments/assets/cce5891d-551c-48f1-aaeb-3a7215ac80d8" />
<img width="1071" height="769" alt="image" src="https://github.com/user-attachments/assets/60f46752-8876-4d75-a574-6ca580530d23" />


- [ ] This change adds test coverage for new/changed/fixed functionality


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-launch screen with a countdown to the 19 August 2026 launch.
  * Updated the campaign-ended experience with launch messaging and relevant links.
  * Added a streamlined pre-launch layout that hides gameplay navigation until launch.
  * Updated campaign metadata to reflect the upcoming launch date.

* **Bug Fixes**
  * Ensured the play landing page and its analytics tracking display consistently before launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->