### PR TITLE
KAN-786: instrument the KYC flow for Datadog

### DIFF
--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -120,6 +120,82 @@ liability. The threshold monitors would likewise fire on staging noise.
 The first one is the one that matters. When the cron dies, nothing else
 anywhere reports it.
 
+## KYC telemetry
+
+The KYC flow reports through `app/lib/kyc-telemetry.ts`: one structured line per
+step outcome, message `kyc step`, flattened into `@kyc.*` attributes. Its
+purpose is answering "why did this user's upgrade fail?" from the Logs Explorer
+instead of asking the user what the screen said.
+
+Every exit path in the KYC routes emits exactly one line — the tier 1 OTP send
+and verify, the tier 2 ID submission and its async Smile ID callback, and the
+tier 3 address check. `/api/kyc/status` reports failures only; every KYC surface
+polls it, so its successes would bury everything else.
+
+| Attribute | Meaning |
+| --- | --- |
+| `@kyc.step` | `signup_email`, `phone_otp_send`, `phone_otp_verify`, `id_verification`, `id_callback`, `address_verification`, `status` |
+| `@kyc.outcome` | `success`, `rejected`, `error`, `noop` (see below) |
+| `@kyc.ok` | `true` only on `success` — the boolean twin of `outcome` |
+| `@kyc.detail` | **The provider's own words.** Smile ID `ResultText`, Dojah's message, the Postgres error |
+| `@kyc.reason` | Stable cause: `provider_rejected`, `attempts_exhausted`, `duplicate_id_document`, `invalid_otp`, `supabase_error`, … |
+| `@kyc.stage` | Where in the route: `provider_verify`, `profile_update`, `attempt_counter`, `otp_check`, … |
+| `@kyc.failure_category` | `classifySmileIdFailure` output: `quality`, `liveness`, `mismatch`, `database`, `general` |
+| `@kyc.wallet_address` | Lower-cased. The key support searches on |
+| `@kyc.tier_from` / `@kyc.tier_to` / `@kyc.promoted` | The tier change, and whether one happened |
+| `@kyc.attempt` / `@kyc.attempts_remaining` | How close the user is to being locked out |
+| `@kyc.provider` / `@kyc.provider_code` / `@kyc.job_id` | `smile_id`, `dojah`, `kudisms`, `twilio`, `supabase`, plus their codes |
+| `@kyc.duration_ms` / `@kyc.status_code` | Wall time and the HTTP status returned |
+
+`outcome` is the distinction that makes alerting possible. A `rejected` line is
+a legitimate refusal — a mistyped OTP, a blurry document, Smile ID saying no —
+and logs at `warn`. An `error` line is our fault, the database's, or a
+provider's, and logs at `error`. Without the split, an outage monitor would be
+drowned by users fat-fingering their OTP. `noop` (info) covers work that
+correctly did nothing, chiefly a Smile ID callback arriving after the
+synchronous path already promoted the profile.
+
+### Supporting a user
+
+```text
+service:noblocks env:production @feature:kyc @kyc.wallet_address:0x1234…
+```
+
+Lower-case the address — the facet is normalised, and a checksummed address
+pasted verbatim will not match. Read `@kyc.detail` for the underlying reason,
+`@kyc.attempts_remaining` for whether they can retry, and **View Trace** for the
+request itself.
+
+### Monitors worth having
+
+As with the worker monitors above, every query is scoped `env:production`.
+**Do not drop that scope** — staging shares this Datadog org.
+
+| Monitor | Query | Why |
+| --- | --- | --- |
+| **KYC infrastructure failure → page** | `service:noblocks env:production @feature:kyc @kyc.outcome:error` | Smile ID, Dojah, or Supabase is failing upgrades; users cannot verify at all |
+| Provider outage burning attempts → Slack | `@feature:kyc @kyc.failure_category:database` | Smile ID infrastructure failures, which refund the attempt — a spike means the provider, not our users |
+| Verified-and-lost → page | `@feature:kyc @kyc.stage:profile_update @kyc.outcome:error` | The provider approved them and the write failed: the user spent an attempt and stayed on the old tier |
+| Callback signature failures → Slack | `@feature:kyc @kyc.reason:invalid_signature` | A genuine Smile ID callback never fails this |
+| Rejection mix → dashboard | `@feature:kyc @kyc.outcome:rejected`, grouped by `@kyc.reason` and `@kyc.id_type` | Which ID types and reasons dominate; the input to fixing the flow rather than individual tickets |
+
+### Client-side
+
+`reportClientError` (`app/lib/sentry.client.ts`) forwards to
+`datadogRum.addError` alongside GlitchTip, so KYC failures that never reach the
+API — a dropped request, a refused camera, a wallet rejection — surface in RUM
+Error Tracking under their `feature` tag. RUM is consent-gated, so the server
+lines remain the complete record.
+
+### PII
+
+Wallet address is logged in the clear: it is the key support needs, and it is
+what these routes already logged. Phone numbers, emails, ID numbers, dates of
+birth, names and document images are never logged. Because Smile ID and Dojah
+quote the failing input back in their rejection messages, `sanitizeDetail`
+masks runs of six or more digits and anything email-shaped before a line ships —
+short numbers like result codes stay readable.
+
 ## Verifying
 
 Deploy, wait ~60s, then in the **EU** app:
@@ -130,6 +206,7 @@ Deploy, wait ~60s, then in the **EU** app:
 | Logs flowing | Logs Explorer → `service:noblocks env:production` |
 | Trace–log correlation | Open a log line → **View Trace** is present |
 | Worker ticks | Logs → `@feature:play @worker.ran_at:*` |
+| KYC steps | Logs → `@feature:kyc @kyc.step:*` |
 | RUM | RUM → Applications |
 | Service Catalog | Software → `noblocks` |
 

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -155,6 +155,11 @@ drowned by users fat-fingering their OTP. `noop` (info) covers work that
 correctly did nothing, chiefly a Smile ID callback arriving after the
 synchronous path already promoted the profile.
 
