### PR TITLE
KAN-784: Quote offramp token amount at token precision

### DIFF
--- a/__tests__/quoteTokenAmountForFiat.test.ts
+++ b/__tests__/quoteTokenAmountForFiat.test.ts
@@ -1,0 +1,78 @@
+import {
+  MAX_QUOTE_DECIMALS,
+  getQuoteDecimals,
+  quoteTokenAmountForFiat,
+} from "../app/utils";
+
+/** What the aggregator pays out: token amount x rate, rounded to the fiat's decimals. */
+const payout = (tokenAmount: number, rate: number) =>
+  Math.round(tokenAmount * rate * 100) / 100;
+
+describe("quoteTokenAmountForFiat", () => {
+  it("pays the full quote for the KAN-784 order that came up short", () => {
+    // 50000 / 1370.79 = 36.47531714..., which 4dp rounding cut to 36.4753 and
+    // the aggregator paid out as NGN 49,999.98.
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 6);
+
+    expect(amount).toBe(36.475318);
+    expect(payout(amount, 1370.79)).toBe(50000);
+    expect(payout(36.4753, 1370.79)).toBe(49999.98); // the old behaviour
+  });
+
+  it("never quotes below the fiat the recipient was promised", () => {
+    const rate = 1370.79;
+    for (let fiat = 1000; fiat <= 200000; fiat += 137) {
+      const amount = quoteTokenAmountForFiat(fiat, rate, 6);
+      expect(amount * rate).toBeGreaterThanOrEqual(fiat);
+      expect(payout(amount, rate)).toBeGreaterThanOrEqual(fiat);
+    }
+  });
+
+  it("overpays by at most one subunit", () => {
+    const rate = 1370.79;
+    for (let fiat = 1000; fiat <= 200000; fiat += 137) {
+      const amount = quoteTokenAmountForFiat(fiat, rate, 6);
+      expect(amount - fiat / rate).toBeLessThanOrEqual(1e-6);
+    }
+  });
+
+  it("does not charge an extra subunit for an exact division", () => {
+    expect(quoteTokenAmountForFiat(1400, 1400, 6)).toBe(1);
+    expect(quoteTokenAmountForFiat(4112.37, 1370.79, 6)).toBe(3);
+    expect(quoteTokenAmountForFiat(68539.5, 1370.79, 6)).toBe(50);
+  });
+
+  it("caps precision so 18-decimal tokens keep a readable amount", () => {
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 18);
+
+    expect(amount).toBe(36.475318);
+    expect(payout(amount, 1370.79)).toBe(50000);
+  });
+
+  it("honours a token coarser than the cap", () => {
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 2);
+
+    expect(amount).toBe(36.48);
+    expect(payout(amount, 1370.79)).toBeGreaterThanOrEqual(50000);
+  });
+
+  it("returns 0 rather than NaN for unusable input", () => {
+    expect(quoteTokenAmountForFiat(50000, 0, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(50000, -1, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(NaN, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(50000, NaN, 6)).toBe(0);
+  });
+});
+
+describe("getQuoteDecimals", () => {
+  it("caps at the quote maximum", () => {
+    expect(getQuoteDecimals(18)).toBe(MAX_QUOTE_DECIMALS);
+    expect(getQuoteDecimals(6)).toBe(6);
+    expect(getQuoteDecimals(2)).toBe(2);
+  });
+
+  it("falls back to the cap when the token is unknown", () => {
+    expect(getQuoteDecimals(undefined)).toBe(MAX_QUOTE_DECIMALS);
+    expect(getQuoteDecimals(0)).toBe(MAX_QUOTE_DECIMALS);
+  });
+});

--- a/__tests__/quoteTokenAmountForFiat.test.ts
+++ b/__tests__/quoteTokenAmountForFiat.test.ts
@@ -1,5 +1,6 @@
 import {
   MAX_QUOTE_DECIMALS,
+  ONRAMP_FIAT_DECIMALS,
   getQuoteDecimals,
   quoteTokenAmountForFiat,
 } from "../app/utils";
@@ -61,6 +62,33 @@ describe("quoteTokenAmountForFiat", () => {
     expect(quoteTokenAmountForFiat(50000, -1, 6)).toBe(0);
     expect(quoteTokenAmountForFiat(NaN, 1370.79, 6)).toBe(0);
     expect(quoteTokenAmountForFiat(50000, NaN, 6)).toBe(0);
+  });
+
+  it("returns 0 for a nonpositive fiat target rather than a negative amount", () => {
+    // Rounding up through zero would also round the wrong way: Math.ceil(-729.5)
+    // is -729, shrinking the magnitude instead of growing it.
+    expect(quoteTokenAmountForFiat(-1, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(-50000, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(0, 1370.79, 6)).toBe(0);
+  });
+});
+
+describe("onramp Send precision", () => {
+  // `amountSent` is fiat on onramp, so it must not follow the token's decimals:
+  // the form picks ONRAMP_FIAT_DECIMALS over quoteDecimals when isSwapped.
+  const amountSentDecimals = (isSwapped: boolean, tokenDecimals: number) =>
+    isSwapped ? ONRAMP_FIAT_DECIMALS : getQuoteDecimals(tokenDecimals);
+
+  it("keeps four places on onramp whatever the token's precision", () => {
+    expect(amountSentDecimals(true, 6)).toBe(4);
+    expect(amountSentDecimals(true, 18)).toBe(4);
+    expect(amountSentDecimals(true, 2)).toBe(4);
+  });
+
+  it("follows the token only on offramp", () => {
+    expect(amountSentDecimals(false, 6)).toBe(6);
+    expect(amountSentDecimals(false, 18)).toBe(MAX_QUOTE_DECIMALS);
+    expect(amountSentDecimals(false, 2)).toBe(2);
   });
 });
 

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -45,6 +45,7 @@ import {
   formatRateForDisplay,
   getQuoteDecimals,
   quoteTokenAmountForFiat,
+  ONRAMP_FIAT_DECIMALS,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -423,6 +424,11 @@ export const TransactionForm = ({
     fetchedTokens.find((t) => t.symbol.toUpperCase() === token?.toUpperCase())
       ?.decimals,
   );
+
+  // `amountSent` is the token leg on offramp but the fiat leg on onramp, where
+  // the token's precision means nothing. Only the token leg follows the token;
+  // onramp fiat keeps the four places it has always allowed.
+  const amountSentDecimals = isSwapped ? ONRAMP_FIAT_DECIMALS : quoteDecimals;
 
   const { handleFundWallet } = useFundWalletHandler("Transaction form");
 
@@ -875,8 +881,8 @@ export const TransactionForm = ({
               const decimals = value.toString().split(".")[1];
               return (
                 !decimals ||
-                decimals.length <= quoteDecimals ||
-                `Maximum ${quoteDecimals} decimal places allowed`
+                decimals.length <= amountSentDecimals ||
+                `Maximum ${amountSentDecimals} decimal places allowed`
               );
             },
             onrampFiatMin: (value: number) => {
@@ -1366,7 +1372,7 @@ export const TransactionForm = ({
     // Only limit decimal places, allow any whole number
     if (cleanedValue.includes(".")) {
       const decimals: string | undefined = cleanedValue.split(".")[1];
-      if (decimals?.length > quoteDecimals) return;
+      if (decimals?.length > amountSentDecimals) return;
     } // Update the form value
     setValue("amountSent", value, {
       shouldValidate: true,

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -43,6 +43,8 @@ import {
   swapModeFromSideParam,
   RATE_DECIMALS,
   formatRateForDisplay,
+  getQuoteDecimals,
+  quoteTokenAmountForFiat,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -414,6 +416,14 @@ export const TransactionForm = ({
 
   const fetchedTokens: Token[] = allTokens[selectedNetwork.chain.name] || [];
 
+  // Precision the token leg is quoted and validated at. Derived from the
+  // selected token so the amount that goes on-chain is not rounded below what
+  // the recipient was quoted — see quoteTokenAmountForFiat.
+  const quoteDecimals = getQuoteDecimals(
+    fetchedTokens.find((t) => t.symbol.toUpperCase() === token?.toUpperCase())
+      ?.decimals,
+  );
+
   const { handleFundWallet } = useFundWalletHandler("Transaction form");
 
   const handleFundWalletClick = async (
@@ -731,8 +741,14 @@ export const TransactionForm = ({
           } else {
             // Not swapped: Receive = Currency, so calculate Send (Token)
             // Send = Receive / Rate (1400 NGN / 1400 = 1 USDC)
-            const calculatedAmount = Number(
-              (Number(amountReceived) / rate).toFixed(4),
+            //
+            // This amount is deposited on-chain verbatim and multiplied back by
+            // the rate to pay the recipient, so it rounds up at the token's own
+            // precision rather than to a fixed 4 places.
+            const calculatedAmount = quoteTokenAmountForFiat(
+              Number(amountReceived),
+              rate,
+              quoteDecimals,
             );
             setValue("amountSent", calculatedAmount, {
               shouldDirty: true,
@@ -758,7 +774,7 @@ export const TransactionForm = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [amountSent, amountReceived, rate, isSwapped],
+    [amountSent, amountReceived, rate, isSwapped, quoteDecimals],
   );
 
   // Derive swap eligibility from tier + spend limits. Always set explicitly so we
@@ -859,8 +875,8 @@ export const TransactionForm = ({
               const decimals = value.toString().split(".")[1];
               return (
                 !decimals ||
-                decimals.length <= 4 ||
-                "Maximum 4 decimal places allowed"
+                decimals.length <= quoteDecimals ||
+                `Maximum ${quoteDecimals} decimal places allowed`
               );
             },
             onrampFiatMin: (value: number) => {
@@ -1350,7 +1366,7 @@ export const TransactionForm = ({
     // Only limit decimal places, allow any whole number
     if (cleanedValue.includes(".")) {
       const decimals: string | undefined = cleanedValue.split(".")[1];
-      if (decimals?.length > 4) return;
+      if (decimals?.length > quoteDecimals) return;
     } // Update the form value
     setValue("amountSent", value, {
       shouldValidate: true,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -342,6 +342,12 @@ export function roundAmountForCurrency(amount: number): number {
  */
 export const MAX_QUOTE_DECIMALS = 6;
 
+/**
+ * Decimal places the onramp Send field accepts. That leg is fiat, not token, so
+ * it is unaffected by token precision and keeps its long-standing limit.
+ */
+export const ONRAMP_FIAT_DECIMALS = 4;
+
 export function getQuoteDecimals(tokenDecimals: number | undefined): number {
   const decimals = Math.trunc(Number(tokenDecimals));
   if (!Number.isFinite(decimals) || decimals <= 0) return MAX_QUOTE_DECIMALS;
@@ -374,7 +380,12 @@ export function quoteTokenAmountForFiat(
   rate: number,
   tokenDecimals: number | undefined,
 ): number {
-  if (!Number.isFinite(fiatAmount) || !Number.isFinite(rate) || rate <= 0) {
+  if (
+    !Number.isFinite(fiatAmount) ||
+    fiatAmount <= 0 ||
+    !Number.isFinite(rate) ||
+    rate <= 0
+  ) {
     return 0;
   }
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -332,6 +332,67 @@ export function roundAmountForCurrency(amount: number): number {
 }
 
 /**
+ * Decimal places a quoted token amount is carried at.
+ *
+ * Capped below the token's own precision so an 18-decimal token does not put
+ * `36.475317147039290123` in the amount field. Six places is finer than one
+ * minor unit of fiat at every corridor rate Noblocks quotes (the highest is
+ * ~3,700 fiat per token, where one subunit is worth ~0.004), so the cap costs
+ * the sender at most a rounding crumb.
+ */
+export const MAX_QUOTE_DECIMALS = 6;
+
+export function getQuoteDecimals(tokenDecimals: number | undefined): number {
+  const decimals = Math.trunc(Number(tokenDecimals));
+  if (!Number.isFinite(decimals) || decimals <= 0) return MAX_QUOTE_DECIMALS;
+  return Math.min(decimals, MAX_QUOTE_DECIMALS);
+}
+
+/**
+ * Scales by a power of ten through the decimal string, so 36.4753 * 1e6 lands on
+ * 36475300 rather than 36475299.999999996. Values already in exponential form
+ * cannot take a second exponent, so those fall back to plain multiplication.
+ */
+function shiftDecimalPoint(value: number, exponent: number): number {
+  const shifted = Number(`${value}e${exponent}`);
+  return Number.isFinite(shifted) ? shifted : value * 10 ** exponent;
+}
+
+/**
+ * Token amount to send so the recipient is paid `fiatAmount`, rounded **up** to
+ * the last subunit.
+ *
+ * Rounding down here is a real loss. The deposited token amount is what the
+ * aggregator multiplies back by the rate to decide the payout, so an amount
+ * short of `fiatAmount / rate` pays the recipient less than the quote — at 4
+ * decimal places a ₦50,000 order at rate 1370.79 deposited 36.4753 USDC and
+ * paid out ₦49,999.98. Rounding up costs the sender at most one subunit and can
+ * only land the recipient on or above the quote.
+ */
+export function quoteTokenAmountForFiat(
+  fiatAmount: number,
+  rate: number,
+  tokenDecimals: number | undefined,
+): number {
+  if (!Number.isFinite(fiatAmount) || !Number.isFinite(rate) || rate <= 0) {
+    return 0;
+  }
+
+  const decimals = getQuoteDecimals(tokenDecimals);
+  const subunits = shiftDecimalPoint(fiatAmount / rate, decimals);
+  if (!Number.isFinite(subunits)) return 0;
+
+  // A division that is mathematically exact can still land a hair off in binary
+  // (3 as 3.0000000000000004). Snapping those back keeps the amount field clean
+  // instead of charging a whole extra subunit for float noise.
+  const nearest = Math.round(subunits);
+  const rounded =
+    Math.abs(subunits - nearest) < 1e-6 ? nearest : Math.ceil(subunits);
+
+  return shiftDecimalPoint(rounded, -decimals);
+}
+
+/**
  * List / details: fiat uses symbol prefix (e.g. ₦1,000.5); crypto uses "1.23 USDC".
  */
 export function formatTransactionAmountDisplay(


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-784

### Description

On an offramp the Receive field lets the user name the fiat the recipient should get, and the Send leg was derived from it with `.toFixed(4)`. That token amount is deposited on-chain verbatim, and the aggregator multiplies it back by the rate to decide the payout — so the precision thrown away at 4 decimal places came straight off the recipient.

Reported case: a ₦50,000 order at rate 1370.79. `50000 / 1370.79 = 36.47531715` USDC, quoted as `36.4753`, deposited as `36475300` subunits. The aggregator paid `36.4753 × 1370.79 = 49,999.976487` → **₦49,999.98**, two kobo short.

It is systemic rather than a one-off. Settled on-chain offramp orders in the aggregator DB over the 14 days to 2026-08-31, grouped by the deposit's decimal places, counting those landing just short of a round ₦100:

| deposit dp | orders | short of a round ₦100 | avg shortfall |
|---|---|---|---|
| 4 | 509 | 50 (9.8%) | ₦0.049 |
| 5 | 210 | 64 (30%) | ₦0.019 |
| 6 | 76 | **0** | — |

The shortfall shrinks as client precision rises and vanishes at full token precision — the signature of client-side quote rounding, not a pricing or fee bug.

**The change.** `quoteTokenAmountForFiat` carries the division at the token's own precision and rounds **up** to the last subunit, so the recipient can only land on or above the quote. Rounding up costs the sender at most one subunit (~₦0.0014 at current rates).

Precision is capped at 6 places (`MAX_QUOTE_DECIMALS`) so an 18-decimal token does not put `36.475317147039290123` in the amount field. Six is finer than one minor unit of fiat at every corridor rate we quote (the highest is ~3,700 fiat per token, where a subunit is worth ~0.004), and the amount field already renders 6 places via `RATE_DECIMALS` — so nothing is truncated on display, and re-editing the field preserves the value.

The `validate.decimals` rule and the Send-field input mask move to the same precision. They had to move together: the conversion's `setValue` passes `shouldValidate: true`, so left at 4 they would reject the amount the form itself computes.

**Alternative considered:** round-to-nearest at 6 dp instead of rounding up. It fixes the reported case (residual ≤ ₦0.0007, well under half a kobo), but it only holds while rates stay below ~10,000 fiat per token. Rounding up holds at any rate, for a bounded one-subunit cost.

**Not in scope.** Three other `.toFixed(4)` sites in the same effect are display-only or onramp, where the API receives `amountIn: "fiat"` and the aggregator does the division at full precision — no money is lost. Onramp is unaffected by this bug.

**No aggregator change is needed.** `services/common/order.go` converts the on-chain event amount from subunits without rounding, and `utils.FiatPayoutAmount` rounds the payout to the currency's decimals. Both are correct; by the time the aggregator sees the deposit the amount is already fixed on-chain, so this can only be fixed here.

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### Testing

`__tests__/quoteTokenAmountForFiat.test.ts` — 9 tests, all passing:

- the KAN-784 order itself: `36.475318` pays ₦50,000.00, against `36.4753` → ₦49,999.98
- a sweep over ₦1,000–₦200,000 asserting the payout never lands under the quote
- the same sweep asserting the overpay never exceeds one subunit
- exact divisions are not charged an extra subunit for binary-float noise
- an 18-decimal token stays capped at 6 places and still pays the full quote
- a token coarser than the cap (2 dp) honours its own precision
- unusable input (zero/negative/NaN rate) returns 0 rather than NaN

Full suite: **544 passed**. `hyperfxStatus.test.ts` fails to resolve `@hyperbridge/sdk` in my local checkout — pre-existing, unrelated, and expected to pass in CI where deps are installed against current `main`.

Manual steps for a reviewer:

1. Offramp (not swapped), Base / USDC / NGN.
2. Type `50000` into the Receive field at a rate near 1370.79.
3. Send should read `36.475318`, not `36.4753`, with no "Maximum decimal places" error.
4. Confirm the Send field accepts a manually typed 6-decimal amount.
5. Onramp (swapped) should be unchanged.

Developed on macOS, Node via pnpm, Next.js App Router.

- [x] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract — n/a, no migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more accurate fiat-to-token quote calculations with token-specific precision.
  - On-ramp fiat amounts now support up to four decimal places.
  - Quote precision is capped at six decimals for consistent results.
  - Invalid or nonpositive quote inputs now safely return zero.

- **Bug Fixes**
  - Improved payout rounding, including very small token denominations and exact divisions.
  - Send amount validation and input limits now reflect the selected token’s precision.
  - Corrected minor floating-point rounding artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->