### PR TITLE
chore(ngn): drop dead SAFAKEPC exception from NUBAN validation

### DIFF
--- a/app/api/v1/recipients/route.ts
+++ b/app/api/v1/recipients/route.ts
@@ -8,6 +8,7 @@ import {
   trackBusinessEvent,
 } from "@/app/lib/server-analytics";
 import { isValidEvmAddressCaseInsensitive } from "@/app/lib/validation";
+import { NGN_NUBAN_LENGTH } from "@/app/utils";
 import type {
   RecipientDetailsWithId,
   SavedRecipientsResponse,
@@ -342,8 +343,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     // Only enforce NUBAN digit-length validation for NGN recipients
     if (currency === "NGN") {
       const digits = sanitizedIdentifier.replace(/\D/g, "");
-      const requiredLen = trimmedInstitutionCode === "SAFAKEPC" ? 6 : 10;
-      if (digits.length !== requiredLen) {
+      if (digits.length !== NGN_NUBAN_LENGTH) {
         trackApiError(
           request,
           "/api/v1/recipients",
@@ -354,10 +354,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
         return NextResponse.json(
           {
             success: false,
-            error:
-              requiredLen === 10
-                ? "Please enter a valid 10-digit account number."
-                : "Please enter a valid 6-digit account number.",
+            error: "Please enter a valid 10-digit account number.",
           },
           { status: 400 },
         );

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -9,7 +9,7 @@ import { AnimatedModal, AnimatedFeedbackItem } from "@/app/components/AnimatedCo
 import { SearchInput } from "@/app/components/recipient/SearchInput";
 import { InputError } from "@/app/components/InputError";
 import type { InstitutionProps, RefundAccountDetails } from "@/app/types";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { primaryBtnClasses, secondaryBtnClasses } from "@/app/components/Styles";
 import { useKYC } from "@/app/context";
@@ -98,18 +98,15 @@ export function AddRefundAccountModal({
     }
 
     const digits = accountNumber.replace(/\D/g, "");
-    const requiredLen = selectedInstitution.code === "SAFAKEPC" ? 6 : 10;
 
     if (currency === "NGN") {
       if (digits.length === 0) {
         setAccountNumberError(null);
         return;
       }
-      if (digits.length !== requiredLen) {
+      if (digits.length !== NGN_NUBAN_LENGTH) {
         setAccountNumberError(
-          requiredLen === 6
-            ? `Please enter a valid 6-digit account number (${digits.length} entered).`
-            : `Please enter a valid 10-digit account number (${digits.length} entered).`,
+          `Please enter a valid 10-digit account number (${digits.length} entered).`,
         );
         return;
       }

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -15,7 +15,7 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
 import {
   RecipientDetails,
   RecipientDetailsFormProps,
@@ -93,11 +93,11 @@ export const RecipientDetailsForm = ({
   const [isManualEntry, setIsManualEntry] = useState(true);
   const [isReturningFromPreview, setIsReturningFromPreview] = useState(false);
 
-  /** NGN NUBAN: cap at 10 digits (6 for SAFAKEPC). Other currencies: no digit cap. */
-  const ngnAccountMaxDigits = useMemo(() => {
-    if (currency !== "NGN") return null;
-    return selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
-  }, [currency, selectedInstitution?.code]);
+  /** NGN NUBAN: cap at 10 digits. Other currencies: no digit cap. */
+  const ngnAccountMaxDigits = useMemo(
+    () => (currency === "NGN" ? NGN_NUBAN_LENGTH : null),
+    [currency],
+  );
 
   const prevCurrencyRef = useRef(currency);
   const isDark = useActualTheme();
@@ -279,19 +279,16 @@ export const RecipientDetailsForm = ({
 
       const isNGN = currency === "NGN";
       const digits = String(accountIdentifier ?? "").replace(/\D/g, "");
-      const requiredLen = selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
 
       if (!institution || !accountIdentifier) {
         setRecipientNameError("");
         return;
       }
 
-      if (isNGN && digits.length !== requiredLen) {
+      if (isNGN && digits.length !== NGN_NUBAN_LENGTH) {
         if (digits.length > 0) {
           setRecipientNameError(
-            requiredLen === 10
-              ? "Please enter a valid 10-digit account number."
-              : "Invalid account number. Please enter a 6-digit account number.",
+            "Please enter a valid 10-digit account number.",
           );
         } else {
           setRecipientNameError("");
@@ -422,12 +419,8 @@ export const RecipientDetailsForm = ({
     validate: (value) => {
       if (currency !== "NGN") return true;
       const digits = String(value ?? "").replace(/\D/g, "");
-      // SAFAKEPC is the sandbox NGN institution (6-digit accounts, not 10-digit NUBAN).
-      const requiredLen = selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
-      if (digits.length !== requiredLen) {
-        return requiredLen === 10
-          ? "Please enter a valid 10-digit account number."
-          : "Invalid account number. Please enter a 6-digit account number.";
+      if (digits.length !== NGN_NUBAN_LENGTH) {
+        return "Please enter a valid 10-digit account number.";
       }
       return true;
     },
@@ -569,8 +562,7 @@ export const RecipientDetailsForm = ({
                 </button>
               </div>
 
-              {/* Account number */}
-              {/* Account number - NUBAN is 10 digits; SAFAKEPC uses 6 digits (NGN only) */}
+              {/* Account number - NGN NUBAN is 10 digits */}
               <div className="w-full flex-1 flex-shrink-0 sm:w-1/2">
                 <input
                   type="text"
@@ -580,13 +572,7 @@ export const RecipientDetailsForm = ({
                     currency,
                     selectedInstitution?.type,
                   )}
-                  maxLength={
-                    currency === "NGN"
-                      ? selectedInstitution?.code === "SAFAKEPC"
-                        ? 6
-                        : 10
-                      : undefined
-                  }
+                  maxLength={ngnAccountMaxDigits ?? undefined}
                   {...accountIdentifierRegister}
                   onChange={(e) => {
                     setIsManualEntry(true);

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -94,6 +94,9 @@ export function getInstitutionNameByCode(
 /** Safaricom M-Pesa institution code (KES). Till/Paybill use the same code + channel metadata. */
 export const KES_MPESA_INSTITUTION_CODE = "SAFAKEPC";
 
+/** NGN NUBAN account numbers are always 10 digits. */
+export const NGN_NUBAN_LENGTH = 10;
+
 export type { KesMpesaChannel };
 
 const KES_MPESA_VIRTUAL_OPTIONS: {


### PR DESCRIPTION
### Description

`SAFAKEPC` is Safaricom Kenya M-Pesa. The aggregator inserts it in [`20240831223854_kes_institutions.sql`](https://github.com/paycrest/aggregator/blob/main/ent/migrate/migrations/20240831223854_kes_institutions.sql) bound to KES, alongside `AIRTKEPC` — it is the only file in the aggregator that mentions the code, and the NGN institution list contains no mobile money entries at all.

Despite that, four NGN NUBAN length checks carried a `selectedInstitution?.code === "SAFAKEPC" ? 6 : 10` exception, each inside a `currency === "NGN"` guard. Institutions are fetched per currency (`GET /institutions/{currency}`), so `SAFAKEPC` is never in the list while the currency is NGN, and those ternaries could only ever evaluate to `10`. The 6-digit branches, and the "please enter a valid 6-digit account number" messages behind them, were unreachable.

The exception predates the NGN gate. It was introduced in `7754bf23` when the length check applied to every currency, and was later swept inside `if (currency === "NGN")` when NUBAN validation was scoped to Nigeria. A comment was then added asserting *"SAFAKEPC is the sandbox NGN institution (6-digit accounts, not 10-digit NUBAN)"* — nothing in the aggregator supports this, and it has since been copied into adjacent comments.

This replaces the dead branches with an exported `NGN_NUBAN_LENGTH` constant. **No behavior change:** every reachable path already resolved to 10.

Sites cleaned up:
- `app/components/recipient/RecipientDetailsForm.tsx` — `ngnAccountMaxDigits`, the debounce-time check, the `validate` rule, and the input `maxLength`
- `app/components/AddRefundAccountModal.tsx` — refund account length check
- `app/api/v1/recipients/route.ts` — server-side NUBAN check

The server check is the one place the branch was technically reachable, since it reads `institutionCode` from the request body rather than a per-currency list. A client sending `currency: "NGN"` with `institutionCode: "SAFAKEPC"` could previously save a 6-digit identifier as an NGN recipient; it now requires 10 digits. That is strictly stricter, and not a flow the UI can produce.

### Testing

- `npx jest --runInBand` — 583 passed. Two suites (`hyperfxStatus`, `kyc-telemetry`) fail to resolve `@hyperbridge/sdk` / `dd-trace` in my local `node_modules`; both fail identically on a clean `main` checkout, unrelated to this change.
- `npx tsc --noEmit` — no errors in any touched file.
- Developed and tested on macOS with Node.js/Jest.

- [ ] This change adds test coverage for new/changed/fixed functionality

Dead-code removal with no behavior change, so no new tests. Existing NGN validation coverage continues to pass.

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Nigerian Naira account-number validation to require exactly 10 digits across recipient, refund, and account lookup forms.
  * Updated validation guidance to consistently instruct users to enter a 10-digit account number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->