+A missing `x-wallet-address` is an `error`, not a rejection: middleware matches
+every KYC route, answers unauthenticated callers with its own 401, and strips
+forged wallet headers, so a handler that finds none has a broken matcher or
+header chain rather than an unauthenticated user.
+
 ### Supporting a user
 
 ```text

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -174,10 +174,10 @@ As with the worker monitors above, every query is scoped `env:production`.
 | Monitor | Query | Why |
 | --- | --- | --- |
 | **KYC infrastructure failure → page** | `service:noblocks env:production @feature:kyc @kyc.outcome:error` | Smile ID, Dojah, or Supabase is failing upgrades; users cannot verify at all |
-| Provider outage burning attempts → Slack | `@feature:kyc @kyc.failure_category:database` | Smile ID infrastructure failures, which refund the attempt — a spike means the provider, not our users |
-| Verified-and-lost → page | `@feature:kyc @kyc.stage:profile_update @kyc.outcome:error` | The provider approved them and the write failed: the user spent an attempt and stayed on the old tier |
-| Callback signature failures → Slack | `@feature:kyc @kyc.reason:invalid_signature` | A genuine Smile ID callback never fails this |
-| Rejection mix → dashboard | `@feature:kyc @kyc.outcome:rejected`, grouped by `@kyc.reason` and `@kyc.id_type` | Which ID types and reasons dominate; the input to fixing the flow rather than individual tickets |
+| Provider outage burning attempts → Slack | `service:noblocks env:production @feature:kyc @kyc.failure_category:database` | Smile ID infrastructure failures, which refund the attempt — a spike means the provider, not our users |
+| Verified-and-lost → page | `service:noblocks env:production @feature:kyc @kyc.stage:profile_update @kyc.outcome:error` | The provider approved them and the write failed: the user spent an attempt and stayed on the old tier |
+| Callback signature failures → Slack | `service:noblocks env:production @feature:kyc @kyc.reason:invalid_signature` | A genuine Smile ID callback never fails this |
+| Rejection mix → dashboard | `service:noblocks env:production @feature:kyc @kyc.outcome:rejected`, grouped by `@kyc.reason` and `@kyc.id_type` | Which ID types and reasons dominate; the input to fixing the flow rather than individual tickets |
 
 ### Client-side
 

--- a/__tests__/kyc-telemetry.test.ts
+++ b/__tests__/kyc-telemetry.test.ts
@@ -122,6 +122,20 @@ describe("buildKycLog", () => {
     });
   });
 
+  it("masks the stack too — its first line repeats the message", () => {
+    const error = new Error("ID 12345678901 could not be verified");
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "error",
+      error,
+    });
+
+    const shipped = log.attributes.error as { message: string; stack: string };
+    expect(shipped.message).toBe("ID [digits] could not be verified");
+    expect(shipped.stack).toContain("ID [digits] could not be verified");
+    expect(shipped.stack).not.toContain("12345678901");
+  });
+
   it("logs a no-op callback at info without claiming a promotion", () => {
     const log = buildKycLog({
       step: "id_callback",

--- a/__tests__/kyc-telemetry.test.ts
+++ b/__tests__/kyc-telemetry.test.ts
@@ -1,0 +1,270 @@
+/**
+ * KYC telemetry: step outcomes → flattened `@kyc.*` Datadog facets, the PII
+ * masking that guards them, and emission through the shared pino logger.
+ */
+// Relative specifier: jest's moduleNameMapper rewrites "@/x" to "<rootDir>/app/x",
+// which cannot resolve the "@/app/..." form that jest.mock needs to match.
+// The mock is built inside the factory because jest hoists this call above any
+// const declared above it.
+jest.mock("../app/lib/logger", () => {
+  const mock = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return { __esModule: true, default: mock, logger: mock };
+});
+
+// dd-trace is patched into the process at boot in production; here it only
+// needs to hand back a span whose tags the assertions can read.
+const addTags = jest.fn();
+const activeSpan: { addTags: jest.Mock } | null = { addTags };
+jest.mock("dd-trace", () => ({
+  __esModule: true,
+  default: {
+    scope: () => ({ active: () => (activeSpan as unknown) }),
+  },
+}));
+
+import loggerModule from "../app/lib/logger";
+
+const mockLogger = loggerModule as unknown as {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+};
+
+import {
+  KYC_EVENT_MESSAGE,
+  buildKycLog,
+  createKycReporter,
+  emitKycEvent,
+  sanitizeDetail,
+} from "@/app/lib/kyc-telemetry";
+
+const kycAttrs = (log: { attributes: Record<string, unknown> }) =>
+  log.attributes.kyc as Record<string, unknown>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("buildKycLog", () => {
+  it("flattens a successful tier 2 upgrade as info", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "success",
+      walletAddress: "0xAbCdEf",
+      tierFrom: 1,
+      tierTo: 2,
+      jobId: "job-1",
+      durationMs: 940,
+    });
+
+    expect(log.message).toBe(KYC_EVENT_MESSAGE);
+    expect(log.status).toBe("info");
+    expect(log.attributes.feature).toBe("kyc");
+    expect(kycAttrs(log)).toMatchObject({
+      step: "id_verification",
+      outcome: "success",
+      ok: true,
+      promoted: true,
+      tier_from: 1,
+      tier_to: 2,
+      duration_ms: 940,
+    });
+  });
+
+  it("lower-cases the wallet address so a search matches any casing", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "success",
+      walletAddress: "0xAbCdEf0123",
+    });
+
+    expect(kycAttrs(log).wallet_address).toBe("0xabcdef0123");
+  });
+
+  it("carries the provider's own rejection text at warn", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "rejected",
+      reason: "provider_rejected",
+      detail: "Selfie does not match ID photo",
+      failureCategory: "mismatch",
+      providerCode: 1012,
+      attempt: 2,
+      attemptsRemaining: 1,
+    });
+
+    expect(log.status).toBe("warn");
+    expect(kycAttrs(log)).toMatchObject({
+      outcome: "rejected",
+      ok: false,
+      reason: "provider_rejected",
+      detail: "Selfie does not match ID photo",
+      failure_category: "mismatch",
+      // Stringified so the facet has one type whatever the provider returns.
+      provider_code: "1012",
+      attempt: 2,
+      attempts_remaining: 1,
+    });
+  });
+
+  it("logs an infrastructure failure at error with error.* for Error Tracking", () => {
+    const log = buildKycLog({
+      step: "address_verification",
+      outcome: "error",
+      reason: "provider_request_failed",
+      error: new TypeError("fetch failed"),
+    });
+
+    expect(log.status).toBe("error");
+    expect(log.attributes.error).toMatchObject({
+      kind: "TypeError",
+      message: "fetch failed",
+    });
+  });
+
+  it("logs a no-op callback at info without claiming a promotion", () => {
+    const log = buildKycLog({
+      step: "id_callback",
+      outcome: "noop",
+      reason: "already_verified",
+    });
+
+    expect(log.status).toBe("info");
+    expect(kycAttrs(log).ok).toBe(false);
+  });
+
+  it("drops empty facets rather than shipping nulls", () => {
+    const log = buildKycLog({
+      step: "status",
+      outcome: "error",
+      detail: null,
+      jobId: "",
+      tierFrom: undefined,
+    });
+
+    const attrs = kycAttrs(log);
+    expect(attrs).not.toHaveProperty("detail");
+    expect(attrs).not.toHaveProperty("job_id");
+    expect(attrs).not.toHaveProperty("tier_from");
+    // A real zero still has to survive.
+    expect(kycAttrs(buildKycLog({ step: "status", outcome: "error", tierFrom: 0 })).tier_from).toBe(0);
+  });
+
+  it("omits `promoted` when only one side of the tier change is known", () => {
+    const log = buildKycLog({
+      step: "phone_otp_verify",
+      outcome: "rejected",
+      tierFrom: 0,
+    });
+
+    expect(kycAttrs(log)).not.toHaveProperty("promoted");
+  });
+});
+
+describe("sanitizeDetail", () => {
+  // Smile ID and Dojah quote the input that failed, so a rejection message can
+  // arrive carrying the very ID number we must never log.
+  it("masks ID-number-length digit runs", () => {
+    expect(sanitizeDetail("ID 12345678901 could not be verified")).toBe(
+      "ID [digits] could not be verified",
+    );
+  });
+
+  it("leaves short numbers — result codes, tiers — readable", () => {
+    expect(sanitizeDetail("ResultCode 1012 on tier 2")).toBe(
+      "ResultCode 1012 on tier 2",
+    );
+  });
+
+  it("masks email addresses", () => {
+    expect(sanitizeDetail("no record for user@example.com")).toBe(
+      "no record for [email]",
+    );
+  });
+
+  it("truncates a pathological message", () => {
+    const masked = sanitizeDetail("x".repeat(900));
+    expect(masked).toHaveLength(501);
+    expect(masked.endsWith("…")).toBe(true);
+  });
+});
+
+describe("emitKycEvent", () => {
+  it("routes each outcome to the matching pino level", () => {
+    emitKycEvent({ step: "phone_otp_send", outcome: "success" });
+    emitKycEvent({ step: "phone_otp_send", outcome: "rejected" });
+    emitKycEvent({ step: "phone_otp_send", outcome: "error" });
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: "kyc" }),
+      KYC_EVENT_MESSAGE,
+    );
+  });
+
+  it("mirrors the identifying facets onto the active APM span", () => {
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "rejected",
+      reason: "provider_rejected",
+      stage: "provider_verify",
+      targetTier: 2,
+    });
+
+    expect(addTags).toHaveBeenCalledWith({
+      "kyc.step": "id_verification",
+      "kyc.outcome": "rejected",
+      "kyc.reason": "provider_rejected",
+      "kyc.stage": "provider_verify",
+      "kyc.target_tier": 2,
+    });
+  });
+
+  it("never throws, whatever the caller passes", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() =>
+      emitKycEvent({
+        step: "id_verification",
+        outcome: "error",
+        error: circular,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("createKycReporter", () => {
+  it("binds base facets and stamps a duration on every exit", () => {
+    const report = createKycReporter({
+      step: "id_verification",
+      walletAddress: "0xabc",
+      targetTier: 2,
+      provider: "smile_id",
+    });
+
+    report.rejected({ reason: "attempts_exhausted", statusCode: 429 });
+
+    const [attributes] = mockLogger.warn.mock.calls[0];
+    expect(attributes.kyc).toMatchObject({
+      step: "id_verification",
+      wallet_address: "0xabc",
+      target_tier: 2,
+      provider: "smile_id",
+      reason: "attempts_exhausted",
+      status_code: 429,
+    });
+    expect(typeof attributes.kyc.duration_ms).toBe("number");
+  });
+
+  it("lets a call override a base facet — the callback learns its wallet late", () => {
+    const report = createKycReporter({ step: "id_callback", targetTier: 2 });
+
+    report.success({ walletAddress: "0xlate", tierFrom: 1, tierTo: 2 });
+
+    const [attributes] = mockLogger.info.mock.calls[0];
+    expect(attributes.kyc.wallet_address).toBe("0xlate");
+  });
+});

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -28,7 +28,10 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     trackApiRequest(request, "/api/kyc/signup-email", "POST");
 
     if (!walletAddress) {
-      report.rejected({ reason: "unauthorized", statusCode: 401 });
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/signup-email",

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/lib/server-analytics";
 import { getEmailForMonitoredAddress } from "@/app/utils";
 import config from "@/app/lib/config";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 /**
  * Fires the Tier 1 "verify your phone to start swapping" email (Activepieces → Brevo)
@@ -16,12 +17,16 @@ import config from "@/app/lib/config";
  */
 export const POST = withRateLimit(async (request: NextRequest) => {
   const startTime = Date.now();
+  // The nudge that starts tier 1. When it silently fails the user is never
+  // told to verify their phone, and nothing else reports it.
+  const report = createKycReporter({ step: "signup_email", targetTier: 1 });
 
   try {
     trackApiRequest(request, "/api/kyc/signup-email", "POST");
 
     const walletAddress = request.headers.get("x-wallet-address");
     if (!walletAddress) {
+      report.rejected({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/signup-email",
@@ -37,9 +42,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const webhookUrl = config.activepiecesSignupVerifyWebhookUrl;
     if (!webhookUrl) {
-      console.error(
-        "[activepieces] ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL not set — skipping signup email",
-      );
+      report.failed({
+        walletAddress,
+        stage: "signup_email_dispatch",
+        reason: "missing_webhook_config",
+        detail: "ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL is not set",
+        statusCode: 200,
+      });
       return NextResponse.json({ success: true, skipped: true });
     }
 
@@ -47,6 +56,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     // wallet/passkey signups without an email are silently skipped.
     const email = await getEmailForMonitoredAddress(walletAddress);
     if (!email) {
+      // Wallet and passkey signups have no email — expected, not a failure.
+      report.noop({
+        walletAddress,
+        stage: "signup_email_dispatch",
+        reason: "no_email_on_identity",
+        statusCode: 200,
+      });
       return NextResponse.json({ success: true, skipped: true });
     }
 
@@ -77,8 +93,21 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/kyc/signup-email", "POST", 200, responseTime);
+    report.success({
+      walletAddress,
+      stage: "signup_email_dispatch",
+      statusCode: 200,
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
+    // Covers the webhook's own non-2xx, which is thrown above.
+    report.failed({
+      stage: "signup_email_dispatch",
+      reason: "webhook_failed",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(
       request,
       "/api/kyc/signup-email",

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -20,11 +20,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
   // The nudge that starts tier 1. When it silently fails the user is never
   // told to verify their phone, and nothing else reports it.
   const report = createKycReporter({ step: "signup_email", targetTier: 1 });
+  // Read outside the try so the catch below can still name the user. The
+  // header is set by the middleware and reading it cannot throw.
+  const walletAddress = request.headers.get("x-wallet-address");
 
   try {
     trackApiRequest(request, "/api/kyc/signup-email", "POST");
 
-    const walletAddress = request.headers.get("x-wallet-address");
     if (!walletAddress) {
       report.rejected({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
@@ -102,6 +104,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
   } catch (error) {
     // Covers the webhook's own non-2xx, which is thrown above.
     report.failed({
+      walletAddress,
       stage: "signup_email_dispatch",
       reason: "webhook_failed",
       detail: error instanceof Error ? error.message : String(error),

--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
 import { getSmileIdJobStatus } from "@/app/lib/smileID";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 // The callback signature only covers timestamp + partner_id (per SmileID's
 // protocol), NOT the body. A captured (timestamp, signature) pair could be
@@ -41,10 +42,23 @@ function confirmSmileSignature(
 }
 
 export async function POST(request: NextRequest) {
+  // The wallet is only known once the body is parsed, so the reporter starts
+  // without one and each call supplies it as soon as it is available.
+  const report = createKycReporter({
+    step: "id_callback",
+    targetTier: 2,
+    provider: "smile_id",
+  });
+
   let body: Record<string, any>;
   try {
     body = await request.json();
   } catch {
+    report.rejected({
+      stage: "request_validation",
+      reason: "invalid_json",
+      statusCode: 400,
+    });
     return NextResponse.json({ status: "error", message: "Invalid JSON" }, { status: 400 });
   }
 
@@ -52,7 +66,13 @@ export async function POST(request: NextRequest) {
   const apiKey = process.env.SMILE_IDENTITY_API_KEY;
 
   if (!partnerId || !apiKey) {
-    console.error("[smile-id/callback] Missing SMILE_IDENTITY_PARTNER_ID or SMILE_IDENTITY_API_KEY");
+    report.failed({
+      stage: "provider_config",
+      reason: "missing_provider_config",
+      detail:
+        "SMILE_IDENTITY_PARTNER_ID or SMILE_IDENTITY_API_KEY is not set",
+      statusCode: 500,
+    });
     return NextResponse.json({ status: "error", message: "Server misconfiguration" }, { status: 500 });
   }
 
@@ -60,6 +80,11 @@ export async function POST(request: NextRequest) {
   const { timestamp, signature } = body;
 
   if (!timestamp || !signature) {
+    report.rejected({
+      stage: "signature_check",
+      reason: "missing_signature_fields",
+      statusCode: 400,
+    });
     return NextResponse.json(
       { status: "error", message: "Missing signature fields" },
       { status: 400 },
@@ -74,7 +99,12 @@ export async function POST(request: NextRequest) {
   );
 
   if (!isValid) {
-    console.warn("[smile-id/callback] Signature verification failed", { timestamp });
+    // Worth alerting on: a genuine Smile ID callback never fails this.
+    report.rejected({
+      stage: "signature_check",
+      reason: "invalid_signature",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Invalid signature" },
       { status: 401 },
@@ -87,7 +117,11 @@ export async function POST(request: NextRequest) {
     timestampMs === null ||
     Math.abs(Date.now() - timestampMs) > MAX_CALLBACK_AGE_MS
   ) {
-    console.warn("[smile-id/callback] Stale or unparseable timestamp", { timestamp });
+    report.rejected({
+      stage: "signature_check",
+      reason: "stale_callback",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Stale callback" },
       { status: 401 },
@@ -103,7 +137,11 @@ export async function POST(request: NextRequest) {
     : rawUserId;
 
   if (!walletAddress) {
-    console.error("[smile-id/callback] Could not extract wallet address", { rawUserId });
+    report.failed({
+      stage: "request_validation",
+      reason: "missing_user_identifier",
+      statusCode: 400,
+    });
     return NextResponse.json(
       { status: "error", message: "Missing user identifier" },
       { status: 400 },
@@ -128,19 +166,42 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
 
   if (fetchError) {
-    console.error("[smile-id/callback] Failed to fetch profile", { walletAddress, fetchError });
+    report.failed({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: fetchError.code,
+      detail: fetchError.message,
+      jobId,
+      statusCode: 500,
+    });
     // Return 500 so SmileID retries delivery.
     return NextResponse.json({ status: "error", message: "Database error" }, { status: 500 });
   }
 
   if (!existing) {
-    console.warn("[smile-id/callback] No KYC profile found for wallet", { walletAddress });
+    report.rejected({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "no_kyc_profile",
+      jobId,
+      statusCode: 200,
+    });
     return NextResponse.json({ status: "ok", action: "none" });
   }
 
   // Already verified at tier 2+ — the sync response handled it; nothing to do.
   if (existing.verified && Number(existing.tier) >= 2) {
-    console.log("[smile-id/callback] Profile already verified, skipping", { walletAddress });
+    // The expected path: the synchronous submission already promoted them.
+    report.noop({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "already_verified",
+      tierFrom: Number(existing.tier) || 0,
+      jobId,
+      statusCode: 200,
+    });
     return NextResponse.json({ status: "ok", action: "already_verified" });
   }
 
@@ -148,8 +209,12 @@ export async function POST(request: NextRequest) {
   // Body fields are not covered by the callback signature; only proceed if
   // SmileID's signed job_status API reports the same success.
   if (!jobId) {
-    console.warn("[smile-id/callback] Missing job_id, cannot confirm job — no action", {
+    report.rejected({
       walletAddress,
+      stage: "job_status_confirm",
+      reason: "missing_job_id",
+      tierFrom: Number(existing.tier) || 0,
+      statusCode: 200,
     });
     return NextResponse.json({ status: "ok", action: "none" });
   }
@@ -168,12 +233,20 @@ export async function POST(request: NextRequest) {
     if (!confirmed) {
       // Covers failed/incomplete jobs too: SmileID sends callbacks for those,
       // and the signed status is the only outcome we act on.
-      console.log("[smile-id/callback] job_status did not confirm verification — no action", {
+      // A failed or still-incomplete job. Smile ID calls back for both, and
+      // the signed status is the only outcome we act on — so this is where an
+      // asynchronously rejected upgrade becomes visible.
+      report.rejected({
         walletAddress,
+        stage: "job_status_confirm",
+        reason: "provider_rejected",
+        detail:
+          (jobStatus?.result?.ResultText as string) ??
+          `job_complete=${jobStatus?.job_complete} job_success=${jobStatus?.job_success}`,
+        providerCode: jobStatus?.result?.ResultCode,
+        tierFrom: Number(existing.tier) || 0,
         jobId,
-        job_complete: jobStatus?.job_complete,
-        job_success: jobStatus?.job_success,
-        ResultCode: jobStatus?.result?.ResultCode,
+        statusCode: 200,
       });
       return NextResponse.json({ status: "ok", action: "none" });
     }
@@ -181,10 +254,14 @@ export async function POST(request: NextRequest) {
     const statusResult = (jobStatus?.result ?? {}) as Record<string, any>;
     signedIdInfo = statusResult.id_info ?? statusResult.ID_Info ?? {};
   } catch (e) {
-    console.error("[smile-id/callback] job_status confirmation failed", {
+    report.failed({
       walletAddress,
+      stage: "job_status_confirm",
+      reason: "provider_status_failed",
+      detail: e instanceof Error ? e.message : String(e),
+      error: e,
       jobId,
-      error: e instanceof Error ? e.message : e,
+      statusCode: 500,
     });
     // 500 so SmileID retries once the status API is reachable again.
     return NextResponse.json(
@@ -235,9 +312,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (idOwnerError) {
-      console.error("[smile-id/callback] ID ownership check failed", {
+      report.failed({
         walletAddress,
-        idOwnerError,
+        stage: "duplicate_id_check",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: idOwnerError.code,
+        detail: idOwnerError.message,
+        jobId,
+        statusCode: 500,
       });
       // Transient: 500 so SmileID retries.
       return NextResponse.json(
@@ -247,10 +330,14 @@ export async function POST(request: NextRequest) {
     }
 
     if (idOwner) {
-      console.warn(
-        "[smile-id/callback] ID document already verified on another wallet — skipping tier promotion",
-        { walletAddress, jobId },
-      );
+      report.rejected({
+        walletAddress,
+        stage: "duplicate_id_check",
+        reason: "duplicate_id_document",
+        tierFrom: currentTier,
+        jobId,
+        statusCode: 200,
+      });
       // 200: the conflict is permanent, so retrying would loop forever.
       return NextResponse.json({
         status: "ok",
@@ -275,24 +362,43 @@ export async function POST(request: NextRequest) {
     // Same conflict, lost to a concurrent verification after the check above.
     // Still permanent — do not ask SmileID to retry.
     if (updateError.code === "23505") {
-      console.warn(
-        "[smile-id/callback] Tier promotion hit the verified-ID unique index",
-        { walletAddress, jobId },
-      );
+      report.rejected({
+        walletAddress,
+        stage: "profile_update",
+        reason: "duplicate_id_document",
+        provider: "supabase",
+        providerCode: updateError.code,
+        tierFrom: currentTier,
+        jobId,
+        statusCode: 200,
+      });
       return NextResponse.json({
         status: "ok",
         action: "duplicate_id_conflict",
       });
     }
-    console.error("[smile-id/callback] Failed to update profile", { walletAddress, updateError });
+    report.failed({
+      walletAddress,
+      stage: "profile_update",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: updateError.code,
+      detail: updateError.message,
+      tierFrom: currentTier,
+      jobId,
+      statusCode: 500,
+    });
     // Return 500 so SmileID retries.
     return NextResponse.json({ status: "error", message: "Database update failed" }, { status: 500 });
   }
 
-  console.log("[smile-id/callback] Profile verified via async callback", {
+  report.success({
     walletAddress,
+    stage: "profile_update",
+    tierFrom: currentTier,
+    tierTo: newTier,
     jobId,
-    newTier,
+    statusCode: 200,
   });
 
   // Notify once, only on the first promotion to tier 2. Earlier guards already

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -11,6 +11,7 @@ import idTypesData from "./id_types.json";
 
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, emitKycEvent } from "@/app/lib/kyc-telemetry";
 
 /**
  * Country|ID-type pairs the app actually offers. The KYC modal builds its
@@ -55,6 +56,13 @@ export async function POST(request: NextRequest) {
   // Rate limit check
   const rateLimitResult = await rateLimit(request);
   if (!rateLimitResult.success) {
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "rejected",
+      targetTier: 2,
+      reason: "rate_limited",
+      statusCode: 429,
+    });
     return NextResponse.json(
       {
         status: "error",
@@ -68,11 +76,27 @@ export async function POST(request: NextRequest) {
   const walletAddress = request.headers.get("x-wallet-address");
 
   if (!walletAddress) {
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "rejected",
+      targetTier: 2,
+      reason: "unauthorized",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Unauthorized" },
       { status: 401 },
     );
   }
+
+  // Every exit below reports through this, so no verification outcome — least
+  // of all a provider rejection — leaves the route without a Datadog line.
+  const report = createKycReporter({
+    step: "id_verification",
+    walletAddress,
+    targetTier: 2,
+    provider: "smile_id",
+  });
 
   try {
     const body = await request.json();
@@ -80,6 +104,11 @@ export async function POST(request: NextRequest) {
 
     // Validate required fields
     if (!images || !Array.isArray(images) || images.length === 0) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "invalid_images",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { status: "error", message: "Invalid images data" },
         { status: 400 },
@@ -88,6 +117,11 @@ export async function POST(request: NextRequest) {
 
     // Validate id_info for Job Type 1 (Biometric KYC)
     if (!id_info?.country || !id_info?.id_type) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_id_info",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -97,9 +131,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Country|ID-type is known from here on: carried on every line so
+    // "which ID types fail most" is a group-by rather than an investigation.
+    const idContext = {
+      idCountry: id_info.country,
+      idType: id_info.id_type,
+    };
+
     // Reject unsupported pairs before the attempt counter is incremented, so a
     // request Smile ID can never verify does not burn one of the user's tries.
     if (!isSupportedCountryIdType(id_info.country, id_info.id_type)) {
+      report.rejected({
+        ...idContext,
+        stage: "request_validation",
+        reason: "unsupported_id_type",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -118,6 +165,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
     if (profileFetchError) {
+      report.failed({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: profileFetchError.code,
+        detail: profileFetchError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -128,6 +184,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!existingProfile) {
+      report.rejected({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "no_kyc_profile",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -139,6 +201,13 @@ export async function POST(request: NextRequest) {
     }
 
     if (existingProfile.tier < 1) {
+      report.rejected({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "phone_verification_required",
+        tierFrom: Number(existingProfile.tier) || 0,
+        statusCode: 403,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -149,18 +218,38 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const tierFrom = Number(existingProfile.tier) || 0;
+
     // Tier 2 allows up to 3 attempts
+    const MAX_ATTEMPTS = 3;
     const { data: newAttemptCount, error: rpcError } = await supabaseAdmin.rpc(
       "increment_kyc_attempts",
-      { p_wallet_address: walletAddress, p_max_attempts: 3 },
+      { p_wallet_address: walletAddress, p_max_attempts: MAX_ATTEMPTS },
     );
     if (rpcError) {
+      report.failed({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: rpcError.code,
+        detail: rpcError.message,
+        tierFrom,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { status: "error", message: "Failed to process verification attempt." },
         { status: 500 },
       );
     }
     if (newAttemptCount === -1) {
+      report.rejected({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "no_kyc_profile",
+        tierFrom,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -170,6 +259,17 @@ export async function POST(request: NextRequest) {
       );
     }
     if (newAttemptCount === -2) {
+      // The user is now stuck until support intervenes — the one rejection
+      // that always needs a human, so it must be findable by wallet address.
+      report.rejected({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "attempts_exhausted",
+        tierFrom,
+        attempt: MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -178,6 +278,11 @@ export async function POST(request: NextRequest) {
         { status: 429 },
       );
     }
+
+    const attemptContext = {
+      attempt: Number(newAttemptCount) || null,
+      attemptsRemaining: Math.max(0, MAX_ATTEMPTS - (Number(newAttemptCount) || 0)),
+    };
 
     // Use server utility to submit SmileID job
     type SmileIdResultType = {
@@ -201,11 +306,33 @@ export async function POST(request: NextRequest) {
       user_id = result.user_id;
     } catch (err) {
       if (err instanceof SmileIdValidationError) {
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "provider_submit",
+          reason: "id_info_validation_failed",
+          detail: err.message,
+          tierFrom,
+          statusCode: 400,
+        });
         return NextResponse.json(
           { status: "error", message: err.message },
           { status: 400 },
         );
       }
+      // Misconfiguration and Smile ID transport failures both land here, and
+      // both look identical to the user ("verification failed").
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "provider_submit",
+        reason: "provider_request_failed",
+        detail: err instanceof Error ? err.message : String(err),
+        error: err,
+        tierFrom,
+        jobType: getJobTypeForIdType(id_info.id_type),
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -237,23 +364,55 @@ export async function POST(request: NextRequest) {
         smileIdResult?.ResultText || "SmileID verification failed";
       const category = classifySmileIdFailure(errorMessage);
 
+      const isInfrastructureFailure = category === "database";
+
+      // The line support reads. `detail` is Smile ID's own ResultText — the
+      // actual reason the upgrade failed — and the category decides whether
+      // this is a user-facing rejection or an outage worth paging on.
+      const outcomeContext = {
+        ...idContext,
+        ...attemptContext,
+        // The refund below restores the try, so report what the user can
+        // actually retry with rather than the pre-refund count. If the refund
+        // itself fails it gets its own line.
+        attemptsRemaining: isInfrastructureFailure
+          ? Math.max(0, MAX_ATTEMPTS - Math.max(0, newAttemptCount - 1))
+          : attemptContext.attemptsRemaining,
+        stage: "provider_verify",
+        detail: errorMessage,
+        failureCategory: category,
+        providerCode: smileIdResult?.ResultCode,
+        jobId: job_id,
+        jobType: getJobTypeForIdType(id_info.id_type),
+        tierFrom,
+        statusCode: 400,
+      };
+      if (isInfrastructureFailure) {
+        report.failed({ ...outcomeContext, reason: "provider_unavailable" });
+      } else {
+        report.rejected({ ...outcomeContext, reason: "provider_rejected" });
+      }
+
       // Infrastructure outages should not count against the user's attempt quota
       // regardless of job type (Job Type 1, 5, or 6). Restore the counter that
       // was incremented above so they can retry freely.
-      if (category === "database") {
-        console.warn("[smile-id] infrastructure failure detected — restoring attempt counter", {
-          walletAddress,
-          jobType: getJobTypeForIdType(id_info.id_type),
-          resultText: errorMessage,
-        });
+      if (isInfrastructureFailure) {
         const { error: restoreError } = await supabaseAdmin
           .from("user_kyc_profiles")
           .update({ attempts: Math.max(0, newAttemptCount - 1) })
           .eq("wallet_address", walletAddress);
         if (restoreError) {
-          console.error("[smile-id] failed to restore attempt counter after infrastructure failure", {
-            walletAddress,
-            error: restoreError.message,
+          // The user keeps a try they should have been refunded — silent to
+          // them, and only visible here.
+          report.failed({
+            ...idContext,
+            ...attemptContext,
+            stage: "attempt_restore",
+            reason: "supabase_error",
+            provider: "supabase",
+            providerCode: restoreError.code,
+            detail: restoreError.message,
+            tierFrom,
           });
         }
       }
@@ -302,9 +461,7 @@ export async function POST(request: NextRequest) {
     ];
 
     // Tier 2 (ID) only after Tier 1 (phone): do not promote from tier 0 straight to 2
-    const currentTier = Number(existingProfile?.tier) || 0;
-    const newTier =
-      currentTier >= 1 ? Math.max(currentTier, 2) : currentTier;
+    const newTier = tierFrom >= 1 ? Math.max(tierFrom, 2) : tierFrom;
 
     const derivedFullName =
       smileIdInfo.full_name ||
@@ -338,12 +495,35 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
       if (idOwnerError) {
+        report.failed({
+          ...idContext,
+          ...attemptContext,
+          stage: "duplicate_id_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: idOwnerError.code,
+          detail: idOwnerError.message,
+          tierFrom,
+          jobId: job_id,
+          statusCode: 500,
+        });
         return NextResponse.json(
           { status: "error", message: "Failed to save KYC data" },
           { status: 500 },
         );
       }
       if (idOwner) {
+        // Smile ID verified them; we refused. Support cannot resolve this
+        // without knowing it happened, and the user is told to contact them.
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "duplicate_id_check",
+          reason: "duplicate_id_document",
+          tierFrom,
+          jobId: job_id,
+          statusCode: 409,
+        });
         return NextResponse.json(
           {
             status: "error",
@@ -379,6 +559,17 @@ export async function POST(request: NextRequest) {
       // 23505: partial unique index on verified ID documents (concurrent
       // verification of the same document on another non-injected wallet).
       if (supabaseError.code === "23505") {
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "profile_update",
+          reason: "duplicate_id_document",
+          provider: "supabase",
+          providerCode: supabaseError.code,
+          tierFrom,
+          jobId: job_id,
+          statusCode: 409,
+        });
         return NextResponse.json(
           {
             status: "error",
@@ -388,6 +579,20 @@ export async function POST(request: NextRequest) {
           { status: 409 },
         );
       }
+      // Verification passed and the write failed: the worst case, because the
+      // user has spent an attempt on a document that did verify.
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: supabaseError.code,
+        detail: supabaseError.message,
+        tierFrom,
+        jobId: job_id,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -399,6 +604,16 @@ export async function POST(request: NextRequest) {
 
     // Verify that a row was actually updated
     if (!updatedProfile || updatedProfile.length === 0) {
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "no_rows_updated",
+        provider: "supabase",
+        tierFrom,
+        jobId: job_id,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -419,13 +634,24 @@ export async function POST(request: NextRequest) {
     // skips when the profile is already verified, so this won't double-send).
     // Resolve the recipient from the authenticated wallet (never the client-supplied
     // `email`) and dispatch after the response so webhook latency can't block KYC.
-    if (newTier >= 2 && currentTier < 2) {
+    if (newTier >= 2 && tierFrom < 2) {
       notifyKycResultEmail(walletAddress, {
         event: "kyc_result",
         status: "success",
         tier: newTier,
       });
     }
+
+    report.success({
+      ...idContext,
+      ...attemptContext,
+      stage: "profile_update",
+      tierFrom,
+      tierTo: newTier,
+      jobId: job_id,
+      jobType: getJobTypeForIdType(id_info.id_type),
+      statusCode: 200,
+    });
 
     return NextResponse.json({
       status: "success",
@@ -436,6 +662,13 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     return NextResponse.json(
       {
         status: "error",

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -76,9 +76,12 @@ export async function POST(request: NextRequest) {
   const walletAddress = request.headers.get("x-wallet-address");
 
   if (!walletAddress) {
+    // Not an unauthenticated user: middleware matches this route, turns those
+    // away with its own 401, and strips forged wallet headers. Reaching the
+    // handler without one means the matcher or header propagation broke.
     emitKycEvent({
       step: "id_verification",
-      outcome: "rejected",
+      outcome: "error",
       targetTier: 2,
       reason: "unauthorized",
       statusCode: 401,

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -16,14 +16,15 @@ export async function GET(request: NextRequest) {
   // Failures only. Every KYC surface polls this endpoint, so logging its
   // successes would bury the upgrade steps that matter.
   const report = createKycReporter({ step: "status" });
+  // Get the wallet address from the header set by the middleware. Read outside
+  // the try so the catch below can still name the user.
+  const walletAddress = request.headers.get("x-wallet-address");
 
   try {
     trackApiRequest(request, "/api/kyc/status", "GET");
 
-    // Get the wallet address from the header set by the middleware
-    const walletAddress = request.headers.get("x-wallet-address");
-
     if (!walletAddress) {
+      report.rejected({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/status",
@@ -147,6 +148,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     report.failed({
+      walletAddress,
       stage: "unhandled",
       reason: "unexpected_error",
       detail: error instanceof Error ? error.message : String(error),

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -9,9 +9,13 @@ import {
   trackApiResponse,
   trackApiError,
 } from "@/app/lib/server-analytics";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
+  // Failures only. Every KYC surface polls this endpoint, so logging its
+  // successes would bury the upgrade steps that matter.
+  const report = createKycReporter({ step: "status" });
 
   try {
     trackApiRequest(request, "/api/kyc/status", "GET");
@@ -41,6 +45,15 @@ export async function GET(request: NextRequest) {
       .maybeSingle();
 
     if (kycProfileError) {
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: kycProfileError.code,
+        detail: kycProfileError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/kyc/status",
@@ -69,6 +82,17 @@ export async function GET(request: NextRequest) {
       pooledWalletCount = scope.wallets.length;
       scopeWallets = scope.wallets;
     } catch (scopeError) {
+      // The identity scope decides which tier and limit the UI shows, so a
+      // failure here reads to the user as a lost verification.
+      report.failed({
+        walletAddress,
+        stage: "identity_scope",
+        reason: "identity_scope_failed",
+        detail:
+          scopeError instanceof Error ? scopeError.message : String(scopeError),
+        error: scopeError,
+        statusCode: 500,
+      });
       trackApiError(request, "/api/kyc/status", "GET", scopeError as Error, 500);
       return NextResponse.json(
         { success: false, error: "Failed to load KYC profile" },
@@ -93,10 +117,19 @@ export async function GET(request: NextRequest) {
         identityHasVerifiedPhone =
           await identityScopeHasVerifiedPhone(scopeWallets);
       } catch (phoneScopeError) {
-        console.error(
-          "[kyc/status] identity phone lookup failed:",
-          phoneScopeError,
-        );
+        // Fail-soft: the per-wallet answer still stands, but a tier 2 user
+        // whose phone lives on a sibling wallet can loop on the phone gate.
+        report.failed({
+          walletAddress,
+          stage: "identity_phone_lookup",
+          reason: "identity_phone_lookup_failed",
+          detail:
+            phoneScopeError instanceof Error
+              ? phoneScopeError.message
+              : String(phoneScopeError),
+          error: phoneScopeError,
+          tierFrom: tier,
+        });
       }
     }
 
@@ -113,6 +146,13 @@ export async function GET(request: NextRequest) {
       fullName: kycProfile?.full_name || null,
     });
   } catch (error) {
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(request, '/api/kyc/status', 'GET', error as Error, 500);
     
     return NextResponse.json(

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -24,7 +24,10 @@ export async function GET(request: NextRequest) {
     trackApiRequest(request, "/api/kyc/status", "GET");
 
     if (!walletAddress) {
-      report.rejected({ reason: "unauthorized", statusCode: 401 });
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/status",

--- a/app/api/kyc/tier3-verify/route.ts
+++ b/app/api/kyc/tier3-verify/route.ts
@@ -46,9 +46,12 @@ export async function POST(request: NextRequest) {
 
   const walletAddress = request.headers.get("x-wallet-address");
   if (!walletAddress) {
+    // Not an unauthenticated user: middleware matches this route, turns those
+    // away with its own 401, and strips forged wallet headers. Reaching the
+    // handler without one means the matcher or header propagation broke.
     emitKycEvent({
       step: "address_verification",
-      outcome: "rejected",
+      outcome: "error",
       targetTier: 3,
       reason: "unauthorized",
       statusCode: 401,

--- a/app/api/kyc/tier3-verify/route.ts
+++ b/app/api/kyc/tier3-verify/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/lib/dojah";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, emitKycEvent } from "@/app/lib/kyc-telemetry";
 const KYC_BUCKET = process.env.KYC_DOCUMENTS_BUCKET || "kyc-documents";
 // Countries where a street address cannot be meaningfully validated (PO Box culture,
 // no formal street addressing, etc.). Expand as needed.
@@ -30,6 +31,13 @@ const MIME_TO_EXT: Record<string, string> = {
 export async function POST(request: NextRequest) {
   const rateLimitResult = await rateLimit(request);
   if (!rateLimitResult.success) {
+    emitKycEvent({
+      step: "address_verification",
+      outcome: "rejected",
+      targetTier: 3,
+      reason: "rate_limited",
+      statusCode: 429,
+    });
     return NextResponse.json(
       { success: false, error: "Too many requests. Please try again later." },
       { status: 429 },
@@ -38,11 +46,25 @@ export async function POST(request: NextRequest) {
 
   const walletAddress = request.headers.get("x-wallet-address");
   if (!walletAddress) {
+    emitKycEvent({
+      step: "address_verification",
+      outcome: "rejected",
+      targetTier: 3,
+      reason: "unauthorized",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 401 },
     );
   }
+
+  const report = createKycReporter({
+    step: "address_verification",
+    walletAddress,
+    targetTier: 3,
+    provider: "dojah",
+  });
 
   try {
     const formData = await request.formData();
@@ -62,6 +84,12 @@ export async function POST(request: NextRequest) {
 
     const validatedDocumentType = documentType.trim();
     if (validatedDocumentType !== ALLOWED_DOCUMENT_TYPE) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "unsupported_document_type",
+        detail: validatedDocumentType || "(empty)",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -73,12 +101,22 @@ export async function POST(request: NextRequest) {
     }
 
     if (!file || file.size === 0) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_document",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Document file is required" },
         { status: 400 },
       );
     }
     if (!countryCode?.trim()) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_country",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Country is required" },
         { status: 400 },
@@ -93,6 +131,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (fetchError) {
+      report.failed({
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: fetchError.code,
+        detail: fetchError.message,
+        idCountry: trimmedCountry,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -103,6 +150,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!currentProfile) {
+      report.rejected({
+        stage: "profile_fetch",
+        reason: "no_kyc_profile",
+        idCountry: trimmedCountry,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -115,6 +168,13 @@ export async function POST(request: NextRequest) {
 
     const currentTier = Number(currentProfile.tier) ?? 0;
     if (currentTier !== 2) {
+      report.rejected({
+        stage: "profile_fetch",
+        reason: "tier_prerequisite_missing",
+        tierFrom: currentTier,
+        idCountry: trimmedCountry,
+        statusCode: 403,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -125,8 +185,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Country and starting tier are known from here on — carried on every line
+    // so tier 3 failures can be grouped by corridor.
+    const addressContext = {
+      idCountry: trimmedCountry,
+      tierFrom: currentTier,
+    };
+
     // Validate file and address fields before consuming an attempt — cheap checks first
     if (file.size > MAX_FILE_BYTES) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "file_too_large",
+        detail: `${file.size} bytes`,
+        statusCode: 413,
+      });
       return NextResponse.json(
         { success: false, error: "File too large; maximum 5 MB" },
         { status: 413 },
@@ -136,6 +210,13 @@ export async function POST(request: NextRequest) {
     if (
       !ALLOWED_MIME_TYPES.includes(mime as (typeof ALLOWED_MIME_TYPES)[number])
     ) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "unsupported_file_type",
+        detail: mime || "(none)",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -150,6 +231,12 @@ export async function POST(request: NextRequest) {
       !STREET_ADDRESS_OPTIONAL_COUNTRIES.has(trimmedCountry.toUpperCase()) &&
       !streetAddress?.trim()
     ) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "missing_street_address",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Street address is required" },
         { status: 400 },
@@ -157,17 +244,33 @@ export async function POST(request: NextRequest) {
     }
 
     // Tier 3 allows up to 5 attempts (document issues are more common than ID issues)
+    const MAX_ATTEMPTS = 5;
     const { data: newAttemptCount, error: rpcError } = await supabaseAdmin.rpc(
       "increment_kyc_attempts",
-      { p_wallet_address: walletAddress, p_max_attempts: 5 },
+      { p_wallet_address: walletAddress, p_max_attempts: MAX_ATTEMPTS },
     );
     if (rpcError) {
+      report.failed({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: rpcError.code,
+        detail: rpcError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { success: false, error: "Failed to process verification attempt." },
         { status: 500 },
       );
     }
     if (newAttemptCount === -1) {
+      report.rejected({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "no_kyc_profile",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -178,6 +281,14 @@ export async function POST(request: NextRequest) {
       );
     }
     if (newAttemptCount === -2) {
+      report.rejected({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "attempts_exhausted",
+        attempt: MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -187,6 +298,14 @@ export async function POST(request: NextRequest) {
         { status: 429 },
       );
     }
+
+    const attemptContext = {
+      attempt: Number(newAttemptCount) || null,
+      attemptsRemaining: Math.max(
+        0,
+        MAX_ATTEMPTS - (Number(newAttemptCount) || 0),
+      ),
+    };
 
     const nameExt = file.name?.split(".").pop();
     const ext =
@@ -215,6 +334,17 @@ export async function POST(request: NextRequest) {
         ? `${msg} Create the "${KYC_BUCKET}" bucket in Supabase (Dashboard → Storage, or migration), or set KYC_DOCUMENTS_BUCKET to an existing private bucket.`
         : msg ||
           "Failed to upload document. Ensure the KYC storage bucket exists.";
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "document_upload",
+        // A missing bucket is a deployment fault, not a transient one — worth
+        // telling apart at a glance in the Logs Explorer.
+        reason: bucketMissing ? "storage_bucket_missing" : "storage_error",
+        provider: "supabase",
+        detail: msg,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { success: false, error: errorText },
         { status: 500 },
@@ -229,6 +359,15 @@ export async function POST(request: NextRequest) {
     const signedUrl = signedUrlData?.signedUrl;
     if (signError || !signedUrl) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "signed_url",
+        reason: "storage_error",
+        provider: "supabase",
+        detail: signError?.message ?? "no signed URL returned",
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -250,19 +389,31 @@ export async function POST(request: NextRequest) {
       const msg =
         dojahResult?.entity?.result?.message ||
         "Document could not be verified as a valid proof of address.";
-      console.error("[tier3-verify] Dojah verification failed", {
-        resultStatus: dojahResult?.entity?.result?.status,
-        resultMessage: dojahResult?.entity?.result?.message,
-        providerName: dojahResult?.entity?.provider_name,
+      // Dojah's own words for why the utility bill was refused — the tier 3
+      // equivalent of Smile ID's ResultText.
+      report.rejected({
+        ...addressContext,
+        ...attemptContext,
+        stage: "provider_verify",
+        reason: "provider_rejected",
+        detail: msg,
+        providerCode: dojahResult?.entity?.result?.status,
+        statusCode: 400,
       });
       const { error: removeError } = await supabaseAdmin.storage
         .from(KYC_BUCKET)
         .remove([path]);
       if (removeError) {
-        console.warn(
-          "[tier3-verify] failed to remove uploaded doc after Dojah failure",
-          removeError.message,
-        );
+        // The rejected document stays in the bucket — a retention problem
+        // rather than a user-facing one.
+        report.failed({
+          ...addressContext,
+          ...attemptContext,
+          stage: "document_cleanup",
+          reason: "storage_error",
+          provider: "supabase",
+          detail: removeError.message,
+        });
       }
       notifyKycResultEmail(walletAddress, {
         event: "kyc_result",
@@ -316,6 +467,18 @@ export async function POST(request: NextRequest) {
 
     if (supabaseError) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      // Dojah approved the document and we failed to record it: the user has
+      // spent an attempt and is still on tier 2.
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: supabaseError.code,
+        detail: supabaseError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -327,6 +490,14 @@ export async function POST(request: NextRequest) {
 
     if (!updatedProfile || updatedProfile.length === 0) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "no_rows_updated",
+        provider: "supabase",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -343,6 +514,14 @@ export async function POST(request: NextRequest) {
       tier: 3,
     });
 
+    report.success({
+      ...addressContext,
+      ...attemptContext,
+      stage: "profile_update",
+      tierTo: Math.max(currentTier, 3),
+      statusCode: 200,
+    });
+
     return NextResponse.json({
       success: true,
       message: "Tier 3 address verification completed",
@@ -350,7 +529,15 @@ export async function POST(request: NextRequest) {
     });
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
-    console.error("[tier3-verify] unexpected error", err);
+    // Dojah transport failures throw rather than returning a result, so this
+    // catch is a real verification outcome, not just a safety net.
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: raw,
+      error: err,
+      statusCode: 500,
+    });
     // Dojah often returns JSON in the thrown message; avoid double-encoding for clients.
     let message = raw;
     if (raw.trim().startsWith("{")) {

--- a/app/api/phone/send-otp/route.ts
+++ b/app/api/phone/send-otp/route.ts
@@ -54,7 +54,10 @@ export async function POST(request: NextRequest) {
     const userId = request.headers.get("x-user-id");
 
     if (!walletAddress) {
-      report.rejected({ reason: "unauthorized", statusCode: 401 });
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/send-otp",

--- a/app/api/phone/send-otp/route.ts
+++ b/app/api/phone/send-otp/route.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../lib/server-analytics";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { isInjectedUserId } from "@/app/lib/injected-identity";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 function hashOTP(otp: string): string {
   return createHash("sha256").update(otp).digest("hex");
@@ -26,23 +27,17 @@ function clampKycTier(tier: unknown): number {
   return Math.min(Math.max(Math.trunc(n), 0), 4);
 }
 
-function logSupabaseError(scope: string, err: { message?: string; code?: string; details?: string; hint?: string }) {
-  const fields = {
-    message: err.message ?? "(no message)",
-    code: err.code,
-    details: err.details,
-    hint: err.hint,
-  };
-  console.error(`[send-otp] ${scope}:`, fields.message, fields);
-}
-
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
+  // Tier 1 starts here: an OTP that never arrives is the first thing support
+  // is asked about, and until now nothing recorded the provider's answer.
+  const report = createKycReporter({ step: "phone_otp_send", targetTier: 1 });
 
   try {
     // Rate limit check
     const rateLimitResult = await rateLimit(request);
     if (!rateLimitResult.success) {
+      report.rejected({ reason: "rate_limited", statusCode: 429 });
       return NextResponse.json(
         { success: false, error: "Too many requests. Please try again later." },
         { status: 429 },
@@ -59,6 +54,7 @@ export async function POST(request: NextRequest) {
     const userId = request.headers.get("x-user-id");
 
     if (!walletAddress) {
+      report.rejected({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -73,6 +69,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!phoneNumber) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "missing_phone_number",
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -92,6 +94,15 @@ export async function POST(request: NextRequest) {
     // Validate phone number
     const validation = validatePhoneNumber(phoneNumber);
     if (!validation.isValid) {
+      // Never log the number itself — the country it parsed to is enough to
+      // tell a corridor problem from a user typo.
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "invalid_phone_format",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -111,6 +122,13 @@ export async function POST(request: NextRequest) {
       validation.country &&
       validation.country !== countryIso.trim().toUpperCase()
     ) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "phone_country_mismatch",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -139,10 +157,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
     if (profileFetchError) {
-      logSupabaseError(
-        "Supabase profile fetch failed",
-        profileFetchError,
-      );
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: profileFetchError.code,
+        detail: profileFetchError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -186,10 +209,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
       if (phoneOwnerError) {
-        logSupabaseError(
-          "Supabase phone uniqueness check failed",
-          phoneOwnerError,
-        );
+        report.failed({
+          walletAddress,
+          stage: "phone_uniqueness_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: phoneOwnerError.code,
+          detail: phoneOwnerError.message,
+          statusCode: 500,
+        });
         return NextResponse.json(
           { success: false, error: "Failed to validate phone number" },
           { status: 500 },
@@ -197,6 +225,15 @@ export async function POST(request: NextRequest) {
       }
 
       if (phoneOwner) {
+        // Common and confusing for the user — they are told to use a different
+        // number with no explanation of which account holds this one.
+        report.rejected({
+          walletAddress,
+          stage: "phone_uniqueness_check",
+          reason: "duplicate_phone_number",
+          idCountry: validation.country,
+          statusCode: 409,
+        });
         trackApiError(
           request,
           "/api/phone/send-otp",
@@ -232,10 +269,16 @@ export async function POST(request: NextRequest) {
     }
 
     if (!result.success) {
-      console.error("[send-otp] OTP provider failed:", {
-        error: result.error,
-        message: result.message,
-        provider: validation.provider,
+      // The SMS never went out. Provider-side, so it reads as an error rather
+      // than a rejection: KudiSMS and Twilio outages page us, not the user.
+      report.failed({
+        walletAddress,
+        stage: "otp_provider",
+        reason: "otp_send_failed",
+        provider: isNigerian ? "kudisms" : "twilio",
+        detail: result.error || result.message,
+        idCountry: validation.country,
+        statusCode: 400,
       });
       const responseTime = Date.now() - startTime;
       trackApiResponse(
@@ -284,7 +327,17 @@ export async function POST(request: NextRequest) {
       );
 
     if (dbError) {
-      logSupabaseError("Supabase upsert (user_kyc_profiles) failed", dbError);
+      // The OTP was sent but the hash was not stored, so the code the user is
+      // about to receive can never verify.
+      report.failed({
+        walletAddress,
+        stage: "profile_upsert",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: dbError.code,
+        detail: dbError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -324,6 +377,15 @@ export async function POST(request: NextRequest) {
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/phone/send-otp", "POST", 200, responseTime);
 
+    report.success({
+      walletAddress,
+      stage: "otp_provider",
+      provider: isNigerian ? "kudisms" : "twilio",
+      idCountry: validation.country,
+      tierFrom: Number(existingProfile?.tier) || 0,
+      statusCode: 200,
+    });
+
     return NextResponse.json({
       success: result.success,
       message: result.message,
@@ -331,7 +393,13 @@ export async function POST(request: NextRequest) {
       phoneNumber: validation.internationalFormat,
     });
   } catch (error) {
-    console.error("[send-otp] POST uncaught exception:", error);
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(request, "/api/phone/send-otp", "POST", error as Error, 500);
 
     return NextResponse.json(

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -195,7 +195,10 @@ export async function POST(request: NextRequest) {
     const walletAddress = request.headers.get("x-wallet-address");
 
     if (!walletAddress) {
-      report.rejected({ reason: "unauthorized", statusCode: 401 });
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/verify-otp",

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -10,6 +10,7 @@ import { validatePhoneNumber } from "@/app/lib/phone-validation";
 import { checkTwilioVerifyCode } from "@/app/lib/phone-verification";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, type KycReporter } from "@/app/lib/kyc-telemetry";
 
 const MAX_ATTEMPTS = 3;
 
@@ -48,6 +49,7 @@ async function promoteVerifiedPhone(
   e164: string,
   currentTier: number,
   isInjected: boolean,
+  report: KycReporter,
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
   if (!isInjected) {
     const { data: phoneOwner, error: ownerError } = await supabaseAdmin
@@ -61,6 +63,16 @@ async function promoteVerifiedPhone(
       .maybeSingle();
 
     if (ownerError) {
+      report.failed({
+        walletAddress,
+        stage: "phone_uniqueness_check",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: ownerError.code,
+        detail: ownerError.message,
+        tierFrom: currentTier,
+        statusCode: 500,
+      });
       return {
         ok: false,
         status: 500,
@@ -68,6 +80,14 @@ async function promoteVerifiedPhone(
       };
     }
     if (phoneOwner) {
+      // They entered the right code and still cannot proceed.
+      report.rejected({
+        walletAddress,
+        stage: "phone_uniqueness_check",
+        reason: "duplicate_phone_number",
+        tierFrom: currentTier,
+        statusCode: 409,
+      });
       return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
     }
   }
@@ -97,8 +117,27 @@ async function promoteVerifiedPhone(
   if (updateError) {
     // Still reachable: two non-injected wallets racing to verify the same number.
     if (updateError.code === "23505") {
+      report.rejected({
+        walletAddress,
+        stage: "promotion",
+        reason: "duplicate_phone_number",
+        provider: "supabase",
+        providerCode: updateError.code,
+        tierFrom: currentTier,
+        statusCode: 409,
+      });
       return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
     }
+    report.failed({
+      walletAddress,
+      stage: "promotion",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: updateError.code,
+      detail: updateError.message,
+      tierFrom: currentTier,
+      statusCode: 500,
+    });
     return {
       ok: false,
       status: 500,
@@ -107,6 +146,13 @@ async function promoteVerifiedPhone(
   }
 
   if (!updatedRow) {
+    report.rejected({
+      walletAddress,
+      stage: "promotion",
+      reason: "superseded_by_newer_otp",
+      tierFrom: currentTier,
+      statusCode: 409,
+    });
     return {
       ok: false,
       status: 409,
@@ -115,15 +161,25 @@ async function promoteVerifiedPhone(
     };
   }
 
+  report.success({
+    walletAddress,
+    stage: "promotion",
+    tierFrom: currentTier,
+    tierTo: currentTier === 0 ? 1 : currentTier,
+    statusCode: 200,
+  });
+
   return { ok: true };
 }
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
+  const report = createKycReporter({ step: "phone_otp_verify", targetTier: 1 });
 
   try {
     const rateLimitResult = await rateLimit(request);
     if (!rateLimitResult.success) {
+      report.rejected({ reason: "rate_limited", statusCode: 429 });
       return NextResponse.json(
         { success: false, error: "Too many requests. Please try again later." },
         { status: 429 },
@@ -139,6 +195,7 @@ export async function POST(request: NextRequest) {
     const walletAddress = request.headers.get("x-wallet-address");
 
     if (!walletAddress) {
+      report.rejected({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -153,6 +210,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!phoneNumber || !otpCode) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "missing_fields",
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -169,6 +232,13 @@ export async function POST(request: NextRequest) {
     // Normalize phone number to E.164 format for consistent querying
     const validation = validatePhoneNumber(phoneNumber);
     if (!validation.isValid || !validation.e164Format) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "invalid_phone_format",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -193,6 +263,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (fetchError) {
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: fetchError.code,
+        detail: fetchError.message,
+        statusCode: 500,
+      });
       trackApiError(request, "/api/phone/verify-otp", "POST", fetchError, 500);
       return NextResponse.json(
         { success: false, error: "Failed to fetch verification record" },
@@ -208,6 +287,13 @@ export async function POST(request: NextRequest) {
     ) {
       const responseTime = Date.now() - startTime;
       trackApiResponse("/api/phone/verify-otp", "POST", 200, responseTime);
+      report.noop({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "already_verified",
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 200,
+      });
       return NextResponse.json({
         success: true,
         message: "Phone number already verified",
@@ -219,6 +305,12 @@ export async function POST(request: NextRequest) {
       !verification ||
       verification.pending_phone_number !== validation.e164Format
     ) {
+      report.rejected({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "no_pending_verification",
+        statusCode: 404,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -239,6 +331,15 @@ export async function POST(request: NextRequest) {
         otpCode,
       );
       if (!checkResult.success) {
+        report.rejected({
+          walletAddress,
+          stage: "otp_check",
+          reason: "invalid_otp",
+          provider: "twilio",
+          detail: checkResult.error,
+          tierFrom: Number(verification.tier) || 0,
+          statusCode: 400,
+        });
         trackApiError(
           request,
           "/api/phone/verify-otp",
@@ -262,6 +363,7 @@ export async function POST(request: NextRequest) {
         validation.e164Format,
         Number(verification.tier) || 0,
         verification.is_injected_wallet === true,
+        report,
       );
       if (!promotion.ok) {
         trackApiError(
@@ -290,7 +392,18 @@ export async function POST(request: NextRequest) {
 
     // KudiSMS path: expiry, attempts, and DB OTP comparison
     const expiresRaw = verification.expires_at;
+    const rejectExpired = (reason: string) => {
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason,
+        provider: "kudisms",
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 400,
+      });
+    };
     if (expiresRaw == null || expiresRaw === "") {
+      rejectExpired("otp_expiry_missing");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
@@ -298,12 +411,14 @@ export async function POST(request: NextRequest) {
     }
     const expiresDate = new Date(expiresRaw as string);
     if (Number.isNaN(expiresDate.getTime())) {
+      rejectExpired("otp_expiry_unparseable");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
       );
     }
     if (new Date() > expiresDate) {
+      rejectExpired("otp_expired");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
@@ -311,6 +426,16 @@ export async function POST(request: NextRequest) {
     }
 
     if (verification.otp_attempts >= MAX_ATTEMPTS) {
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason: "attempts_exhausted",
+        provider: "kudisms",
+        attempt: Number(verification.otp_attempts) || MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -329,6 +454,15 @@ export async function POST(request: NextRequest) {
         });
 
       if (attemptsError) {
+        report.failed({
+          walletAddress,
+          stage: "otp_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: attemptsError.code,
+          detail: attemptsError.message,
+          statusCode: 500,
+        });
         trackApiError(
           request,
           "/api/phone/verify-otp",
@@ -344,6 +478,15 @@ export async function POST(request: NextRequest) {
 
       // Null means attempts limit was already reached mid-flight
       if (updatedAttempts === null || updatedAttempts === undefined) {
+        report.rejected({
+          walletAddress,
+          stage: "otp_check",
+          reason: "attempts_exhausted",
+          provider: "kudisms",
+          attemptsRemaining: 0,
+          tierFrom: Number(verification.tier) || 0,
+          statusCode: 429,
+        });
         return NextResponse.json(
           {
             success: false,
@@ -354,6 +497,16 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason: "invalid_otp",
+        provider: "kudisms",
+        attempt: Number(updatedAttempts) || null,
+        attemptsRemaining: Math.max(0, MAX_ATTEMPTS - Number(updatedAttempts)),
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -371,6 +524,7 @@ export async function POST(request: NextRequest) {
       validation.e164Format,
       Number(verification.tier) || 0,
       verification.is_injected_wallet === true,
+      report,
     );
     if (!promotion.ok) {
       trackApiError(
@@ -398,6 +552,13 @@ export async function POST(request: NextRequest) {
       phoneNumber: phoneNumber,
     });
   } catch (error) {
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(
       request,
       "/api/phone/verify-otp",

--- a/app/lib/kyc-telemetry.ts
+++ b/app/lib/kyc-telemetry.ts
@@ -85,12 +85,13 @@ function truncate(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…` : value;
 }
 
