### PR TITLE
Fixing Leaderboard updates for noblocks Play

### DIFF
--- a/__tests__/fantasy-participant-patches.test.ts
+++ b/__tests__/fantasy-participant-patches.test.ts
@@ -1,0 +1,66 @@
+jest.mock("server-only", () => ({}));
+jest.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: jest.fn() },
+}));
+jest.mock("@/lib/fantasy/settings", () => ({
+  getFantasySettings: jest.fn(),
+  invalidateFantasySettingsCache: jest.fn(),
+}));
+jest.mock("@/lib/fantasy/players", () => ({
+  getPlayersMap: jest.fn(),
+  invalidatePlayersCache: jest.fn(),
+}));
+
+import {
+  batchUpsertParticipants,
+  mergeParticipantPatches,
+} from "@/app/lib/fantasy/worker/scoring";
+
+describe("mergeParticipantPatches", () => {
+  it("merges duplicate normalized wallets into one payload", () => {
+    expect(
+      mergeParticipantPatches([
+        { wallet_address: "0xABC", total_points: 10 },
+        { wallet_address: "0xabc", current_rank: 3 },
+        { wallet_address: " 0xAbC ", total_points: 24 },
+      ]),
+    ).toEqual([{ wallet_address: "0xabc", total_points: 24, current_rank: 3 }]);
+  });
+
+  it("later rows override defined fields for the same wallet", () => {
+    expect(
+      mergeParticipantPatches([
+        { wallet_address: "0x1", total_points: 5, current_rank: 9 },
+        { wallet_address: "0x1", total_points: 12, previous_rank: 9 },
+      ]),
+    ).toEqual([
+      { wallet_address: "0x1", total_points: 12, current_rank: 9, previous_rank: 9 },
+    ]);
+  });
+
+  it("leaves distinct wallets separate", () => {
+    expect(
+      mergeParticipantPatches([
+        { wallet_address: "0xaaa", total_points: 1 },
+        { wallet_address: "0xbbb", total_points: 2 },
+      ]),
+    ).toEqual([
+      { wallet_address: "0xaaa", total_points: 1 },
+      { wallet_address: "0xbbb", total_points: 2 },
+    ]);
+  });
+});
+
+describe("batchUpsertParticipants", () => {
+  it("rejects invalid batchSize before any DB access", async () => {
+    await expect(
+      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], 0),
+    ).rejects.toThrow("batchSize must be a positive integer");
+    await expect(
+      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], -1),
+    ).rejects.toThrow("batchSize must be a positive integer");
+    await expect(
+      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], 1.5),
+    ).rejects.toThrow("batchSize must be a positive integer");
+  });
+});

--- a/__tests__/fantasy-participant-patches.test.ts
+++ b/__tests__/fantasy-participant-patches.test.ts
@@ -11,10 +11,14 @@ jest.mock("@/lib/fantasy/players", () => ({
   invalidatePlayersCache: jest.fn(),
 }));
 
+import { supabaseAdmin } from "../app/lib/supabase";
+
 import {
   batchUpsertParticipants,
   mergeParticipantPatches,
 } from "@/app/lib/fantasy/worker/scoring";
+
+const from = supabaseAdmin.from as unknown as jest.Mock;
 
 describe("mergeParticipantPatches", () => {
   it("merges duplicate normalized wallets into one payload", () => {
@@ -52,15 +56,14 @@ describe("mergeParticipantPatches", () => {
 });
 
 describe("batchUpsertParticipants", () => {
+  beforeEach(() => from.mockReset());
+
   it("rejects invalid batchSize before any DB access", async () => {
-    await expect(
-      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], 0),
-    ).rejects.toThrow("batchSize must be a positive integer");
-    await expect(
-      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], -1),
-    ).rejects.toThrow("batchSize must be a positive integer");
-    await expect(
-      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], 1.5),
-    ).rejects.toThrow("batchSize must be a positive integer");
+    for (const batchSize of [0, -1, 1.5]) {
+      await expect(
+        batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }], batchSize),
+      ).rejects.toThrow("batchSize must be a positive integer");
+      expect(from).not.toHaveBeenCalled();
+    }
   });
 });

