### PR TITLE
fix(PlayPromo): noblock play regression test fixes

### DIFF
--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -488,7 +488,7 @@ export function PlayPromoButton() {
 
   return (
     <motion.div
-      className="pointer-events-none fixed left-0 right-0 top-[72px] z-30"
+      className="pointer-events-none fixed left-0 right-0 top-[78px] z-30"
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: "easeOut" }}

--- a/app/components/play/JoinModal.tsx
+++ b/app/components/play/JoinModal.tsx
@@ -4,11 +4,17 @@
  * Join-the-league modal: pick a permanent username (debounced availability
  * check + suggestions), accept the T&Cs, and POST /api/play/join. Handles the
  * 409 username race by surfacing the server's suggestions.
+ *
+ * With an `inviteCode` (arrived via a friend's mini-league link) the modal also
+ * joins that league straight after, so the invite finishes in one pass instead
+ * of dumping the user on /play/team with the code lost.
  */
 
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { DialogTitle } from "@headlessui/react";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
@@ -19,18 +25,24 @@ import {
 } from "hugeicons-react";
 import { AnimatedModal } from "../AnimatedComponents";
 import { trackEvent } from "@/app/hooks/analytics/client";
-import { PlayApiError } from "./api";
-import { useJoinLeague, useUsernameAvailability } from "./hooks";
+import { PlayApiError, joinMiniLeague } from "./api";
+import { playKeys, useJoinLeague, useUsernameAvailability } from "./hooks";
+import { leagueJoinPath } from "./league-invite";
 import { primaryButtonClasses } from "./ui";
 
 export const JoinModal = ({
   isOpen,
   onClose,
+  inviteCode = null,
 }: {
   isOpen: boolean;
   onClose: () => void;
+  /** Mini-league code from a `?join=` invite link, joined right after signup. */
+  inviteCode?: string | null;
 }) => {
   const router = useRouter();
+  const { getAccessToken } = usePrivy();
+  const queryClient = useQueryClient();
   const [username, setUsername] = useState("");
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -50,6 +62,30 @@ export const JoinModal = ({
 
   const canSubmit =
     trimmed.length >= 3 && acceptTerms && available && !join.isPending;
+
+  /**
+   * Redeem the invite the user arrived with. A bad or already-used code must not
+   * strand a brand-new manager, so any failure still hands off to Leagues with
+   * the code pre-filled rather than surfacing a dead end.
+   */
+  const joinInvitedLeague = async (code: string) => {
+    try {
+      const token = await getAccessToken();
+      if (!token) throw new PlayApiError("Unauthorized", 401);
+      const { league } = await joinMiniLeague(code, token);
+      await queryClient.invalidateQueries({ queryKey: playKeys.rewards });
+      trackEvent("league_invite_redeemed", { league_id: league.id });
+      toast.success(`Joined "${league.name}"`);
+      router.push("/play/rewards");
+    } catch (error) {
+      toast.error(
+        error instanceof PlayApiError
+          ? error.message
+          : "Couldn't join that league — try the code below.",
+      );
+      router.push(leagueJoinPath(code));
+    }
+  };
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
@@ -71,6 +107,12 @@ export const JoinModal = ({
           : `Welcome to the league, ${data.username}!`,
       );
       onClose();
+
+      if (inviteCode) {
+        await joinInvitedLeague(inviteCode);
+        return;
+      }
+
       router.push("/play/team");
     } catch (error) {
       if (error instanceof PlayApiError) {

--- a/app/components/play/JoinModal.tsx
+++ b/app/components/play/JoinModal.tsx
@@ -10,7 +10,7 @@
  * of dumping the user on /play/team with the code lost.
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { usePrivy } from "@privy-io/react-auth";
@@ -46,6 +46,11 @@ export const JoinModal = ({
   const [username, setUsername] = useState("");
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  // The invite redemption is awaited *after* onClose, so this component stays
+  // mounted and reopenable while the request is in flight. The ref blocks a
+  // second redemption; the state keeps the submit button disabled meanwhile.
+  const [redeemingInvite, setRedeemingInvite] = useState(false);
+  const redeemingInviteRef = useRef(false);
 
   const { result, checking } = useUsernameAvailability(username);
   const join = useJoinLeague();
@@ -61,7 +66,11 @@ export const JoinModal = ({
     : (result?.suggestions ?? []);
 
   const canSubmit =
-    trimmed.length >= 3 && acceptTerms && available && !join.isPending;
+    trimmed.length >= 3 &&
+    acceptTerms &&
+    available &&
+    !join.isPending &&
+    !redeemingInvite;
 
   /**
    * Redeem the invite the user arrived with. A bad or already-used code must not
@@ -69,6 +78,9 @@ export const JoinModal = ({
    * the code pre-filled rather than surfacing a dead end.
    */
   const joinInvitedLeague = async (code: string) => {
+    if (redeemingInviteRef.current) return;
+    redeemingInviteRef.current = true;
+    setRedeemingInvite(true);
     try {
       const token = await getAccessToken();
       if (!token) throw new PlayApiError("Unauthorized", 401);
@@ -84,6 +96,9 @@ export const JoinModal = ({
           : "Couldn't join that league — try the code below.",
       );
       router.push(leagueJoinPath(code));
+    } finally {
+      redeemingInviteRef.current = false;
+      setRedeemingInvite(false);
     }
   };
 
@@ -158,7 +173,7 @@ export const JoinModal = ({
               maxLength={20}
               autoComplete="off"
               autoFocus
-              disabled={join.isPending}
+              disabled={join.isPending || redeemingInvite}
               className="w-full border-0 bg-transparent pt-1 text-base font-medium text-text-body placeholder:text-text-placeholder focus:outline-none focus:ring-0 dark:text-white dark:placeholder:text-white/30"
             />
             {trimmed.length >= 3 &&
@@ -227,7 +242,11 @@ export const JoinModal = ({
           disabled={!canSubmit}
           className={`w-full ${primaryButtonClasses}`}
         >
-          {join.isPending ? "Joining..." : "Join the league"}
+          {redeemingInvite
+            ? "Joining your league..."
+            : join.isPending
+              ? "Joining..."
+              : "Join the league"}
         </button>
       </motion.div>
     </AnimatedModal>

--- a/app/components/play/LeaderboardTable.tsx
+++ b/app/components/play/LeaderboardTable.tsx
@@ -9,6 +9,9 @@ import Link from "next/link";
 import { ArrowDown01Icon, ArrowUp01Icon } from "hugeicons-react";
 import type { LeaderboardRowData } from "./types";
 
+/** DOM id of the signed-in user's row — the Find me scroll target. */
+export const SELF_ROW_ID = "leaderboard-self-row";
+
 const managerHref = (username: string) =>
   `/play/manager/${encodeURIComponent(username)}`;
 
@@ -49,9 +52,12 @@ const Movement = ({ value }: { value: number }) => {
 export const LeaderboardTable = ({
   rows,
   compact = false,
+  highlightSelf = false,
 }: {
   rows: LeaderboardRowData[];
   compact?: boolean;
+  /** Flash the "You" row after a Find me jump so it is obvious where you landed. */
+  highlightSelf?: boolean;
 }) => {
   const router = useRouter();
 
@@ -70,17 +76,26 @@ export const LeaderboardTable = ({
           {rows.map((row) => (
             <tr
               key={`${row.rank}-${row.username ?? "anon"}`}
-              id={row.is_me ? "leaderboard-self-row" : undefined}
+              id={row.is_me ? SELF_ROW_ID : undefined}
+              tabIndex={row.is_me ? -1 : undefined}
+              aria-current={row.is_me ? "true" : undefined}
               onClick={
                 row.username
                   ? () => router.push(managerHref(row.username!))
                   : undefined
               }
-              className={`border-b border-border-light last:border-0 dark:border-white/5 ${
+              className={`border-b border-border-light last:border-0 transition-colors duration-500 dark:border-white/5 ${
                 row.username ? "cursor-pointer" : ""
               } ${
                 row.is_me
-                  ? "bg-lavender-50 dark:bg-lavender-500/10"
+                  ? // The Find me flash deepens the row's own wash rather than
+                    // ringing it: a ring is a square rectangle, and on the last
+                    // row the wrapper's rounded-2xl clips its bottom corners, so
+                    // the outline visibly breaks against the curve. Backgrounds
+                    // follow that clip cleanly.
+                    highlightSelf
+                    ? "bg-lavender-200 dark:bg-lavender-500/40"
+                    : "bg-lavender-50 dark:bg-lavender-500/10"
                   : compact
                     ? ""
                     : "hover:bg-background-neutral dark:hover:bg-white/[.03]"

--- a/app/components/play/PlayShell.tsx
+++ b/app/components/play/PlayShell.tsx
@@ -16,6 +16,7 @@
 
 import { ReactNode } from "react";
 import Link from "next/link";
+import { Home01Icon } from "hugeicons-react";
 import { NoblocksLogo, NoblocksLogoIcon } from "../ImageAssets";
 import { PlayTabs } from "./PlayTabs";
 import { CountdownChip } from "./CountdownChip";
@@ -34,7 +35,20 @@ export const PlayHeader = ({ right }: { right?: ReactNode }) => (
         <NoblocksLogoIcon className="size-[18px] sm:hidden" />
         <NoblocksLogo className="max-sm:hidden" />
       </Link>
-      <div className="flex items-center gap-2">{right}</div>
+      <div className="flex items-center gap-2">
+        {/* The wordmark goes to /play (the game's own home), so leaving the
+            game needed the browser back button until this existed. */}
+        <Link
+          href="/"
+          aria-label="Noblocks home"
+          title="Noblocks home"
+          className="inline-flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-accent-gray hover:text-text-body dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
+        >
+          <Home01Icon className="size-[18px] shrink-0" />
+          <span className="max-sm:sr-only">Home</span>
+        </Link>
+        {right}
+      </div>
     </div>
   </header>
 );

--- a/app/components/play/hooks.ts
+++ b/app/components/play/hooks.ts
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
+  keepPreviousData,
   useMutation,
   useQuery,
   useQueryClient,
@@ -102,6 +103,10 @@ export function useLeaderboard(page: number, findMe = false) {
     // findMe only makes sense once signed in — skip the request entirely
     // for anonymous visits instead of issuing a tokenless findMe lookup.
     enabled: ready && (!findMe || authenticated),
+    // Page changes are their own query key, so without this the table would
+    // unmount into skeletons on every Prev/Next. Hold the previous page's rows
+    // until the new ones arrive; callers dim the table via isFetching instead.
+    placeholderData: keepPreviousData,
     staleTime: 60_000,
     refetchInterval: false,
   });

--- a/app/play/leaderboard/page.tsx
+++ b/app/play/leaderboard/page.tsx
@@ -38,28 +38,32 @@ export default function LeaderboardPage() {
   const { authenticated } = usePrivy();
   const { joined } = useJoinStatus();
 
-  const { data, isPending, isFetching, isError, refetch } = useLeaderboard(
-    page,
-    findMe,
-  );
+  const { data, isPending, isFetching, isPlaceholderData, isError, refetch } =
+    useLeaderboard(page, findMe);
 
   useEffect(() => {
     trackEvent("leaderboard_viewed", { page });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // keepPreviousData hands back the outgoing page's rows the instant findMe
+  // flips the query key, so `data` is non-null before the find request has run.
+  // Acting on that placeholder would set the page back to where we already were
+  // and clear findMe, silently cancelling the jump — wait for the real result.
   useEffect(() => {
-    if (findMe && data) {
+    if (findMe && data && !isPlaceholderData) {
       setPage(data.page);
       setFindMe(false);
     }
-  }, [findMe, data]);
+  }, [findMe, data, isPlaceholderData]);
 
   // Landing on the right page is not enough — on a full page of 50 the "You"
   // row is usually below the fold. Once the rows holding it are committed,
   // bring it to the middle of the viewport and ring it.
   useEffect(() => {
-    if (!pendingSelfScroll || !data) return;
+    // Placeholder rows belong to the page we are leaving: scrolling to them, or
+    // concluding from them that there is no self row, both break the jump.
+    if (!pendingSelfScroll || !data || isPlaceholderData) return;
     const hasSelf = data.rows.some((row) => row.is_me);
     if (!hasSelf) {
       // Signed in but not ranked yet (no scores computed) — nothing to jump to.
@@ -73,7 +77,7 @@ export default function LeaderboardPage() {
     // preventScroll: scrollIntoView above already owns the movement, and
     // focus() would otherwise jump instantly and cancel the smooth scroll.
     row?.focus({ preventScroll: true });
-  }, [pendingSelfScroll, data, findMe]);
+  }, [pendingSelfScroll, data, findMe, isPlaceholderData]);
 
   useEffect(() => {
     if (!highlightSelf) return;

--- a/app/play/leaderboard/page.tsx
+++ b/app/play/leaderboard/page.tsx
@@ -5,7 +5,7 @@
  * points, with self-row highlight, "Find me" jump and pagination.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
   ArrowLeft01Icon,
@@ -14,7 +14,10 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { trackEvent } from "@/app/hooks/analytics/client";
-import { LeaderboardTable } from "@/app/components/play/LeaderboardTable";
+import {
+  LeaderboardTable,
+  SELF_ROW_ID,
+} from "@/app/components/play/LeaderboardTable";
 import { useJoinStatus, useLeaderboard } from "@/app/components/play/hooks";
 import {
   EmptyState,
@@ -23,13 +26,22 @@ import {
   secondaryButtonClasses,
 } from "@/app/components/play/ui";
 
+/** How long the "You" row keeps its ring after a Find me jump. */
+const SELF_HIGHLIGHT_MS = 2400;
+
 export default function LeaderboardPage() {
   const [page, setPage] = useState(1);
   const [findMe, setFindMe] = useState(false);
+  const [pendingSelfScroll, setPendingSelfScroll] = useState(false);
+  const [highlightSelf, setHighlightSelf] = useState(false);
+  const tableRef = useRef<HTMLDivElement>(null);
   const { authenticated } = usePrivy();
   const { joined } = useJoinStatus();
 
-  const { data, isPending, isError, refetch } = useLeaderboard(page, findMe);
+  const { data, isPending, isFetching, isError, refetch } = useLeaderboard(
+    page,
+    findMe,
+  );
 
   useEffect(() => {
     trackEvent("leaderboard_viewed", { page });
@@ -43,7 +55,44 @@ export default function LeaderboardPage() {
     }
   }, [findMe, data]);
 
+  // Landing on the right page is not enough — on a full page of 50 the "You"
+  // row is usually below the fold. Once the rows holding it are committed,
+  // bring it to the middle of the viewport and ring it.
+  useEffect(() => {
+    if (!pendingSelfScroll || !data) return;
+    const hasSelf = data.rows.some((row) => row.is_me);
+    if (!hasSelf) {
+      // Signed in but not ranked yet (no scores computed) — nothing to jump to.
+      if (!findMe) setPendingSelfScroll(false);
+      return;
+    }
+    setPendingSelfScroll(false);
+    setHighlightSelf(true);
+    const row = document.getElementById(SELF_ROW_ID);
+    row?.scrollIntoView({ behavior: "smooth", block: "center" });
+    // preventScroll: scrollIntoView above already owns the movement, and
+    // focus() would otherwise jump instantly and cancel the smooth scroll.
+    row?.focus({ preventScroll: true });
+  }, [pendingSelfScroll, data, findMe]);
+
+  useEffect(() => {
+    if (!highlightSelf) return;
+    const timer = window.setTimeout(
+      () => setHighlightSelf(false),
+      SELF_HIGHLIGHT_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [highlightSelf]);
+
   const totalPages = data ? Math.max(1, Math.ceil(data.total / data.page_size)) : 1;
+
+  const goToPage = (next: number) => {
+    setPage(next);
+    setHighlightSelf(false);
+    // Keep the top of the list in view: without this the browser holds the old
+    // scroll offset and the new page appears to open halfway down.
+    tableRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
     <div className="space-y-4 max-lg:pb-10">
@@ -56,6 +105,7 @@ export default function LeaderboardPage() {
             type="button"
             onClick={() => {
               setFindMe(true);
+              setPendingSelfScroll(true);
             }}
             className={`${secondaryButtonClasses} inline-flex items-center gap-2`}
           >
@@ -84,11 +134,22 @@ export default function LeaderboardPage() {
         />
       ) : (
         <>
-          <LeaderboardTable rows={data.rows} />
+          {/* Rows from the previous page stay mounted while the next one loads
+              (see keepPreviousData in useLeaderboard) — dim them rather than
+              collapsing the table into skeletons on every Prev/Next. */}
+          <div
+            ref={tableRef}
+            aria-busy={isFetching}
+            className={`transition-opacity duration-200 ${
+              isFetching ? "opacity-60" : "opacity-100"
+            }`}
+          >
+            <LeaderboardTable rows={data.rows} highlightSelf={highlightSelf} />
+          </div>
           <div className="flex items-center justify-between">
             <button
               type="button"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              onClick={() => goToPage(Math.max(1, page - 1))}
               disabled={page <= 1}
               className={`${secondaryButtonClasses} inline-flex items-center gap-1`}
             >
@@ -100,7 +161,7 @@ export default function LeaderboardPage() {
             </span>
             <button
               type="button"
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              onClick={() => goToPage(Math.min(totalPages, page + 1))}
               disabled={page >= totalPages}
               className={`${secondaryButtonClasses} inline-flex items-center gap-1`}
             >

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -28,10 +28,19 @@ import {
 const ASSET = (name: string) => `/images/play-promo/${name}`;
 const HERO_PILL_BUTTON =
   "inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-white px-4 py-2 text-sm font-semibold text-text-body transition-transform active:scale-[0.98] dark:bg-white dark:text-text-body";
+// The desktop banner is a fixed-aspect box whose headline, body and gaps are all
+// sized in cqw; these two buttons were its only fixed-px elements. At text-sm
+// with px-6 they needed ~308px side by side but the text column is only 35.34%
+// (~287px at the 812px design width), so the row wrapped to two lines and the
+// second button spilled through the banner's bottom edge — worse the narrower
+// the screen, since the box height shrank while the buttons did not. Sizing them
+// in cqw too keeps the pair on one line at every container width.
+const HERO_DESKTOP_BUTTON_SIZING =
+  "px-[2.1cqw] py-[1.15cqw] text-[1.6cqw]";
 const HERO_DESKTOP_PRIMARY_BUTTON =
-  "inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-text-body px-6 py-2.5 text-sm font-semibold text-lavender-100 transition-transform hover:bg-text-body/90 active:scale-[0.98] dark:bg-black dark:text-lavender-100 dark:hover:bg-black/90";
+  `inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-text-body ${HERO_DESKTOP_BUTTON_SIZING} font-semibold text-lavender-100 transition-transform hover:bg-text-body/90 active:scale-[0.98] dark:bg-black dark:text-lavender-100 dark:hover:bg-black/90`;
 const HERO_SECONDARY_BUTTON =
-  "inline-flex min-h-0 items-center justify-center whitespace-nowrap rounded-full bg-white/10 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/20";
+  `inline-flex min-h-0 items-center justify-center whitespace-nowrap rounded-full bg-white/10 ${HERO_DESKTOP_BUTTON_SIZING} font-semibold text-white transition-colors hover:bg-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/20`;
 const BOTTOM_CTA_SECTION =
   "relative overflow-hidden rounded-3xl bg-text-body dark:bg-surface-overlay";
 const BOTTOM_CTA_SCRIM = "pointer-events-none absolute inset-0 z-0 bg-text-body/70 dark:bg-surface-overlay/70";
@@ -235,7 +244,11 @@ const JoinCTA = ({
     return (
       <Link
         href="/play/team"
-        className={`${buttonClassName} inline-flex items-center gap-2  px-8 py-3 ${className}`}
+        className={`${buttonClassName} inline-flex items-center gap-2 ${
+          // Callers passing their own look (the hero banners) size their own
+          // padding; only the default button needs this widening.
+          buttonClassName === primaryButtonClasses ? "px-8 py-3" : ""
+        } ${className}`}
       >
         My Team
         <ArrowRight01Icon className="size-4" />

--- a/app/play/rewards/page.tsx
+++ b/app/play/rewards/page.tsx
@@ -15,6 +15,7 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { toast } from "sonner";
+import { JoinModal } from "@/app/components/play/JoinModal";
 import { LeagueCard } from "@/app/components/play/LeagueCard";
 import { playKeys, useRewards } from "@/app/components/play/hooks";
 import {
@@ -56,10 +57,12 @@ export default function RewardsPage() {
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
   const [joinHighlight, setJoinHighlight] = useState(false);
+  const [playJoinOpen, setPlayJoinOpen] = useState(false);
   const joinInputRef = useRef<HTMLInputElement>(null);
+  const inviteCode = searchParams.get("join")?.trim().toUpperCase() || null;
 
   useEffect(() => {
-    const join = searchParams.get("join")?.trim().toUpperCase();
+    const join = inviteCode;
     if (!join || join.length < 4) return;
     setCode(join);
     setJoinHighlight(true);
@@ -70,7 +73,7 @@ export default function RewardsPage() {
         block: "center",
       });
     }, 300);
-  }, [searchParams]);
+  }, [inviteCode]);
 
   const refresh = async () => {
     await queryClient.invalidateQueries({ queryKey: playKeys.rewards });
@@ -95,7 +98,6 @@ export default function RewardsPage() {
   if (!ready || (authenticated && isLoading)) return <RewardsSkeleton />;
 
   if (!authenticated) {
-    const inviteCode = searchParams.get("join")?.trim().toUpperCase();
     return (
       <EmptyState
         icon={<UserGroupIcon className="size-8 text-lavender-500" />}
@@ -119,17 +121,35 @@ export default function RewardsPage() {
   }
 
   if (error instanceof PlayApiError && error.code === "NOT_JOINED") {
+    // Joining Play used to bounce through /play, which dropped the invite code
+    // and left the user to find Leagues and retype it. Do it here instead: the
+    // modal redeems `inviteCode` as soon as the username is taken.
     return (
-      <EmptyState
-        icon={<UserGroupIcon className="size-8 text-lavender-500" />}
-        title="Join Noblocks Play first"
-        description="Pick a username and enter the league, then come back here to join your friend's mini-league."
-        action={
-          <Link href="/play" className={primaryButtonClasses}>
-            Join the league
-          </Link>
-        }
-      />
+      <>
+        <EmptyState
+          icon={<UserGroupIcon className="size-8 text-lavender-500" />}
+          title="Join Noblocks Play first"
+          description={
+            inviteCode
+              ? `Pick a username to enter the league — we'll add you to the mini-league (${inviteCode}) straight after.`
+              : "Pick a username and enter the league, then come back here to join a friend's mini-league."
+          }
+          action={
+            <button
+              type="button"
+              onClick={() => setPlayJoinOpen(true)}
+              className={primaryButtonClasses}
+            >
+              Join the league
+            </button>
+          }
+        />
+        <JoinModal
+          isOpen={playJoinOpen}
+          onClose={() => setPlayJoinOpen(false)}
+          inviteCode={inviteCode}
+        />
+      </>
     );
   }
 


### PR DESCRIPTION



### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-758

### Description

- Updated the PlayPromoButton component to adjust its vertical position from 72px to 78px.
- Enhanced the useLeaderboard hook to retain previous page data during pagination, improving user experience by preventing table unmounting.
- Added functionality to the JoinModal for redeeming invite codes directly upon user signup, streamlining the league joining process.
- Improved the LeaderboardTable to highlight the signed-in user's row and maintain visibility during pagination.
- Updated the RewardsPage to handle invite codes more effectively, ensuring users can join leagues seamlessly.


### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [x] CodeRabbit / CI green


### References



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added invite-code redemption during Play signup, with success and error handling.
  * Added a home link to Play navigation.
  * Added “Find me” leaderboard navigation with row highlighting and focus support.
  * Added an inline join flow from the Rewards page.

* **Improvements**
  * Leaderboard pagination now preserves existing rows while loading.
  * Improved responsive Play hero button sizing.
  * Adjusted dismissed-banner Play button positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->