### PR TITLE
KAN-789: Bump SW cache to v4 and reload stale PWA tabs on worker update

### DIFF
--- a/__tests__/PWAInstallManager.test.tsx
+++ b/__tests__/PWAInstallManager.test.tsx
@@ -15,6 +15,7 @@ type MockServiceWorkerContainer = EventTarget & {
   register: jest.Mock;
 };
 
+/** Installs a mock `navigator.serviceWorker`; `controller` says whether the page is already controlled. */
 function installServiceWorkerMock(controller: object | null) {
   const sw = new EventTarget() as MockServiceWorkerContainer;
   sw.controller = controller;
@@ -26,6 +27,7 @@ function installServiceWorkerMock(controller: object | null) {
   return sw;
 }
 
+/** Dispatches `controllerchange` on the mock container inside React's `act`. */
 function fireControllerChange(sw: EventTarget) {
   act(() => {
     sw.dispatchEvent(new Event("controllerchange"));

--- a/__tests__/PWAInstallManager.test.tsx
+++ b/__tests__/PWAInstallManager.test.tsx
@@ -1,0 +1,89 @@
+/// <reference types="jest" />
+
+import { act, render } from "@testing-library/react";
+
+import PWAInstall from "../app/components/PWAInstallManager";
+
+const mockUseStep = jest.fn();
+
+jest.mock("../app/context/StepContext", () => ({
+  useStep: () => mockUseStep(),
+}));
+
+type MockServiceWorkerContainer = EventTarget & {
+  controller: object | null;
+  register: jest.Mock;
+};
+
+function installServiceWorkerMock(controller: object | null) {
+  const sw = new EventTarget() as MockServiceWorkerContainer;
+  sw.controller = controller;
+  sw.register = jest.fn().mockResolvedValue({});
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: sw,
+  });
+  return sw;
+}
+
+function fireControllerChange(sw: EventTarget) {
+  act(() => {
+    sw.dispatchEvent(new Event("controllerchange"));
+  });
+}
+
+describe("PWAInstall service worker update handling", () => {
+  const originalLocation = window.location;
+  let reloadMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reloadMock = jest.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: reloadMock } as unknown as Location,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    delete (window.navigator as { serviceWorker?: unknown }).serviceWorker;
+  });
+
+  it("does not reload on the first install, when the page was not yet controlled", () => {
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    const sw = installServiceWorkerMock(null);
+
+    render(<PWAInstall />);
+    fireControllerChange(sw);
+
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads immediately when a new worker takes over on the form step", () => {
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    const sw = installServiceWorkerMock({});
+
+    render(<PWAInstall />);
+    fireControllerChange(sw);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers the reload while a transaction is on screen, then reloads on return to the form", () => {
+    mockUseStep.mockReturnValue({ isFormStep: false });
+    const sw = installServiceWorkerMock({});
+
+    const { rerender } = render(<PWAInstall />);
+    fireControllerChange(sw);
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    rerender(<PWAInstall />);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/PWAInstallManager.tsx
+++ b/app/components/PWAInstallManager.tsx
@@ -3,6 +3,11 @@
 import React, { useEffect, useRef } from "react";
 import { useStep } from "../context/StepContext";
 
+/**
+ * Registers the PWA service worker and keeps open tabs on the current build:
+ * when a new worker takes control it reloads the page — skipped on first
+ * install, and deferred while a transaction step is on screen.
+ */
 export default function PWAInstall() {
   const { isFormStep } = useStep();
   // True once this page has been controlled by a service worker. The first

--- a/app/components/PWAInstallManager.tsx
+++ b/app/components/PWAInstallManager.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+import { useStep } from "../context/StepContext";
 
 export default function PWAInstall() {
+  const { isFormStep } = useStep();
+  // True once this page has been controlled by a service worker. The first
+  // controllerchange after an uncontrolled load is the initial install, not an
+  // update — reloading there would loop on every first visit.
+  const hadControllerRef = useRef(false);
+  const updatePendingRef = useRef(false);
+
   useEffect(() => {
     // Register service worker
     if ("serviceWorker" in navigator) {
@@ -30,6 +38,41 @@ export default function PWAInstall() {
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
   }, []);
+
+  // sw.js calls skipWaiting() + clients.claim(), so a new worker takes over
+  // open pages immediately — but each page keeps running the JS it already
+  // loaded. Build-time config (NEXT_PUBLIC_* keys) lives in that JS, so a
+  // long-lived PWA tab keeps stamping stale values until it reloads. Reload as
+  // soon as a new worker takes control, unless a transaction is on screen; in
+  // that case wait until the user is back on the form.
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+    const sw = navigator.serviceWorker;
+    if (sw.controller) hadControllerRef.current = true;
+
+    const reloadIfSafe = () => {
+      if (!updatePendingRef.current || !isFormStep) return;
+      updatePendingRef.current = false;
+      window.location.reload();
+    };
+
+    const handleControllerChange = () => {
+      if (!hadControllerRef.current) {
+        hadControllerRef.current = true;
+        return;
+      }
+      updatePendingRef.current = true;
+      reloadIfSafe();
+    };
+
+    sw.addEventListener("controllerchange", handleControllerChange);
+    // The step may have just returned to the form with an update pending.
+    reloadIfSafe();
+
+    return () => {
+      sw.removeEventListener("controllerchange", handleControllerChange);
+    };
+  }, [isFormStep]);
 
   // This component doesn't render anything - it just sets up PWA functionality
   // The browser will show its native install prompt when appropriate

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,8 @@
-const CACHE_NAME = 'noblocks-pwa-v3';
-const RUNTIME_CACHE = 'noblocks-runtime-v3';
+// Bump BOTH versions on any deploy that changes build-time config (e.g. a
+// NEXT_PUBLIC_* key). The activate handler below purges every cache that does
+// not match, which is the only thing that evicts a stale precached shell.
+const CACHE_NAME = 'noblocks-pwa-v4';
+const RUNTIME_CACHE = 'noblocks-runtime-v4';
 const OFFLINE_URL = '/offline.html';
 
 // Static assets to cache immediately


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-789

### Description

`NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` is inlined into the client bundle at build time and written into the encrypted on-chain order payload as `metadata.apiKey`, which the aggregator indexer uses to attribute the order to a sender profile. After the 12 Aug key rotation, two orders (18 and 19 Aug, same wallet) were still attributed to the previous sender profile because the browser was running a pre-rotation bundle.

Two things kept that bundle alive, and this PR addresses both:

**1. Stale precached shell — `public/sw.js`.** The `install` handler precaches `/` into `CACHE_NAME`, and only a `CACHE_NAME` change makes the `activate` handler evict it. Bumped `noblocks-pwa-v3` / `noblocks-runtime-v3` to `v4`, with a comment stating that both must be bumped on any deploy that changes build-time config, since that is the only eviction path.

**2. Long-lived PWA tabs never reload — `PWAInstallManager.tsx`.** `sw.js` already calls `skipWaiting()` + `clients.claim()`, so a new worker takes control of open pages immediately — but each page keeps executing the JS it already loaded, and the key lives in that JS. An installed PWA left open for days therefore keeps stamping the old key no matter how many deploys happen. This is the more likely cause of the two misattributed orders than an offline fallback.

The fix listens for `controllerchange` and reloads the page, with two guards:

- **No reload on first install.** The first `controllerchange` after an uncontrolled page load is the initial install, not an update; reloading there would loop on every first visit. Tracked via whether `navigator.serviceWorker.controller` existed before the event.
- **Never mid-transaction.** Reload only when `useStep().isFormStep` is true. If a transaction is on screen (Preview / Make payment / Status), the update is marked pending and the reload fires when the user returns to the form.

A forced reload was chosen over an "update available" toast deliberately: the stale value affects money attribution, and a dismissable prompt lets the stale bundle live on.

**Alternatives considered / not done here:**

- Deriving `CACHE_NAME` from a build id so every deploy invalidates automatically. `sw.js` is a static file in `public/` and is not processed by the Next build, so this needs a prebuild step. Worth doing, but out of scope for this fix; the comment in `sw.js` makes the manual step explicit until then.
- The root cause — `metadata.apiKey` being client-controlled and build-time frozen — is tracked separately in KAN-790 (stamp attribution server-side). This PR is the mitigation.
- `Navbar.tsx` also registers `/sw.js` (a duplicate of the registration in `PWAInstallManager.tsx`). Left untouched to keep the diff focused; the update handling lives only in `PWAInstallManager.tsx`, which is the canonical registration point.

No API, contract, or schema changes. No migrations.

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### References

- Root-cause follow-up: https://paycrest-io.atlassian.net/browse/KAN-790
- Affected orders (aggregator): `bb21ebd1-f135-48ce-8fd9-70602331610f`, `7a2d53aa-d788-4df7-8616-01eb86a56ff4`

### Testing

Unit tests added in `__tests__/PWAInstallManager.test.tsx` (3 cases, all passing):

1. First install — page not yet controlled, `controllerchange` fires → **no** reload.
2. Update while on the form step → reload exactly once.
3. Update while a transaction is on screen → no reload; on return to the form step → reload exactly once.

`navigator.serviceWorker` is mocked as an `EventTarget` and `window.location.reload` is stubbed, since jsdom implements neither.

Not covered by unit tests — manual steps for reviewers on staging:

1. Install the staging PWA (or keep a tab open) on the current build.
2. Deploy this branch. On the open tab, observe the page reload once the new worker activates (DevTools → Application → Service Workers shows `noblocks-pwa-v4`).
3. Repeat with an offramp in the Preview / Status step open: the tab must **not** reload until you return to the form.
4. Confirm `noblocks-pwa-v3` / `noblocks-runtime-v3` caches are gone after activation.

`pnpm tsc --noEmit` reports only pre-existing errors unrelated to this change (missing optional deps `@hyperbridge/sdk`, `dd-trace`, `pino`, `dapvatar`, and stale `.next/types`); nothing in the touched files. `next lint` cannot run in this checkout because a parent-directory `.eslintrc.cjs` declares an uninstalled plugin — linted the touched files directly against the repo config instead.

Developed on macOS 26.2, Node v22.22.2, pnpm 9.11.0.

- [x] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract — N/A, no migration


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service-worker update handling to avoid unnecessary reloads during initial installation.
  * Updates detected during an active transaction now wait to reload until returning to the form step.
  * Subsequent service-worker updates reload promptly when the form is active.
  * Updated cached assets help ensure users receive the latest application version after an update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->