--- a/__tests__/fantasy-participant-patches.test.ts
+++ b/__tests__/fantasy-participant-patches.test.ts
@@ -66,4 +66,63 @@ describe("batchUpsertParticipants", () => {
       expect(from).not.toHaveBeenCalled();
     }
   });
+
+  it("caps in-flight participant updates regardless of batch size", async () => {
+    const rows = Array.from({ length: 120 }, (_, i) => ({
+      wallet_address: `0x${i}`,
+      total_points: i,
+    }));
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const updated: string[] = [];
+
+    from.mockImplementation((table: string) => {
+      if (table !== "fantasy_participants") throw new Error(`unexpected table ${table}`);
+      return {
+        select: () => ({
+          in: (_col: string, wallets: string[]) =>
+            Promise.resolve({
+              data: wallets.map((w) => ({ wallet_address: w })),
+              error: null,
+            }),
+        }),
+        update: () => ({
+          eq: async (_col: string, wallet: string) => {
+            inFlight += 1;
+            peakInFlight = Math.max(peakInFlight, inFlight);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            inFlight -= 1;
+            updated.push(wallet);
+            return { error: null };
+          },
+        }),
+      };
+    });
+
+    await batchUpsertParticipants(rows);
+
+    expect(updated).toHaveLength(120);
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakInFlight).toBeLessThanOrEqual(25);
+  });
+
+  it("propagates the first update error", async () => {
+    from.mockImplementation(() => ({
+      select: () => ({
+        in: (_col: string, wallets: string[]) =>
+          Promise.resolve({
+            data: wallets.map((w) => ({ wallet_address: w })),
+            error: null,
+          }),
+      }),
+      update: () => ({
+        eq: async () => ({ error: { message: "boom" } }),
+      }),
+    }));
+
+    await expect(
+      batchUpsertParticipants([{ wallet_address: "0x1", total_points: 1 }]),
+    ).rejects.toEqual({ message: "boom" });
+  });
 });

--- a/app/lib/fantasy/worker.ts
+++ b/app/lib/fantasy/worker.ts
@@ -61,6 +61,22 @@ export { recomputeScores } from "./worker/scoring";
 
 let tickRunning = false;
 
+/** PostgREST errors are plain objects — String(error) yields "[object Object]". */
+function formatWorkerError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const e = error as { message?: string; code?: string; details?: string; hint?: string };
+    const parts = [
+      e.message,
+      e.code ? `code=${e.code}` : undefined,
+      e.details,
+      e.hint,
+    ].filter((part): part is string => typeof part === "string" && part.length > 0);
+    if (parts.length > 0) return parts.join(" | ");
+  }
+  return String(error);
+}
+
 export async function runWorkerTick(options?: { force?: boolean }): Promise<WorkerReport> {
   const force = options?.force ?? false;
   const nowDate = new Date();
@@ -132,7 +148,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           fixtures = await loadFixtures(settings);
         }
       } catch (error) {
-        report.alerts.push(`timelapse fixture advance failed: ${String(error)}`);
+        report.alerts.push(`timelapse fixture advance failed: ${formatWorkerError(error)}`);
       }
     } else if (refreshDue) {
       try {
@@ -141,7 +157,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
         fixtures = await loadFixtures(settings);
         checkFrozenDeadlinePostponements(matchdays, fixtures, now, report.alerts);
       } catch (error) {
-        report.alerts.push(`fixture refresh failed: ${String(error)}`);
+        report.alerts.push(`fixture refresh failed: ${formatWorkerError(error)}`);
       }
     }
 
@@ -167,7 +183,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           if (pass === "reconcile_final") report.fixtures_finalized++;
         } catch (error) {
           report.alerts.push(
-            `stats sync failed for fixture ${fixture.provider_fixture_id} (${pass}): ${String(error)}`,
+            `stats sync failed for fixture ${fixture.provider_fixture_id} (${pass}): ${formatWorkerError(error)}`,
           );
         }
       }
