### PR TITLE
fix(db): idempotent refund_accounts currency migration for re-apply

### DIFF
--- a/supabase/migrations/20260817180000_refund_accounts_per_currency.sql
+++ b/supabase/migrations/20260817180000_refund_accounts_per_currency.sql
@@ -1,4 +1,8 @@
 -- Scope refund accounts per wallet + fiat currency (onramp).
+--
+-- Idempotent: #667 landed on stable and its DDL was applied to production
+-- outside the main migrate ledger. After retimestamping to 20260817180000,
+-- db push re-runs this file; column/constraint may already exist.
 
 alter table public.refund_accounts
   add column if not exists currency text;
@@ -15,6 +19,16 @@ alter table public.refund_accounts
   drop constraint if exists refund_accounts_one_per_wallet;
 
 -- Unique (wallet, currency) also provides the lookup index; no separate btree needed.
-alter table public.refund_accounts
-  add constraint refund_accounts_one_per_wallet_currency
-  unique (normalized_wallet_address, currency);
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid = 'public.refund_accounts'::regclass
+       and conname  = 'refund_accounts_one_per_wallet_currency'
+  ) then
+    alter table public.refund_accounts
+      add constraint refund_accounts_one_per_wallet_currency
+      unique (normalized_wallet_address, currency);
+  end if;
+end
+$$;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Jira Issue

Jira Issue: _(Atlassian MCP not authenticated — please file a KAN Bug labeled `noblocks` and update this link)_

### Description

After #678 retimestamped migrations, main migrate tried to apply `20260817180000_refund_accounts_per_currency.sql` and failed:

```text
ERROR: relation "refund_accounts_one_per_wallet_currency" already exists (SQLSTATE 42P07)
```

Notices showed `currency` already exists and `refund_accounts_one_per_wallet` already gone — the #667 DDL was applied to production (stable path) but never recorded under the new version id. The identity migrations never ran because this file aborted first.

Make the unique-constraint add idempotent via a `pg_constraint` existence check (same pattern as `20260817180200`). Column add / old-constraint drop were already safe.

### Self-review

- [x] Reviewed against failing migrate log
- [ ] CodeRabbit / CI green

### References

- Failing migrate: https://github.com/paycrest/noblocks/actions/runs/32049797292/job/95447501567
- Blocked promotion: https://github.com/paycrest/noblocks/pull/677
- Prior retimestamp fix: https://github.com/paycrest/noblocks/pull/678

### Testing

- After merge, main migrate should skip the existing unique constraint, record `20260817180000`, then apply `20260817180100`–`20260817180400`
- Confirm no `42P07` on refund_accounts

- [ ] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3310ed36-28df-4edd-9622-d4a578debc42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3310ed36-28df-4edd-9622-d4a578debc42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