+function maskSensitive(value: string): string {
+  return value.replace(EMAIL_LIKE, "[email]").replace(DIGIT_RUN, "[digits]");
+}
+
 /** Exported for the test suite — masking is the guard that keeps PII out. */
 export function sanitizeDetail(value: string): string {
-  return truncate(
-    value.replace(EMAIL_LIKE, "[email]").replace(DIGIT_RUN, "[digits]"),
-    MAX_DETAIL_LENGTH,
-  );
+  return truncate(maskSensitive(value), MAX_DETAIL_LENGTH);
 }
 
 /** Facets are only useful when absent means absent — drop empty keys. */
@@ -228,8 +229,10 @@ export function buildKycLog(event: KycEvent): KycLog {
         truncate(normalized.message, MAX_ERROR_MESSAGE_LENGTH),
       ),
       // Our own frames, and the main reason to ship an error line at all.
+      // Masked on its own budget: the first line of a stack repeats the
+      // message, so skipping it here would undo the masking above.
       stack: normalized.stack
-        ? truncate(normalized.stack, MAX_ERROR_STACK_LENGTH)
+        ? truncate(maskSensitive(normalized.stack), MAX_ERROR_STACK_LENGTH)
         : undefined,
     });
   }

--- a/app/lib/kyc-telemetry.ts
+++ b/app/lib/kyc-telemetry.ts
@@ -1,0 +1,328 @@
+/**
+ * Datadog telemetry for the KYC flow (tiers 1–3).
+ *
+ * Until this existed, a failed tier upgrade left no queryable trace. Client
+ * errors went to GlitchTip, Mixpanel only ever heard about submissions and
+ * successes, and the routes themselves reported failures through `console.*` —
+ * unparsed strings with no trace correlation, and in the case of a genuine
+ * Smile ID rejection, nothing at all. "Why did this user's upgrade fail?" was
+ * not answerable from Datadog.
+ *
+ * One structured line per KYC step outcome, flattened into `@kyc.*` facets so
+ * Datadog can turn them into metrics (Logs → Generate Metrics) and monitors,
+ * and so support can search a wallet address and read the provider's own words
+ * for why it failed.
+ *
+ * Emitted through the shared pino logger to stdout, where the agent sidecar
+ * collects it. `logger` stamps dd.trace_id, so each line links back to its
+ * trace; the same facets are mirrored onto the active span so the failures are
+ * filterable from APM too.
+ *
+ * Server-only — `logger` pulls in Node internals.
+ */
+import tracer from "dd-trace";
+
+import logger from "@/app/lib/logger";
+
+type DatadogLogStatus = "info" | "warn" | "error";
+
+/** Stable message string — log-based metrics and monitors filter on this. */
+export const KYC_EVENT_MESSAGE = "kyc step";
+
+/**
+ * The upgrade steps, plus the signup nudge that precedes tier 1 and the
+ * read-only status endpoint (failures only — every KYC surface polls it, so
+ * logging its successes would bury everything else).
+ */
+export type KycStep =
+  | "signup_email"
+  | "phone_otp_send"
+  | "phone_otp_verify"
+  | "id_verification"
+  | "id_callback"
+  | "address_verification"
+  | "status";
+
+/**
+ * `rejected` is a legitimate user-facing outcome (wrong OTP, Smile ID said no,
+ * attempts exhausted); `error` is our fault or a provider's. Separating them is
+ * what keeps an outage monitor from being drowned by users mistyping an OTP.
+ *
+ * `noop` is for work that correctly did nothing — chiefly the async Smile ID
+ * callback arriving after the synchronous path already promoted the profile.
+ * It logs at info so callback delivery stays observable without a stream of
+ * warnings about the normal case.
+ */
+export type KycOutcome = "success" | "rejected" | "error" | "noop";
+
+export type KycProvider =
+  | "smile_id"
+  | "dojah"
+  | "kudisms"
+  | "twilio"
+  | "supabase";
+
+/**
+ * Bounds on the payload. Provider and Postgres messages are built from the data
+ * that caused them, so an unbounded `detail` is both a payload-size and an
+ * accidental-disclosure risk.
+ */
+const MAX_DETAIL_LENGTH = 500;
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+const MAX_ERROR_STACK_LENGTH = 2_000;
+
+/**
+ * Provider rejection messages quote the input that failed — Smile ID and Dojah
+ * both echo the submitted ID number back in `ResultText`. Mask long digit runs
+ * (NIN and BVN are 11, passport and licence numbers are shorter but still
+ * caught) and anything email-shaped before the line ships. Result codes
+ * (4 digits) and tier numbers stay readable.
+ */
+const DIGIT_RUN = /\d{6,}/g;
+const EMAIL_LIKE = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Exported for the test suite — masking is the guard that keeps PII out. */
+export function sanitizeDetail(value: string): string {
+  return truncate(
+    value.replace(EMAIL_LIKE, "[email]").replace(DIGIT_RUN, "[digits]"),
+    MAX_DETAIL_LENGTH,
+  );
+}
+
+/** Facets are only useful when absent means absent — drop empty keys. */
+function compact(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined || value === null || value === "") continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Everything a step can report beyond its identity and outcome. */
+export interface KycEventDetails {
+  /** Lower-cased before it ships, so a search matches whatever casing support pastes. */
+  walletAddress?: string | null;
+  /** Where in the route it happened: `profile_fetch`, `provider_submit`, … */
+  stage?: string;
+  /** Stable machine-readable cause: `attempts_exhausted`, `provider_rejected`, … */
+  reason?: string;
+  /** The provider's or Postgres' own message. Masked and truncated. */
+  detail?: string | null;
+  /** `classifySmileIdFailure` output, for the ID step. */
+  failureCategory?: string | null;
+  provider?: KycProvider;
+  /** Smile ID ResultCode, Postgres SQLSTATE, Dojah status. */
+  providerCode?: string | number | null;
+  jobId?: string | null;
+  jobType?: number | null;
+  idCountry?: string | null;
+  idType?: string | null;
+  tierFrom?: number | null;
+  tierTo?: number | null;
+  /** The tier this step is trying to reach, even when it never gets there. */
+  targetTier?: number | null;
+  attempt?: number | null;
+  attemptsRemaining?: number | null;
+  durationMs?: number;
+  statusCode?: number;
+  /** Attached as `error.*` so Datadog Error Tracking groups it. */
+  error?: unknown;
+}
+
+export interface KycEvent extends KycEventDetails {
+  step: KycStep;
+  outcome: KycOutcome;
+}
+
+export interface KycLog {
+  message: string;
+  status: DatadogLogStatus;
+  attributes: Record<string, unknown>;
+}
+
+const STATUS_BY_OUTCOME: Record<KycOutcome, DatadogLogStatus> = {
+  success: "info",
+  noop: "info",
+  rejected: "warn",
+  error: "error",
+};
+
+/**
+ * Flattens one step outcome. `@kyc.ok` is the boolean twin of `outcome` so a
+ * single "upgrades in the last hour" query can count failures without an
+ * outcome-by-outcome filter.
+ */
+export function buildKycLog(event: KycEvent): KycLog {
+  const {
+    step,
+    outcome,
+    walletAddress,
+    stage,
+    reason,
+    detail,
+    failureCategory,
+    provider,
+    providerCode,
+    jobId,
+    jobType,
+    idCountry,
+    idType,
+    tierFrom,
+    tierTo,
+    targetTier,
+    attempt,
+    attemptsRemaining,
+    durationMs,
+    statusCode,
+    error,
+  } = event;
+
+  const attributes: Record<string, unknown> = {
+    feature: "kyc",
+    kyc: compact({
+      step,
+      outcome,
+      ok: outcome === "success",
+      wallet_address: walletAddress ? walletAddress.toLowerCase() : undefined,
+      stage,
+      reason,
+      detail: detail ? sanitizeDetail(detail) : undefined,
+      failure_category: failureCategory,
+      provider,
+      provider_code:
+        providerCode === undefined || providerCode === null
+          ? undefined
+          : String(providerCode),
+      job_id: jobId,
+      job_type: jobType,
+      id_country: idCountry,
+      id_type: idType,
+      tier_from: tierFrom,
+      tier_to: tierTo,
+      target_tier: targetTier,
+      // Boolean twin so a promotion is countable without a null-vs-0 filter.
+      promoted:
+        typeof tierFrom === "number" && typeof tierTo === "number"
+          ? tierTo > tierFrom
+          : undefined,
+      attempt,
+      attempts_remaining: attemptsRemaining,
+      duration_ms: durationMs,
+      status_code: statusCode,
+    }),
+  };
+
+  if (error !== undefined) {
+    const normalized =
+      error instanceof Error ? error : new Error(String(error));
+    attributes.error = compact({
+      kind: normalized.name,
+      message: sanitizeDetail(
+        truncate(normalized.message, MAX_ERROR_MESSAGE_LENGTH),
+      ),
+      // Our own frames, and the main reason to ship an error line at all.
+      stack: normalized.stack
+        ? truncate(normalized.stack, MAX_ERROR_STACK_LENGTH)
+        : undefined,
+    });
+  }
+
+  return {
+    message: KYC_EVENT_MESSAGE,
+    status: STATUS_BY_OUTCOME[outcome],
+    attributes,
+  };
+}
+
+/**
+ * Mirrors the identifying facets onto the active APM span so the same failure
+ * is findable from the trace view, not only from Logs.
+ *
+ * Deliberately does not set the span's error flag: dd-trace already marks 5xx
+ * responses, and flagging a `rejected` outcome (a user mistyping an OTP) would
+ * inflate the service's APM error rate with normal product behaviour.
+ */
+function tagActiveSpan(event: KycEvent): void {
+  try {
+    const span = tracer.scope().active();
+    if (!span) return;
+    span.addTags(
+      compact({
+        "kyc.step": event.step,
+        "kyc.outcome": event.outcome,
+        "kyc.reason": event.reason,
+        "kyc.stage": event.stage,
+        "kyc.target_tier": event.targetTier,
+      }),
+    );
+  } catch {
+    // APM disabled or unavailable — the log line still stands on its own.
+  }
+}
+
+/**
+ * Writes a step outcome to stdout for the agent to collect.
+ *
+ * Synchronous and non-throwing by contract: pino writes to a stream rather than
+ * making a network call, so there is nothing to await and no in-flight request
+ * for the runtime to drop. Telemetry must never be the reason a verification
+ * fails, so the whole body is guarded.
+ */
+export function emitKycEvent(event: KycEvent): void {
+  try {
+    tagActiveSpan(event);
+    const log = buildKycLog(event);
+    logger[log.status](log.attributes, log.message);
+  } catch {
+    // Never let reporting break the flow it is reporting on.
+  }
+}
+
+export interface KycReporter {
+  /** The step completed and the user is now at `tierTo`. */
+  success(details?: KycEventDetails): void;
+  /** A legitimate user-facing refusal — the flow worked, the answer was no. */
+  rejected(details: KycEventDetails): void;
+  /** Our fault, the database's, or the provider's. */
+  failed(details: KycEventDetails): void;
+  /** Correctly did nothing — already verified, superseded, not applicable. */
+  noop(details: KycEventDetails): void;
+}
+
+/**
+ * Binds the facets a route already knows (step, wallet, target tier, provider)
+ * and stamps `duration_ms` from construction, so each exit path is one call
+ * naming only what is new about it.
+ *
+ * Construct it as early as the wallet address is known; later calls can still
+ * override any base field — the async Smile ID callback, for one, only learns
+ * the wallet from the request body.
+ */
+export function createKycReporter(
+  base: KycEventDetails & { step: KycStep },
+): KycReporter {
+  const startedAt = Date.now();
+
+  const emit = (outcome: KycOutcome, details: KycEventDetails = {}) =>
+    emitKycEvent({
+      ...base,
+      ...details,
+      step: base.step,
+      outcome,
+      durationMs: details.durationMs ?? Date.now() - startedAt,
+    });
+
+  return {
+    success: (details) => emit("success", details),
+    rejected: (details) => emit("rejected", details),
+    failed: (details) => emit("error", details),
+    noop: (details) => emit("noop", details),
+  };
+}