@@ -191,7 +207,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           await rolloverMatchday(md, matchdays, settings, report.alerts);
           report.rolled_over_to = nextMatchday(matchdays, md.id)?.id ?? null;
         } catch (error) {
-          report.alerts.push(`rollover after MD${md.id} failed: ${String(error)}`);
+          report.alerts.push(`rollover after MD${md.id} failed: ${formatWorkerError(error)}`);
         }
       }
 
@@ -244,7 +260,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
         if (pendingRescore.length > 0) await clearPendingRescore(report.alerts);
       } catch (error) {
         recomputeSucceeded = false;
-        report.alerts.push(`score recompute failed: ${String(error)}`);
+        report.alerts.push(`score recompute failed: ${formatWorkerError(error)}`);
       }
     }
 
@@ -255,7 +271,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           const n = await resolveChallengesForGameweek(md.id, report.alerts);
           if (n > 0) report.transitions.push(`MD${md.id}: resolved ${n} challenge(s)`);
         } catch (error) {
-          report.alerts.push(`challenge resolve after MD${md.id} failed: ${String(error)}`);
+          report.alerts.push(`challenge resolve after MD${md.id} failed: ${formatWorkerError(error)}`);
         }
       }
     } else {
@@ -277,7 +293,7 @@ export async function runWorkerTick(options?: { force?: boolean }): Promise<Work
           report.alerts,
         );
       } catch (error) {
-        report.alerts.push(`notifications failed: ${String(error)}`);
+        report.alerts.push(`notifications failed: ${formatWorkerError(error)}`);
       }
     }
 

--- a/app/lib/fantasy/worker/scoring.ts
+++ b/app/lib/fantasy/worker/scoring.ts
@@ -9,6 +9,9 @@ import type { FantasySettings, Position } from "../types";
 /** Skip overlapping ticks when another run started within this window (seconds). */
 const WORKER_STALE_SECONDS = 90;
 
+/** In-flight participant UPDATEs allowed at once (one request each). */
+const UPDATE_CONCURRENCY = 25;
+
 /**
  * Claim the cross-instance run lock. Resolves to a uuid ownership token, or
  * null when another tick holds a non-stale claim. The token must be handed
@@ -56,6 +59,8 @@ export function mergeParticipantPatches(rows: ParticipantPatch[]): ParticipantPa
  * Batch-merge score/rank patches onto existing participants.
  * Preflight resolves canonical wallet_address values, then UPDATE-only (join
  * owns inserts + terms_accepted_at; upsert partial rows can still INSERT).
+ * Updates are one request per participant, so they go out in fixed-size
+ * groups: a full batchSize chunk would otherwise open 500 at once.
  */
 export async function batchUpsertParticipants(
   rows: ParticipantPatch[],
@@ -86,22 +91,24 @@ export async function batchUpsertParticipants(
     const patches = chunk.filter((row) => canonical.has(row.wallet_address));
     if (patches.length === 0) continue;
 
-    await Promise.all(
-      patches.map(async (row) => {
-        const patch: Record<string, unknown> = {
-          updated_at: new Date().toISOString(),
-        };
-        if (row.total_points !== undefined) patch.total_points = row.total_points;
-        if (row.current_rank !== undefined) patch.current_rank = row.current_rank;
-        if (row.previous_rank !== undefined) patch.previous_rank = row.previous_rank;
+    for (const group of chunkArray(patches, UPDATE_CONCURRENCY)) {
+      await Promise.all(
+        group.map(async (row) => {
+          const patch: Record<string, unknown> = {
+            updated_at: new Date().toISOString(),
+          };
+          if (row.total_points !== undefined) patch.total_points = row.total_points;
+          if (row.current_rank !== undefined) patch.current_rank = row.current_rank;
+          if (row.previous_rank !== undefined) patch.previous_rank = row.previous_rank;
 
-        const { error } = await supabaseAdmin
-          .from("fantasy_participants")
-          .update(patch)
-          .eq("wallet_address", canonical.get(row.wallet_address)!);
-        if (error) throw error;
-      }),
-    );
+          const { error } = await supabaseAdmin
+            .from("fantasy_participants")
+            .update(patch)
+            .eq("wallet_address", canonical.get(row.wallet_address)!);
+          if (error) throw error;
+        }),
+      );
+    }
   }
 }
 

