### PR TITLE
Implement auto-substitution logic 

### DIFF
--- a/__tests__/fantasy-scoring.test.ts
+++ b/__tests__/fantasy-scoring.test.ts
@@ -9,6 +9,7 @@ import {
   computeSquadPoints,
   emptyStats,
   hasPlayed,
+  subStateFor,
 } from "@/app/lib/fantasy/scoring";
 import type { FantasySettings, PlayerMatchStats, Position } from "@/app/lib/fantasy/types";
 
@@ -153,6 +154,93 @@ describe("C/VC with auto-subs", () => {
       .reduce((s, p) => s + p.points, 0);
     // After autosub still no double if C/VC blank
     expect(points).toBeLessThanOrEqual(baseWithoutDouble);
+  });
+});
+
+describe("bench never scores unless auto-subbed in", () => {
+  /** 1-4-4-2 in slots 1–11, bench GK/DEF/MID/FWD in 12–15. */
+  const buildSquad = () => [
+    { playerId: 1, slot: 1, isCaptain: false, isVice: false, position: "GK" as const },
+    { playerId: 2, slot: 2, isCaptain: false, isVice: false, position: "DEF" as const },
+    { playerId: 3, slot: 3, isCaptain: false, isVice: false, position: "DEF" as const },
+    { playerId: 4, slot: 4, isCaptain: false, isVice: false, position: "DEF" as const },
+    { playerId: 5, slot: 5, isCaptain: false, isVice: false, position: "DEF" as const },
+    { playerId: 6, slot: 6, isCaptain: false, isVice: false, position: "MID" as const },
+    { playerId: 7, slot: 7, isCaptain: false, isVice: false, position: "MID" as const },
+    { playerId: 8, slot: 8, isCaptain: false, isVice: false, position: "MID" as const },
+    { playerId: 9, slot: 9, isCaptain: false, isVice: false, position: "MID" as const },
+    { playerId: 10, slot: 10, isCaptain: true, isVice: false, position: "FWD" as const },
+    { playerId: 11, slot: 11, isCaptain: false, isVice: true, position: "FWD" as const },
+    { playerId: 12, slot: 12, isCaptain: false, isVice: false, position: "GK" as const },
+    { playerId: 13, slot: 13, isCaptain: false, isVice: false, position: "DEF" as const },
+    { playerId: 14, slot: 14, isCaptain: false, isVice: false, position: "MID" as const },
+    { playerId: 15, slot: 15, isCaptain: false, isVice: false, position: "FWD" as const },
+  ];
+
+  /** Everyone plays; bench carries fat scores that must not leak into the total. */
+  const played = (points: number) => ({ points, minutes: 90, yellowCards: 0, redCards: 0 });
+  const blanked = { points: 0, minutes: 0, yellowCards: 0, redCards: 0 };
+
+  it("ignores points-scoring bench players when no starter blanks", () => {
+    const squad = buildSquad();
+    const playerPoints = new Map(
+      squad.map((p) => [p.playerId, played(p.slot <= 11 ? 2 : 9)]),
+    );
+    const { points, scoringXi } = computeSquadPoints(
+      { squad, playerPoints, transferPointsDeduction: 0 },
+      applyAutoSubs,
+    );
+    expect(scoringXi).toHaveLength(11);
+    expect(scoringXi.every((p) => p.slot <= 11)).toBe(true);
+    // 11 starters × 2 + captain double. The 36 bench points contribute nothing.
+    expect(points).toBe(11 * 2 + 2);
+  });
+
+  it("counts a bench player only once auto-subbed in for a blank", () => {
+    const squad = buildSquad();
+    const playerPoints = new Map(
+      squad.map((p) => [
+        p.playerId,
+        p.playerId === 9 ? blanked : played(p.slot <= 11 ? 2 : 9),
+      ]),
+    );
+    const { points, scoringXi } = computeSquadPoints(
+      { squad, playerPoints, transferPointsDeduction: 0 },
+      applyAutoSubs,
+    );
+    expect(scoringXi).toHaveLength(11);
+    // Subs are not like-for-like: the highest-priority outfield bench player
+    // who played takes the slot, so DEF 13 (not MID 14) covers the blanked
+    // MID — 5 DEF / 3 MID / 2 FWD still clears the floors.
+    expect(scoringXi.map((p) => p.playerId)).toContain(13);
+    expect(scoringXi.map((p) => p.playerId)).not.toContain(9);
+    expect(scoringXi.map((p) => p.playerId)).not.toContain(14);
+    // 10 surviving starters × 2 + sub 9 + captain double.
+    expect(points).toBe(10 * 2 + 9 + 2);
+  });
+
+  it("subtracts the transfer hit from the XI total, not from the bench", () => {
+    const squad = buildSquad();
+    const playerPoints = new Map(
+      squad.map((p) => [p.playerId, played(p.slot <= 11 ? 2 : 9)]),
+    );
+    const { points } = computeSquadPoints(
+      { squad, playerPoints, transferPointsDeduction: 4 },
+      applyAutoSubs,
+    );
+    expect(points).toBe(11 * 2 + 2 - 4);
+  });
+});
+
+describe("subStateFor", () => {
+  it("badges a promoted bench player and an excluded starter", () => {
+    expect(subStateFor(14, true)).toBe("in");
+    expect(subStateFor(9, false)).toBe("out");
+  });
+
+  it("stays silent for counted starters and unused bench players", () => {
+    expect(subStateFor(9, true)).toBeNull();
+    expect(subStateFor(14, false)).toBeNull();
   });
 });
 

