### PR TITLE
feat(smileIdValidation): add tests and validation for Nigeria ID types

### DIFF
--- a/__tests__/smileIdIdValidation.test.ts
+++ b/__tests__/smileIdIdValidation.test.ts
@@ -1,0 +1,94 @@
+import {
+  getJobTypeForIdType,
+  validateSmileIdIdInfo,
+} from "../app/lib/smileIdIdValidation";
+import idTypesData from "../app/api/kyc/smile-id/id_types.json";
+
+// V_NIN (Virtual NIN) was offered for Nigeria but is not enabled on our Smile ID
+// account, so every job submitted under it failed at the provider after burning one
+// of the user's three tier 2 attempts. These tests pin the removal: it must be gone
+// from the catalogue the KYC modal renders, and it must no longer be treated as a
+// job-type-5 NIN-family type by the validator.
+
+const nigeriaIdTypes = idTypesData.continents
+  .flatMap((continent) => continent.countries)
+  .find((country) => country.code === "NG")?.id_types;
+
+describe("Nigeria ID type catalogue", () => {
+  it("no longer offers V_NIN", () => {
+    expect(nigeriaIdTypes).toBeDefined();
+    expect(nigeriaIdTypes?.map((t) => t.type)).not.toContain("V_NIN");
+  });
+
+  it("keeps the supported biometric paths to tier 2", () => {
+    expect(nigeriaIdTypes?.map((t) => t.type)).toEqual(
+      expect.arrayContaining(["BVN", "NIN_SLIP"]),
+    );
+  });
+
+  it("does not offer V_NIN for any other country", () => {
+    const everyPair = idTypesData.continents
+      .flatMap((continent) => continent.countries)
+      .flatMap((country) => country.id_types.map((t) => t.type));
+    expect(everyPair).not.toContain("V_NIN");
+  });
+});
+
+describe("getJobTypeForIdType", () => {
+  it("keeps the remaining NIN family on job type 5", () => {
+    for (const idType of ["BVN", "NIN", "NIN_SLIP", "NIN_V2"]) {
+      expect(getJobTypeForIdType(idType)).toBe(5);
+    }
+  });
+
+  it("no longer routes V_NIN to job type 5", () => {
+    expect(getJobTypeForIdType("V_NIN")).not.toBe(5);
+  });
+
+  it("still routes DRIVERS_LICENSE to job type 6 and others to job type 1", () => {
+    expect(getJobTypeForIdType("DRIVERS_LICENSE")).toBe(6);
+    expect(getJobTypeForIdType("PASSPORT")).toBe(1);
+  });
+});
+
+describe("validateSmileIdIdInfo", () => {
+  it("accepts an 11-digit NIN slip", () => {
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "NIN_SLIP",
+        id_number: "12345678901",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a short NIN slip with the NIN-specific message", () => {
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "NIN_SLIP",
+        id_number: "1234",
+      }),
+    ).toEqual({ ok: false, message: "Enter a valid 11-digit NIN." });
+  });
+
+  it("still requires country and id_type", () => {
+    expect(validateSmileIdIdInfo({ country: "", id_type: "" })).toEqual({
+      ok: false,
+      message: "Country and ID type are required.",
+    });
+  });
+
+  it("no longer applies 11-digit NIN validation to V_NIN", () => {
+    // V_NIN now falls through to the job-type-1 branch, where an unmatched
+    // country|type pair carries no authority rule. The route rejects it against
+    // the catalogue before it ever reaches Smile ID.
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "V_NIN",
+        id_number: "1234",
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/app/api/kyc/smile-id/id_types.json
+++ b/app/api/kyc/smile-id/id_types.json
@@ -439,8 +439,7 @@
             { "type": "REGISTRATION_CERTIFICATE", "verification_method": "doc_verification" },
             { "type": "RESIDENT_ID", "verification_method": "doc_verification" },
             { "type": "TRAVEL_DOC", "verification_method": "doc_verification" },
-            { "type": "VOTER_ID", "verification_method": "doc_verification" },
-            { "type": "V_NIN", "verification_method": "biometric_kyc" }
+            { "type": "VOTER_ID", "verification_method": "doc_verification" }
           ]
         },
         {

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -7,8 +7,28 @@ import {
   type SmileIDIdInfo,
 } from "@/app/lib/smileID";
 
+import idTypesData from "./id_types.json";
+
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+
+/**
+ * Country|ID-type pairs the app actually offers. The KYC modal builds its
+ * dropdown from the same catalogue, so any other pair reaching this route is a
+ * stale or hand-crafted request for a product we have not enabled on Smile ID.
+ */
+const SUPPORTED_COUNTRY_ID_TYPES: ReadonlySet<string> = new Set(
+  idTypesData.continents.flatMap((continent) =>
+    continent.countries.flatMap((country) =>
+      country.id_types.map((idType) => `${country.code}|${idType.type}`),
+    ),
+  ),
+);
+
+function isSupportedCountryIdType(country: string, idType: string): boolean {
+  const key = `${country.trim().toUpperCase()}|${idType.trim().toUpperCase()}`;
+  return SUPPORTED_COUNTRY_ID_TYPES.has(key);
+}
 
 type SmileFailureCategory = "database" | "quality" | "liveness" | "mismatch" | "general";
 
@@ -72,6 +92,18 @@ export async function POST(request: NextRequest) {
         {
           status: "error",
           message: "Missing id_info: country and id_type are required",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Reject unsupported pairs before the attempt counter is incremented, so a
+    // request Smile ID can never verify does not burn one of the user's tries.
+    if (!isSupportedCountryIdType(id_info.country, id_info.id_type)) {
+      return NextResponse.json(
+        {
+          status: "error",
+          message: "Unsupported ID type for the selected country.",
         },
         { status: 400 },
       );

--- a/app/lib/smileIdIdValidation.ts
+++ b/app/lib/smileIdIdValidation.ts
@@ -23,7 +23,7 @@ export class SmileIdValidationError extends Error {
 
 export function getJobTypeForIdType(idType: string): number {
   const normalized = idType?.toString().trim().toUpperCase();
-  if (["BVN", "NIN", "NIN_SLIP", "V_NIN", "NIN_V2"].includes(normalized)) return 5;
+  if (["BVN", "NIN", "NIN_SLIP", "NIN_V2"].includes(normalized)) return 5;
   if (normalized === "DRIVERS_LICENSE") return 6;
   return 1;
 }
@@ -32,7 +32,6 @@ const SMILE_ELEVEN_DIGIT_ID_TYPES = new Set([
   "BVN",
   "NIN",
   "NIN_SLIP",
-  "V_NIN",
   "NIN_V2",
 ]);
 
@@ -124,7 +123,6 @@ function elevenDigitNinFamilyMessage(idType: string): string {
   const ninFamily =
     idType === "NIN" ||
     idType === "NIN_SLIP" ||
-    idType === "V_NIN" ||
     idType === "NIN_V2";
   return ninFamily
     ? "Enter a valid 11-digit NIN."


### PR DESCRIPTION


### Jira Issue

Jira Issue:  https://paycrest-io.atlassian.net/browse/KAN-785

### Description

- Introduced a new test suite for validating Nigeria ID types, ensuring "V_NIN" is no longer offered and confirming the integrity of supported biometric paths.
- Updated the `getJobTypeForIdType` function to exclude "V_NIN" from job type 5 routing.
- Enhanced the `validateSmileIdIdInfo` function to correctly handle validation for "V_NIN", ensuring it does not apply 11-digit NIN validation.
- Modified the ID types JSON to remove "V_NIN" from the available types, reflecting the updated KYC requirements.
- Added a check in the KYC route to reject unsupported country-ID type pairs, improving error handling and user experience.


### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [x] CodeRabbit / CI green


### References




### Testing



- [ ] This change adds test coverage for new/changed/fixed functionality


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to reject unsupported country and ID-type combinations before processing KYC attempts.

* **Updates**
  * Removed biometric NIN verification as a supported Nigerian document option.
  * Nigerian voter ID verification remains available through document verification.
  * Updated ID validation so unsupported NIN variants no longer receive specialized NIN handling.

* **Tests**
  * Added coverage for supported Nigerian verification paths, required fields, job-type mappings, and NIN slip validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->