--- a/app/lib/sentry.client.ts
+++ b/app/lib/sentry.client.ts
@@ -2,6 +2,8 @@
 
 import * as Sentry from "@sentry/react";
 
+import { datadogRum, isDatadogRumInitialized } from "./datadog.client";
+
 const INIT_KEY = "__noblocks_sentry_init__" as const;
 
 function scrubEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
@@ -104,9 +106,16 @@ export function ensureSentryClientInitialized(): void {
 }
 
 /**
- * Report a handled error to GlitchTip. The **primary event** is `error` itself
- * (original message, stack, etc.); `context` / `extra` is only supplemental
- * (e.g. `userFacingMessage` for the copy shown in the UI).
+ * Report a handled error to GlitchTip **and** Datadog RUM. The **primary
+ * event** is `error` itself (original message, stack, etc.); `context` /
+ * `extra` is only supplemental (e.g. `userFacingMessage` for the copy shown in
+ * the UI).
+ *
+ * RUM matters for the failures that never reach our API — a dropped network
+ * request, a camera permission refusal, a wallet rejection — which no
+ * server-side log can see. It is consent-gated and initialised separately, so
+ * this is strictly additive: server logs remain the complete record, and a
+ * user who declined analytics cookies still reports to GlitchTip.
  */
 export function reportClientError(
   error: unknown,
@@ -117,6 +126,15 @@ export function reportClientError(
   Sentry.captureException(error, {
     extra: context,
   });
+
+  // Calling addError before init is a no-op that logs a warning, so guard it.
+  if (!isDatadogRumInitialized()) return;
+  try {
+    // RUM's own beforeSend scrubs this context (see datadog.client.ts).
+    datadogRum.addError(error, context);
+  } catch {
+    // Reporting must never be the reason a handler throws.
+  }
 }
 
 export { Sentry };


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-786

### Description

When a user's KYC tier upgrade failed, we could not answer "why" from Datadog. Support's only recourse was to ask the user to describe the error message they saw.

Nothing in the KYC flow reported to Datadog deliberately. `instrumentation.ts` gave us an errored span with no KYC context; `app/lib/logger.ts` was structured and trace-correlated but its only consumer was the fantasy worker; no KYC code touched RUM; client failures went to GlitchTip, and Mixpanel only ever heard `"Submitted"` / `"Success"` — there was no failure event. The routes themselves used bare `console.error` / `console.warn`, which do reach Datadog Logs as container stdout but as unparsed strings with no trace correlation and nothing queryable.

Worst of all, the genuine verification-failure path was silent: in `app/api/kyc/smile-id/route.ts`, when `verificationSuccess` was false only the infrastructure category logged a `console.warn`. A real Smile ID rejection wrote nothing, and neither did the catch-all.

**This PR** adds `app/lib/kyc-telemetry.ts` on the same pino → stdout → agent path the fantasy worker already uses — pure builders plus one emit, no HTTP shipper, nothing to await, and non-throwing by contract so telemetry can never be the reason a verification fails. It emits one structured line per step outcome under `@feature:kyc`, flattened into `@kyc.*` facets, carrying the provider's own message in `@kyc.detail`. The identifying facets are mirrored onto the active APM span (without setting the span error flag — dd-trace already marks 5xx) so the same failures are filterable from traces, not just Logs.

Every exit path in the KYC routes now emits exactly one line, and none of them rely on `console.*` for a failure signal:

| Route | `@kyc.step` |
| --- | --- |
| `phone/send-otp`, `phone/verify-otp` | `phone_otp_send`, `phone_otp_verify` — including all three exits inside `promoteVerifiedPhone` |
| `kyc/smile-id` | `id_verification` — 20 exits, including the branch that logged nothing |
| `kyc/smile-id/callback` | `id_callback` — the async promotion path had no queryable signal at all |
| `kyc/tier3-verify` | `address_verification` |
| `kyc/status`, `kyc/signup-email` | `status` (failures only — every KYC surface polls it), `signup_email` |

**Why `outcome` has four values.** `rejected` (warn) is a legitimate refusal — a mistyped OTP, a blurry document, Smile ID saying no. `error` (error) is our fault, the database's, or a provider's. Without that split, an outage monitor is drowned by users fat-fingering their OTP. `noop` (info) is work that correctly did nothing, chiefly a callback arriving after the synchronous path already promoted the profile — it keeps callback delivery observable without a stream of warnings about the normal case.

**PII.** Wallet address is logged in the clear: it is the key support needs to find one user, and it is what these routes already logged. Phone numbers, emails, ID numbers, dates of birth, names and document images are not. Because Smile ID and Dojah quote the failing input back in their rejection messages, `sanitizeDetail` masks digit runs of six or more and anything email-shaped before a line ships — short numbers like result codes stay readable.

`reportClientError` (`app/lib/sentry.client.ts`) now also forwards to `datadogRum.addError`, guarded on RUM being initialised. This is deliberately not KYC-specific: it is the single client error funnel, and it is what makes failures that never reach our API — a dropped request, a refused camera, a wallet rejection — visible at all. It is strictly additive; RUM is consent-gated, so the server lines remain the complete record.

**One behavioural change**, called out because the ticket is otherwise observability-only: on a Smile ID infrastructure failure the attempt is refunded *after* the line is emitted, so `attempts_remaining` is computed post-refund rather than reporting a number one too low. If the refund itself fails it gets its own line. No response body or status code changes anywhere in this PR. A duplicate `currentTier` / `tierFrom` const in the smile-id route was also collapsed.

`app/api/kyc/transaction-summary` is untouched — it reports spend against limits, not a verification step.

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green — see the note under Testing about `next build`

### Testing

`__tests__/kyc-telemetry.test.ts` (16 tests) follows `__tests__/fantasy-worker-telemetry.test.ts`, mocking the logger at the relative `../app/lib/logger` specifier and dd-trace's active span. It covers the facet flattening per outcome, the level each outcome logs at, wallet lower-casing, empty-facet dropping (while a real `0` survives), span tagging, the reporter's base-facet binding and per-call override, that emission never throws on a circular payload, and the masking guard:

```
npx jest __tests__/kyc-telemetry.test.ts   # 16 passed
npx jest                                   # 57 suites, 577 tests, all passing
npx tsc --noEmit --skipLibCheck            # clean
```

**`next build` fails on this branch — and it fails identically on clean `main`.** It is a `dd-trace` → `instrumentation.ts` webpack resolution error (`node_source_map`, `diagnostics_channel`), which I confirmed is pre-existing by stashing this work and rebuilding `main`. Not introduced here, but it means a webpack build is not currently green on the default branch and probably deserves its own ticket.

Not verified by tests, and worth a reviewer's eye: that the lines actually land in the EU org with a working **View Trace** link, which needs a deploy with the agent sidecar running. Once deployed, `OBSERVABILITY.md` documents the verification query and five monitors worth creating (all scoped `env:production` — staging shares the org).

Developed on Node with the repo's pinned Next 15 / jest setup.

- [x] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows) — **not done.** Needs a staging deploy with the Datadog agent to confirm the lines arrive and correlate; the code paths themselves are unchanged in behaviour.

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing — pending first CI run; see the `next build` note above
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract — n/a, no migration, no new env vars, no new dependencies

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured observability across KYC, phone verification, OTP, and identity verification flows.
  * Added outcome tracking for successful, rejected, failed, and provider-related events.
  * Added client-side error reporting to Datadog RUM alongside existing error tracking.
  * Added privacy protections that sanitize and truncate sensitive telemetry details.

* **Documentation**
  * Added KYC monitoring guidance, support queries, dashboards, and verification steps.

* **Tests**
  * Added comprehensive coverage for telemetry formatting, privacy handling, error reporting, and monitoring metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->