--- a/app/api/play/squad/route.ts
+++ b/app/api/play/squad/route.ts
@@ -5,7 +5,9 @@ import { trackBusinessEvent } from "@/app/lib/server-analytics";
 import { getFantasySettings } from "@/app/lib/fantasy/settings";
 import { getPlayersMap } from "@/app/lib/fantasy/players";
 import { validateSquad } from "@/app/lib/fantasy/validation";
-import type { SquadSelection } from "@/app/lib/fantasy/types";
+import { applyAutoSubs } from "@/app/lib/fantasy/autosubs";
+import { hasPlayed, subStateFor, type SquadPlayerRow } from "@/app/lib/fantasy/scoring";
+import type { Position, SquadSelection } from "@/app/lib/fantasy/types";
 import { hasActiveFixtures } from "@/app/lib/fantasy/fixture-activity";
 import {
   fantasyDisabledResponse,
@@ -68,6 +70,28 @@ export const GET = withRateLimitAndAnalytics(async (request: NextRequest) => {
 
     const players = await getPlayersMap();
 
+    // Same auto-sub pass the scorer runs, so the pitch can badge promotions
+    // in place and the round total reconciles against the cards on screen.
+    // Before kickoff nobody has played, so this resolves to no subs at all.
+    const live = (id: number) =>
+      playerPoints.get(id) ?? { points: 0, minutes: 0, yellowCards: 0, redCards: 0 };
+    const scoringIds = new Set(
+      squad
+        ? applyAutoSubs(
+            squad.players.map(
+              (entry): SquadPlayerRow => ({
+                playerId: entry.player_id,
+                slot: entry.slot,
+                isCaptain: entry.is_captain,
+                isVice: entry.is_vice,
+                position: players.get(entry.player_id)?.position ?? ("MID" as Position),
+              }),
+            ),
+            (id) => hasPlayed(live(id)),
+          ).map((p) => p.playerId)
+        : [],
+    );
+
     return jsonOk({
       matchday,
       locked: isMatchdayLocked(matchday),
@@ -88,12 +112,8 @@ export const GET = withRateLimitAndAnalytics(async (request: NextRequest) => {
                     }
                   : undefined,
                 lock_state: "unlocked" as const,
-                live: playerPoints.get(entry.player_id) ?? {
-                  points: 0,
-                  minutes: 0,
-                  yellowCards: 0,
-                  redCards: 0,
-                },
+                live: live(entry.player_id),
+                sub_state: subStateFor(entry.slot, scoringIds.has(entry.player_id)),
               };
             }),
           }

--- a/app/components/play/BenchRow.tsx
+++ b/app/components/play/BenchRow.tsx
@@ -1,24 +1,32 @@
 "use client";
 
 /**
- * Bench row (slots 12–15). Displayed below the pitch — bench players are
- * shown but NEVER auto-substitute (adapted rule, stated on /play/terms).
+ * Bench row (slots 12–15). Bench players keep their picked slot even after
+ * an auto-sub promotes them into the scoring XI — the swap is badged on the
+ * card (see SlotView.subState) rather than moving the card onto the pitch.
  */
 
+import type { ReactNode } from "react";
 import { PlayerSlotCard, type SlotView } from "./PitchView";
 
 export const BenchRow = ({
   slots,
   showPrice,
   onSlotClick,
+  note,
 }: {
   slots: SlotView[];
   showPrice: boolean;
   onSlotClick: (slot: SlotView) => void;
+  /** Round-specific caption; defaults to how the bench will be used. */
+  note?: ReactNode;
 }) => (
   <div className="rounded-2xl bg-background-neutral p-3 dark:bg-white/5 sm:p-4">
     <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary dark:text-white/40">
-      Bench <span className="font-normal normal-case">— no auto-subs</span>
+      Bench{" "}
+      <span className="font-normal normal-case">
+        — {note ?? "auto-subs promote in slot order"}
+      </span>
     </p>
     <div className="flex flex-wrap items-start justify-center gap-2 sm:justify-start sm:gap-4">
       {slots.map((slot) => (

--- a/app/components/play/ManagerTeamView.tsx
+++ b/app/components/play/ManagerTeamView.tsx
@@ -4,6 +4,10 @@
  * Read-only view of another manager's team (/play/manager/[username]):
  * the latest locked round's XI + bench with effective points (captain
  * double included). Reuses the same pitch the owner sees on /play/team.
+ *
+ * Players stay in the slot they were picked in. Auto-subs are badged in
+ * place (SUB ON / SUB OFF), so a promoted bench player still renders on the
+ * bench while carrying the points that count towards the round total.
  */
 
 import Link from "next/link";
@@ -37,6 +41,7 @@ const toSlotView = (p: PublicTeamPlayer): SlotView => ({
   isCaptain: p.is_captain,
   isVice: p.is_vice,
   livePoints: p.points,
+  subState: p.sub_state,
 });
 
 export const ManagerTeamView = ({
@@ -59,6 +64,19 @@ export const ManagerTeamView = ({
     if (p.slot <= 11) rows[p.position].push(toSlotView(p));
     else bench.push(toSlotView(p));
   }
+
+  // Reconciles the header: the round total is the badged-on bench players
+  // plus the starters who were not badged off, never the raw pitch row.
+  const subsOn = (team?.players ?? []).filter((p) => p.sub_state === "in").length;
+  // Auto-subs only settle when the round does: a starter whose fixture has
+  // not kicked off yet reads as a blank mid-round, so say "so far" until final.
+  const provisional = team != null && team.matchday.status !== "final";
+  const benchNote =
+    subsOn > 0
+      ? `${subsOn} auto-sub${subsOn === 1 ? "" : "s"} counted below${provisional ? " so far" : ""}`
+      : team?.matchday.status === "final"
+        ? "no auto-subs this round"
+        : undefined;
 
   return (
     <div className="space-y-4 max-lg:pb-10">
@@ -88,7 +106,12 @@ export const ManagerTeamView = ({
           </div>
           <PitchView rows={rows} showPrice={false} onSlotClick={() => {}} />
           {bench.length > 0 && (
-            <BenchRow slots={bench} showPrice={false} onSlotClick={() => {}} />
+            <BenchRow
+              slots={bench}
+              showPrice={false}
+              onSlotClick={() => {}}
+              note={benchNote}
+            />
           )}
         </>
       ) : (

--- a/app/components/play/ManagerTeamView.tsx
+++ b/app/components/play/ManagerTeamView.tsx
@@ -103,6 +103,13 @@ export const ManagerTeamView = ({
           <div className="flex flex-wrap items-center gap-2">
             <Chip>{team.matchday.display_name}</Chip>
             <Chip>{team.points} pts this round</Chip>
+            {/* The hit is already inside team.points, so the cards on the
+                pitch sum to team.points + this. Shown so that still adds up. */}
+            {team.transfer_points_deduction > 0 && (
+              <Chip tone="red">
+                −{team.transfer_points_deduction} pts transfers
+              </Chip>
+            )}
           </div>
           <PitchView rows={rows} showPrice={false} onSlotClick={() => {}} />
           {bench.length > 0 && (

--- a/app/components/play/PitchView.tsx
+++ b/app/components/play/PitchView.tsx
@@ -29,6 +29,12 @@ export interface SlotView {
   markedOut?: boolean;
   /** Just transferred in (pending). */
   markedIn?: boolean;
+  /**
+   * Auto-sub outcome for a scored round: "in" = came off the bench and
+   * counted, "out" = started but was replaced, so the 0 shown is exclusion
+   * rather than a blank. Cards stay in their picked slot either way.
+   */
+  subState?: "in" | "out" | null;
   /** Highlighted as an eligible swap target. */
   highlighted?: boolean;
   dimmed?: boolean;
@@ -140,7 +146,7 @@ export const PlayerSlotCard = ({
       type="button"
       onClick={onClick}
       className={`relative flex w-16 flex-col items-center gap-1 transition-opacity sm:w-20 ${
-        slot.dimmed ? "opacity-40" : ""
+        slot.dimmed || slot.subState === "out" ? "opacity-40" : ""
       } ${slot.highlighted ? "scale-105" : ""}`}
     >
       <span
@@ -151,7 +157,11 @@ export const PlayerSlotCard = ({
               ? "ring-2 ring-accent-red rounded-lg"
               : slot.markedIn
                 ? "ring-2 ring-emerald-400 rounded-lg"
-                : ""
+                : slot.subState === "in"
+                  ? "ring-2 ring-emerald-400 rounded-lg"
+                  : slot.subState === "out"
+                    ? "ring-2 ring-white/40 rounded-lg"
+                    : ""
         }`}
       >
         <PlayerPhoto
@@ -214,6 +224,27 @@ export const PlayerSlotCard = ({
         {slot.markedIn && (
           <span className="absolute -bottom-1 rounded bg-emerald-500 px-1 text-[9px] font-bold text-white">
             IN
+          </span>
+        )}
+        {/* Auto-sub badges never coexist with the transfer pills: those are
+            pending-edit state on an open round, these only exist once a round
+            has been scored. */}
+        {slot.subState === "in" && !slot.markedIn && (
+          <span
+            className="absolute -bottom-1 rounded bg-emerald-500 px-1 text-[9px] font-bold text-white"
+            aria-label="Auto-substituted on"
+            title="Auto-substituted on — these points count"
+          >
+            SUB ON
+          </span>
+        )}
+        {slot.subState === "out" && !slot.markedOut && (
+          <span
+            className="absolute -bottom-1 rounded bg-black/70 px-1 text-[9px] font-bold text-white"
+            aria-label="Auto-substituted off"
+            title="Auto-substituted off — replaced by a bench player, scores nothing"
+          >
+            SUB OFF
           </span>
         )}
       </span>

--- a/app/components/play/TeamManager.tsx
+++ b/app/components/play/TeamManager.tsx
@@ -151,6 +151,28 @@ export const TeamManager = ({
     },
     [squad, doubledId],
   );
+  // Server-side auto-sub outcome. Only meaningful once the round is locked;
+  // while editing, the pitch shows the squad as picked and nothing is badged.
+  const subStateOf = useCallback(
+    (id: number) =>
+      locked
+        ? (squad?.players.find((p) => p.player_id === id)?.sub_state ?? null)
+        : null,
+    [squad, locked],
+  );
+  const subsOn = useMemo(
+    () => (squad?.players ?? []).filter((p) => p.sub_state === "in").length,
+    [squad],
+  );
+  // Auto-subs only settle when the round does: a starter whose fixture has
+  // not kicked off yet reads as a blank mid-round, so say "so far" until final.
+  const benchNote = !locked
+    ? undefined
+    : subsOn > 0
+      ? `${subsOn} auto-sub${subsOn === 1 ? "" : "s"} counted${matchday.status === "final" ? "" : " so far"}`
+      : matchday.status === "final"
+        ? "no auto-subs this round"
+        : undefined;
 
   /* --------------------------- editor state --------------------------- */
 
@@ -631,6 +653,7 @@ export const TeamManager = ({
       isVice: view.viceId === id,
       lockState: locked ? lockStateOf(id) : undefined,
       livePoints: livePointsOf(id),
+      subState: subStateOf(id),
       markedIn: pendingIn.has(id),
       eliminated: player ? !player.is_active : false,
       highlighted: swapTargets?.has(id) ?? false,
@@ -863,6 +886,7 @@ export const TeamManager = ({
           slots={benchSlots}
           showPrice={showPrice}
           onSlotClick={handleSlotClick}
+          note={benchNote}
         />
       )}
 

--- a/app/components/play/types.ts
+++ b/app/components/play/types.ts
@@ -12,6 +12,7 @@ import type {
   PublicManagerTeam,
   PublicTeamPlayer,
   ScoringMatrix,
+  SubState,
 } from "@/app/lib/fantasy/types";
 
 export type {
@@ -22,6 +23,7 @@ export type {
   PublicManagerTeam,
   PublicTeamPlayer,
   ScoringMatrix,
+  SubState,
 };
 
 export interface PlayMatchday {
@@ -65,6 +67,8 @@ export interface SquadPlayerEntry {
   player?: FantasyPlayer;
   lock_state: LockState;
   live: { points: number; minutes: number };
+  /** Auto-sub outcome for the round — see PublicTeamPlayer.sub_state. */
+  sub_state: SubState;
 }
 
 export interface SquadData {

--- a/app/lib/fantasy/scoring.ts
+++ b/app/lib/fantasy/scoring.ts
@@ -4,6 +4,7 @@ import type {
   PointsBreakdownEntry,
   Position,
   ScoringMatrix,
+  SubState,
 } from "./types";
 
 /**
@@ -88,6 +89,17 @@ export function computePoints(
 
   const points = breakdown.reduce((sum, e) => sum + e.points, 0);
   return { points, breakdown };
+}
+
+/**
+ * Badge state for a picked slot, given whether the player ended up in the
+ * post-auto-sub XI. Players keep the slot they were picked in, so this is
+ * what tells a UI that a bench card is scoring ("in") or that a starter's 0
+ * is exclusion rather than a blank ("out").
+ */
+export function subStateFor(slot: number, inScoringXi: boolean): SubState {
+  if (inScoringXi) return slot > 11 ? "in" : null;
+  return slot <= 11 ? "out" : null;
 }
 
 /** Appearance or yellow/red ⇒ played (FPL auto-sub definition). */

--- a/app/lib/fantasy/server.ts
+++ b/app/lib/fantasy/server.ts
@@ -8,7 +8,7 @@ import { getPlayersMap } from "./players";
 import { fetchAll } from "./pagination";
 import { LIVE_STATUSES, FINISHED_STATUSES } from "./provider";
 import { applyAutoSubs } from "./autosubs";
-import { hasPlayed, type SquadPlayerRow } from "./scoring";
+import { hasPlayed, subStateFor, type SquadPlayerRow } from "./scoring";
 import type {
   FantasySettings,
   MatchdayStatus,
@@ -313,6 +313,9 @@ export async function getPublicManagerTeam(
             const player = players.get(entry.player_id);
             const stats = live(entry.player_id);
             const earnsPoints = scoringIds.has(entry.player_id);
+            // Slot stays as picked; membership of the post-auto-sub XI is
+            // reported separately so the pitch can badge the swap in place.
+            const subState = subStateFor(entry.slot, earnsPoints);
             return {
               ...entry,
               name: player?.name ?? "Unknown",
@@ -328,6 +331,7 @@ export async function getPublicManagerTeam(
                 ? stats.points * (entry.player_id === doubledId ? 2 : 1)
                 : 0,
               minutes: stats.minutes,
+              sub_state: subState,
             };
           }),
       };

--- a/app/lib/fantasy/server.ts
+++ b/app/lib/fantasy/server.ts
@@ -246,7 +246,7 @@ export async function getPublicManagerTeam(
     const { data: squadRow, error: squadError } = await supabaseAdmin
       .from("fantasy_squads")
       .select(
-        "matchday_id, players:fantasy_squad_players(player_id, slot, is_captain, is_vice)",
+        "matchday_id, transfer_points_deduction, players:fantasy_squad_players(player_id, slot, is_captain, is_vice)",
       )
       .eq("wallet_address", row.wallet_address)
       .gte("matchday_id", seasonMin)
@@ -307,6 +307,7 @@ export async function getPublicManagerTeam(
           status: matchday.status,
         },
         points: Number(score?.points ?? 0),
+        transfer_points_deduction: Number(squadRow.transfer_points_deduction ?? 0),
         players: entries
           .sort((a, b) => a.slot - b.slot)
           .map((entry) => {

--- a/app/lib/fantasy/types.ts
+++ b/app/lib/fantasy/types.ts
@@ -141,7 +141,10 @@ export interface PublicManagerTeam {
   badge: string;
   team: {
     matchday: { id: number; display_name: string; status: MatchdayStatus };
+    /** Round score as stored: the scoring XI minus `transfer_points_deduction`. */
     points: number;
+    /** Paid-transfer hit already subtracted from `points`. */
+    transfer_points_deduction: number;
     players: PublicTeamPlayer[];
   } | null;
 }

--- a/app/lib/fantasy/types.ts
+++ b/app/lib/fantasy/types.ts
@@ -105,6 +105,13 @@ export interface SquadSelection {
   viceId: number;
 }
 
+/**
+ * Auto-sub outcome for a picked slot. "in" = promoted off the bench and
+ * scoring, "out" = picked to start but replaced, so the 0 shown is exclusion
+ * rather than a blank. null = counted as picked, or an unused bench player.
+ */
+export type SubState = "in" | "out" | null;
+
 export interface PublicTeamPlayer {
   player_id: number;
   slot: number;
@@ -117,6 +124,12 @@ export interface PublicTeamPlayer {
   photo_url: string | null;
   points: number;
   minutes: number;
+  /**
+   * Auto-sub outcome for this round. Players keep their picked slot either
+   * way; this is what lets the UI badge the swap in place instead of
+   * relocating the card.
+   */
+  sub_state: SubState;
 }
 
 export interface PublicManagerTeam {


### PR DESCRIPTION

### Jira Issue

Jira Issue:  https://paycrest-io.atlassian.net/browse/KAN-777

### Description

- Added `subStateFor` function to determine the auto-substitution state of players.
- Updated scoring logic to badge players who are auto-substituted on or off without moving their cards.
- Enhanced `BenchRow` and `ManagerTeamView` components to reflect the new auto-sub state, providing clearer feedback on player status.
- Updated types to include `sub_state` for better tracking of player substitutions during a matchday.
- Improved unit tests to cover new functionality and ensure accurate scoring calculations.

This pull request introduces visible auto-substitution badges and logic to the fantasy football squad UI, ensuring that bench and starter cards are badged to reflect auto-sub outcomes without moving cards between pitch and bench. It also updates the backend and API to provide this information, and enhances test coverage for auto-sub scenarios.

**Auto-substitution UI and logic:**

* Cards in both pitch and bench rows now display "SUB ON" or "SUB OFF" badges to indicate auto-sub outcomes, using the new `subState` property in `SlotView`. Cards remain in their original slots, and visual cues (badges, opacity) communicate their scoring status. [[1]](diffhunk://#diff-c95560ead0ca8cdeab4c64a0e33132f43a2234258706678f3fecc4f5510863fbR32-R37) F104403cL151R151, [[2]](diffhunk://#diff-c95560ead0ca8cdeab4c64a0e33132f43a2234258706678f3fecc4f5510863fbR160-R163) [[3]](diffhunk://#diff-c95560ead0ca8cdeab4c64a0e33132f43a2234258706678f3fecc4f5510863fbR229-R249) [[4]](diffhunk://#diff-64f54ec173d541f7cf1767ad5068586f8f9862ffe7d3f745d8b90d47c6f56596L4-R29) [[5]](diffhunk://#diff-ee990abc70f150ea19d5d195d0a24c77847eef14b7dce094aaa0842376e62dbdR7-R10)

**Backend and API support:**

* The backend (`getPublicManagerTeam`, squad API route) now computes and returns each player's auto-sub state using the new `subStateFor` function, exposing this as `sub_state` in the API and types. [[1]](diffhunk://#diff-9739c7685e379619c814566738fe6a34097eb55ec8f849143b7fc47d8a040538R94-R104) [[2]](diffhunk://#diff-9739c7685e379619c814566738fe6a34097eb55ec8f849143b7fc47d8a040538R7) [[3]](diffhunk://#diff-06d5e040f3d01ce8327036f88740a0c4d9fd24c63362736ae561a179a003a616L11-R11) [[4]](diffhunk://#diff-06d5e040f3d01ce8327036f88740a0c4d9fd24c63362736ae561a179a003a616R316-R318) [[5]](diffhunk://#diff-06d5e040f3d01ce8327036f88740a0c4d9fd24c63362736ae561a179a003a616R334) [[6]](diffhunk://#diff-4436617917b37662542b3877ae6d9eb782ac4ca0dae7380c5b0bd424ee1d5fb3L8-R10) [[7]](diffhunk://#diff-4436617917b37662542b3877ae6d9eb782ac4ca0dae7380c5b0bd424ee1d5fb3R73-R94) [[8]](diffhunk://#diff-4436617917b37662542b3877ae6d9eb782ac4ca0dae7380c5b0bd424ee1d5fb3L91-R116) [[9]](diffhunk://#diff-1037293e86ff879e97bff0f9860014abf5439a5f898a64edc9eb363c4e99c43fR15) [[10]](diffhunk://#diff-1037293e86ff879e97bff0f9860014abf5439a5f898a64edc9eb363c4e99c43fR26) [[11]](diffhunk://#diff-1037293e86ff879e97bff0f9860014abf5439a5f898a64edc9eb363c4e99c43fR70-R71)

**Bench row and team views:**

* The bench row now displays a dynamic note summarizing auto-sub usage for the round, and both the manager and viewer team pages reconcile the round total based on badged bench players, not just pitch slots. [[1]](diffhunk://#diff-64f54ec173d541f7cf1767ad5068586f8f9862ffe7d3f745d8b90d47c6f56596L4-R29) [[2]](diffhunk://#diff-ee990abc70f150ea19d5d195d0a24c77847eef14b7dce094aaa0842376e62dbdR44) [[3]](diffhunk://#diff-ee990abc70f150ea19d5d195d0a24c77847eef14b7dce094aaa0842376e62dbdR68-R80) [[4]](diffhunk://#diff-ee990abc70f150ea19d5d195d0a24c77847eef14b7dce094aaa0842376e62dbdL91-R114) [[5]](diffhunk://#diff-ecdb30af7b855657031e60012d62eae29b63040dab152ef7311e53f9a9c576e9R154-R175) [[6]](diffhunk://#diff-ecdb30af7b855657031e60012d62eae29b63040dab152ef7311e53f9a9c576e9R656) [[7]](diffhunk://#diff-ecdb30af7b855657031e60012d62eae29b63040dab152ef7311e53f9a9c576e9R889)

**Testing improvements:**

* Adds comprehensive tests for bench behavior and auto-sub logic, including cases where bench points must not leak unless a player is auto-subbed, and for the new `subStateFor` function. [[1]](diffhunk://#diff-620aeb99a3882da28afae1bf8ce55c2865134fb5233163c05972e8a0768e4a70R160-R246) [[2]](diffhunk://#diff-620aeb99a3882da28afae1bf8ce55c2865134fb5233163c05972e8a0768e4a70R12)

Overall, these changes ensure auto-substitution outcomes are clearly communicated to users, both visually and in the underlying data, without altering the picked squad layout.



### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [x] CodeRabbit / CI green


### References



### Testing

<img width="1067" height="1426" alt="image" src="https://github.com/user-attachments/assets/83848756-cc21-4c33-a628-027d228d89a0" />


- [ ] This change adds test coverage for new/changed/fixed functionality


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic-substitution handling to live fantasy scoring.
  * Bench players now contribute points only when promoted into the scoring XI.
  * Added “SUB ON” and “SUB OFF” indicators while preserving original player slots.
  * Displayed counted auto-substitutions with final or in-progress round status.
  * Applied transfer deductions correctly to starting-XI totals.
  * Added visible transfer deduction amounts alongside round points.

* **Bug Fixes**
  * Prevented duplicate scoring for auto-substituted players.
  * Improved substitution state and live-stat accuracy across team views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->