--- a/app/lib/fantasy/worker/scoring.ts
+++ b/app/lib/fantasy/worker/scoring.ts
@@ -3,7 +3,7 @@ import { applyAutoSubs } from "../autosubs";
 import { computeSquadPoints } from "../scoring";
 import { getFantasySettings, invalidateFantasySettingsCache } from "../settings";
 import { getPlayersMap, invalidatePlayersCache } from "../players";
-import { fetchAll } from "../pagination";
+import { chunkArray, fetchAll, IN_CHUNK } from "../pagination";
 import type { FantasySettings, Position } from "../types";
 
 /** Skip overlapping ticks when another run started within this window (seconds). */
@@ -30,6 +30,10 @@ export async function releaseWorkerRun(token: string): Promise<void> {
   if (error) throw error;
 }
 
+/**
+ * Batch-merge score/rank patches onto existing participants.
+ * Preflight existence so upsert never inserts (join owns creation + terms_accepted_at).
+ */
 export async function batchUpsertParticipants(
   rows: {
     wallet_address: string;
@@ -41,20 +45,34 @@ export async function batchUpsertParticipants(
 ): Promise<void> {
   if (rows.length === 0) return;
 
-  const termsAt = new Date().toISOString();
   for (let i = 0; i < rows.length; i += batchSize) {
-    const batch = rows.slice(i, i + batchSize).map((row) => {
-      const payload: Record<string, unknown> = {
-        wallet_address: row.wallet_address.trim().toLowerCase(),
-        // Required on upsert insert path (NOT NULL, no default). Active managers
-        // in the scoring pipeline have accepted terms by definition.
-        terms_accepted_at: termsAt,
-      };
-      if (row.total_points !== undefined) payload.total_points = row.total_points;
-      if (row.current_rank !== undefined) payload.current_rank = row.current_rank;
-      if (row.previous_rank !== undefined) payload.previous_rank = row.previous_rank;
-      return payload;
-    });
+    const chunk = rows.slice(i, i + batchSize);
+    const wallets = [...new Set(chunk.map((r) => r.wallet_address.trim().toLowerCase()))];
+
+    const existing = new Set<string>();
+    for (const walletChunk of chunkArray(wallets, IN_CHUNK)) {
+      const { data, error } = await supabaseAdmin
+        .from("fantasy_participants")
+        .select("wallet_address")
+        .in("wallet_address", walletChunk);
+      if (error) throw error;
+      for (const row of data ?? []) existing.add(row.wallet_address);
+    }
+
+    const batch = chunk
+      .filter((row) => existing.has(row.wallet_address.trim().toLowerCase()))
+      .map((row) => {
+        const payload: Record<string, unknown> = {
+          wallet_address: row.wallet_address.trim().toLowerCase(),
+        };
+        if (row.total_points !== undefined) payload.total_points = row.total_points;
+        if (row.current_rank !== undefined) payload.current_rank = row.current_rank;
+        if (row.previous_rank !== undefined) payload.previous_rank = row.previous_rank;
+        return payload;
+      });
+
+    if (batch.length === 0) continue;
+
     const { error } = await supabaseAdmin
       .from("fantasy_participants")
       .upsert(batch, { onConflict: "wallet_address", defaultToNull: false });

--- a/app/lib/fantasy/worker/scoring.ts
+++ b/app/lib/fantasy/worker/scoring.ts
@@ -30,24 +30,44 @@ export async function releaseWorkerRun(token: string): Promise<void> {
   if (error) throw error;
 }
 
+export type ParticipantPatch = {
+  wallet_address: string;
+  total_points?: number;
+  current_rank?: number;
+  previous_rank?: number | null;
+};
+
+/** One patch per normalized wallet; later rows override defined fields. */
+export function mergeParticipantPatches(rows: ParticipantPatch[]): ParticipantPatch[] {
+  const byWallet = new Map<string, ParticipantPatch>();
+  for (const row of rows) {
+    const wallet = row.wallet_address.trim().toLowerCase();
+    const merged: ParticipantPatch = { ...(byWallet.get(wallet) ?? { wallet_address: wallet }) };
+    merged.wallet_address = wallet;
+    if (row.total_points !== undefined) merged.total_points = row.total_points;
+    if (row.current_rank !== undefined) merged.current_rank = row.current_rank;
+    if (row.previous_rank !== undefined) merged.previous_rank = row.previous_rank;
+    byWallet.set(wallet, merged);
+  }
+  return [...byWallet.values()];
+}
+
 /**
  * Batch-merge score/rank patches onto existing participants.
  * Preflight existence so upsert never inserts (join owns creation + terms_accepted_at).
  */
 export async function batchUpsertParticipants(
-  rows: {
-    wallet_address: string;
-    total_points?: number;
-    current_rank?: number;
-    previous_rank?: number | null;
-  }[],
+  rows: ParticipantPatch[],
   batchSize = 500,
 ): Promise<void> {
   if (rows.length === 0) return;
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error("batchSize must be a positive integer");
+  }
 
   for (let i = 0; i < rows.length; i += batchSize) {
-    const chunk = rows.slice(i, i + batchSize);
-    const wallets = [...new Set(chunk.map((r) => r.wallet_address.trim().toLowerCase()))];
+    const chunk = mergeParticipantPatches(rows.slice(i, i + batchSize));
+    const wallets = chunk.map((r) => r.wallet_address);
 
     const existing = new Set<string>();
     for (const walletChunk of chunkArray(wallets, IN_CHUNK)) {
@@ -60,10 +80,10 @@ export async function batchUpsertParticipants(
     }
 
     const batch = chunk
-      .filter((row) => existing.has(row.wallet_address.trim().toLowerCase()))
+      .filter((row) => existing.has(row.wallet_address))
       .map((row) => {
         const payload: Record<string, unknown> = {
-          wallet_address: row.wallet_address.trim().toLowerCase(),
+          wallet_address: row.wallet_address,
         };
         if (row.total_points !== undefined) payload.total_points = row.total_points;
         if (row.current_rank !== undefined) payload.current_rank = row.current_rank;

--- a/app/lib/fantasy/worker/scoring.ts
+++ b/app/lib/fantasy/worker/scoring.ts
@@ -39,10 +39,25 @@ export async function batchUpsertParticipants(
   }[],
   batchSize = 500,
 ): Promise<void> {
+  if (rows.length === 0) return;
+
+  const termsAt = new Date().toISOString();
   for (let i = 0; i < rows.length; i += batchSize) {
+    const batch = rows.slice(i, i + batchSize).map((row) => {
+      const payload: Record<string, unknown> = {
+        wallet_address: row.wallet_address.trim().toLowerCase(),
+        // Required on upsert insert path (NOT NULL, no default). Active managers
+        // in the scoring pipeline have accepted terms by definition.
+        terms_accepted_at: termsAt,
+      };
+      if (row.total_points !== undefined) payload.total_points = row.total_points;
+      if (row.current_rank !== undefined) payload.current_rank = row.current_rank;
+      if (row.previous_rank !== undefined) payload.previous_rank = row.previous_rank;
+      return payload;
+    });
     const { error } = await supabaseAdmin
       .from("fantasy_participants")
-      .upsert(rows.slice(i, i + batchSize), { onConflict: "wallet_address" });
+      .upsert(batch, { onConflict: "wallet_address", defaultToNull: false });
     if (error) throw error;
   }
 }

--- a/app/lib/fantasy/worker/scoring.ts
+++ b/app/lib/fantasy/worker/scoring.ts
@@ -54,7 +54,8 @@ export function mergeParticipantPatches(rows: ParticipantPatch[]): ParticipantPa
 
 /**
  * Batch-merge score/rank patches onto existing participants.
- * Preflight existence so upsert never inserts (join owns creation + terms_accepted_at).
+ * Preflight resolves canonical wallet_address values, then UPDATE-only (join
+ * owns inserts + terms_accepted_at; upsert partial rows can still INSERT).
  */
 export async function batchUpsertParticipants(
   rows: ParticipantPatch[],
@@ -69,34 +70,38 @@ export async function batchUpsertParticipants(
     const chunk = mergeParticipantPatches(rows.slice(i, i + batchSize));
     const wallets = chunk.map((r) => r.wallet_address);
 
-    const existing = new Set<string>();
+    const canonical = new Map<string, string>();
     for (const walletChunk of chunkArray(wallets, IN_CHUNK)) {
       const { data, error } = await supabaseAdmin
         .from("fantasy_participants")
         .select("wallet_address")
         .in("wallet_address", walletChunk);
       if (error) throw error;
-      for (const row of data ?? []) existing.add(row.wallet_address);
+      for (const row of data ?? []) {
+        const key = row.wallet_address.trim().toLowerCase();
+        canonical.set(key, row.wallet_address);
+      }
     }
 
-    const batch = chunk
-      .filter((row) => existing.has(row.wallet_address))
-      .map((row) => {
-        const payload: Record<string, unknown> = {
-          wallet_address: row.wallet_address,
+    const patches = chunk.filter((row) => canonical.has(row.wallet_address));
+    if (patches.length === 0) continue;
+
+    await Promise.all(
+      patches.map(async (row) => {
+        const patch: Record<string, unknown> = {
+          updated_at: new Date().toISOString(),
         };
-        if (row.total_points !== undefined) payload.total_points = row.total_points;
-        if (row.current_rank !== undefined) payload.current_rank = row.current_rank;
-        if (row.previous_rank !== undefined) payload.previous_rank = row.previous_rank;
-        return payload;
-      });
+        if (row.total_points !== undefined) patch.total_points = row.total_points;
+        if (row.current_rank !== undefined) patch.current_rank = row.current_rank;
+        if (row.previous_rank !== undefined) patch.previous_rank = row.previous_rank;
 
-    if (batch.length === 0) continue;
-
-    const { error } = await supabaseAdmin
-      .from("fantasy_participants")
-      .upsert(batch, { onConflict: "wallet_address", defaultToNull: false });
-    if (error) throw error;
+        const { error } = await supabaseAdmin
+          .from("fantasy_participants")
+          .update(patch)
+          .eq("wallet_address", canonical.get(row.wallet_address)!);
+        if (error) throw error;
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
### Jira Issue

Jira Issue: <!-- e.g. https://paycrest-io.atlassian.net/browse/KAN-123 -->

### Description

This pull request improves error reporting and participant update logic in the fantasy worker system, and adds comprehensive tests for the new participant patch merging and upsert functionality. The main changes include introducing a utility for formatting errors, refactoring participant patch merging and batch updates to be more robust and efficient, and adding thorough unit tests for these changes.

**Error Handling Improvements**
- Added a `formatWorkerError` utility to provide more readable and informative error messages for worker alerts, replacing generic stringification of errors throughout the `runWorkerTick` function. [[1]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31R64-R79) [[2]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L135-R151) [[3]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L144-R160) [[4]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L170-R186) [[5]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L194-R210) [[6]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L247-R263) [[7]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L258-R274) [[8]](diffhunk://#diff-3f52be04c5cb515107b3ff95cbef6f21f3034c1569080dc0c3de9cab17adcc31L280-R296)

**Participant Patch Merging and Upsert Refactor**
- Introduced a new `ParticipantPatch` type and a `mergeParticipantPatches` function to normalize wallet addresses and merge multiple patches per wallet, ensuring later patches override earlier values.
- Refactored `batchUpsertParticipants` to use the new merging logic, resolve canonical wallet addresses before updating, and cap concurrent in-flight updates to 25 per batch for efficiency and safety. [[1]](diffhunk://#diff-07104e3ac9eb5f86258c1fdfe336e5dcf027f3aa891dc0268b40a815ff3fbc97L6-R14) [[2]](diffhunk://#diff-07104e3ac9eb5f86258c1fdfe336e5dcf027f3aa891dc0268b40a815ff3fbc97L33-R111)

**Testing Enhancements**
- Added a new test suite (`fantasy-participant-patches.test.ts`) with comprehensive unit tests for both `mergeParticipantPatches` and `batchUpsertParticipants`, covering normalization, merging, error handling, and concurrency limits.


### This fixes the leaderboard no refresh for noblocks play.


### Self-review

- [ ] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green


### References




### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).