### PR TITLE
KAN-790: Move the aggregator sender API key server-side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,6 @@
 
 # Aggregator API
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
-# Sender API key UUID (aggregator dashboard): server proxy + client on-chain messageHash
-NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
 
 # KYC tier monthly swap limits (USD). Omitted or empty = defaults below.
 # Tier 3 also accepts "unlimited" (case-insensitive) to remove the monthly cap.
@@ -98,6 +96,11 @@ NEXT_PUBLIC_ENABLE_EMAIL_IN_ANALYTICS=false
 # Internal API Security
 # Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=
+
+# Server-only: Sender API key UUID (aggregator dashboard). Used by the
+# /api/v1/payment-orders* routes (API-Key header + encrypted offramp messageHash).
+# Never NEXT_PUBLIC_ — it must not reach the browser.
+AGGREGATOR_SENDER_API_KEY_ID=
 
 # =============================================================================
 # Feature Flags

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Visit the live site at [noblocks.xyz](https://noblocks.xyz).
      - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard → Project Settings → API
      - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
 
-   See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
+   See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
 
 3. Install dependencies and start the development server:
 

--- a/__tests__/PWAInstallManager.test.tsx
+++ b/__tests__/PWAInstallManager.test.tsx
@@ -13,6 +13,7 @@ jest.mock("../app/context/StepContext", () => ({
 type MockServiceWorkerContainer = EventTarget & {
   controller: object | null;
   register: jest.Mock;
+  getRegistration?: jest.Mock;
 };
 
 /** Installs a mock `navigator.serviceWorker`; `controller` says whether the page is already controlled. */
@@ -31,6 +32,14 @@ function installServiceWorkerMock(controller: object | null) {
 function fireControllerChange(sw: EventTarget) {
   act(() => {
     sw.dispatchEvent(new Event("controllerchange"));
+  });
+}
+
+/** Points `document.visibilityState` at a mutable value for the update-check tests. */
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
   });
 }
 
@@ -87,5 +96,73 @@ describe("PWAInstall service worker update handling", () => {
     rerender(<PWAInstall />);
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PWAInstall service worker update polling", () => {
+  let updateMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    updateMock = jest.fn().mockResolvedValue(undefined);
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete (window.navigator as { serviceWorker?: unknown }).serviceWorker;
+  });
+
+  function installWithRegistration() {
+    const sw = installServiceWorkerMock({});
+    sw.getRegistration = jest.fn().mockResolvedValue({ update: updateMock });
+    return sw;
+  }
+
+  it("asks the registration to check for an update when the tab becomes visible", async () => {
+    installWithRegistration();
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not check while the tab is hidden", async () => {
+    installWithRegistration();
+    setVisibilityState("hidden");
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("checks for an update on the periodic timer", async () => {
+    jest.useFakeTimers();
+    installWithRegistration();
+    render(<PWAInstall />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(15 * 60 * 1000);
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when no registration exists yet", async () => {
+    installServiceWorkerMock({});
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/paymentOrderMessageHash.test.ts
+++ b/__tests__/paymentOrderMessageHash.test.ts
@@ -1,0 +1,360 @@
+/// <reference types="jest" />
+
+import {
+  constants,
+  createPublicKey,
+  generateKeyPairSync,
+  privateDecrypt,
+} from "crypto";
+
+const SENDER_API_KEY = "11111111-2222-3333-4444-555555555555";
+
+const mockGetSenderApiKey = jest.fn<string, []>(() => SENDER_API_KEY);
+const mockFetchAggregatorPublicKey = jest.fn();
+
+jest.mock("server-only", () => ({}));
+jest.mock("../app/lib/config", () => ({
+  __esModule: true,
+  default: { aggregatorUrl: "https://aggregator.test/v1" },
+}));
+jest.mock("../app/lib/server-config", () => ({
+  getAggregatorSenderApiKey: () => mockGetSenderApiKey(),
+}));
+jest.mock("../app/lib/server-analytics", () => ({
+  trackApiRequest: jest.fn(),
+  trackApiResponse: jest.fn(),
+  trackApiError: jest.fn(),
+}));
+jest.mock("../app/api/aggregator", () => ({
+  fetchAggregatorPublicKey: () => mockFetchAggregatorPublicKey(),
+}));
+// Avoid loading the full utils module (react, sonner, viem) for one constant.
+jest.mock("../app/utils", () => ({ KES_MPESA_INSTITUTION_CODE: "SAFAKEPC" }));
+
+import {
+  buildOfframpRecipient,
+  encryptRecipient,
+  generateRecipientNonce,
+  handleCreateMessageHash,
+  maxPkcs1v15PlaintextBytes,
+  parseAggregatorPublicKey,
+  parseMessageHashBody,
+  RecipientTooLongError,
+  type MessageHashInput,
+  type MessageHashRequest,
+} from "../app/lib/payment-order-message-hash";
+
+type Keys = { publicPem: string; privatePem: string };
+
+function makeKeys(modulusLength: number): Keys {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    modulusLength,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicPem: publicKey, privatePem: privateKey };
+}
+
+/** Decrypts the way the aggregator does (Go rsa.DecryptPKCS1v15) and parses the JSON. */
+function decrypt(messageHashB64: string, privatePem: string): unknown {
+  return JSON.parse(
+    privateDecrypt(
+      { key: privatePem, padding: constants.RSA_PKCS1_PADDING },
+      Buffer.from(messageHashB64, "base64"),
+    ).toString("utf8"),
+  );
+}
+
+function makeRequest(
+  body: unknown,
+  wallet: string | null = "0xabc",
+): MessageHashRequest {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "x-wallet-address" ? wallet : null,
+    },
+    json: async () => body,
+  };
+}
+
+const baseInput: MessageHashInput = {
+  accountIdentifier: "0123456789",
+  accountName: "ADAEZE OKONKWO",
+  institution: "GTBINGLA",
+  memo: "Sept salary",
+};
+
+let keys2048: Keys;
+let keys1024: Keys;
+
+beforeAll(() => {
+  keys2048 = makeKeys(2048);
+  keys1024 = makeKeys(1024);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSenderApiKey.mockReturnValue(SENDER_API_KEY);
+  mockFetchAggregatorPublicKey.mockResolvedValue({
+    status: "success",
+    message: "OK",
+    data: `\n${keys2048.publicPem}\n`,
+  });
+});
+
+describe("parseMessageHashBody", () => {
+  it("accepts the base offramp input and drops unknown fields", () => {
+    const result = parseMessageHashBody({
+      ...baseInput,
+      metadata: { apiKey: "evil" },
+      apiKey: "evil",
+      nonce: "fixed",
+      refundAddress: "0xdead",
+    });
+    expect(result).toEqual({ ok: true, input: baseInput });
+  });
+
+  it.each([
+    ["accountIdentifier", "accountIdentifier is required"],
+    ["accountName", "accountName is required"],
+    ["institution", "institution is required"],
+  ])("rejects a missing %s", (field, error) => {
+    const body = { ...baseInput } as Record<string, unknown>;
+    delete body[field];
+    expect(parseMessageHashBody(body)).toEqual({ ok: false, error });
+  });
+
+  it("rejects a non-object body", () => {
+    expect(parseMessageHashBody(null).ok).toBe(false);
+    expect(parseMessageHashBody([]).ok).toBe(false);
+    expect(parseMessageHashBody("x").ok).toBe(false);
+  });
+
+  it("rejects an invalid kesChannel and a non-numeric businessNumber", () => {
+    expect(parseMessageHashBody({ ...baseInput, kesChannel: "Bank" })).toEqual({
+      ok: false,
+      error: "kesChannel must be one of Mobile, Till, Paybill",
+    });
+    expect(
+      parseMessageHashBody({ ...baseInput, businessNumber: "12a4" }).ok,
+    ).toBe(false);
+  });
+
+  it("bounds memo and providerId", () => {
+    expect(parseMessageHashBody({ ...baseInput, memo: "x".repeat(26) }).ok).toBe(false);
+    expect(
+      parseMessageHashBody({ ...baseInput, providerId: "not valid!" }).ok,
+    ).toBe(false);
+    expect(
+      parseMessageHashBody({ ...baseInput, providerId: "prov_123-abc" }),
+    ).toEqual({ ok: true, input: { ...baseInput, providerId: "prov_123-abc" } });
+  });
+
+  it("treats empty optional strings as absent", () => {
+    const result = parseMessageHashBody({
+      ...baseInput,
+      memo: "",
+      kesChannel: "",
+      businessNumber: "  ",
+    });
+    expect(result).toEqual({
+      ok: true,
+      input: {
+        accountIdentifier: baseInput.accountIdentifier,
+        accountName: baseInput.accountName,
+        institution: baseInput.institution,
+      },
+    });
+  });
+});
+
+describe("buildOfframpRecipient", () => {
+  it("produces exactly the keys the aggregator decrypts, in order", () => {
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "nonce1");
+    expect(Object.keys(recipient)).toEqual([
+      "accountIdentifier",
+      "accountName",
+      "institution",
+      "memo",
+      "nonce",
+      "metadata",
+    ]);
+    expect(recipient.metadata).toEqual({ apiKey: SENDER_API_KEY });
+    expect(recipient.nonce).toBe("nonce1");
+  });
+
+  it("always serialises memo as a string and includes providerId only when given", () => {
+    const { memo: _memo, ...noMemo } = baseInput;
+    expect(buildOfframpRecipient(noMemo, SENDER_API_KEY).memo).toBe("");
+    expect("providerId" in buildOfframpRecipient(noMemo, SENDER_API_KEY)).toBe(false);
+    expect(
+      buildOfframpRecipient({ ...baseInput, providerId: "p1" }, SENDER_API_KEY)
+        .providerId,
+    ).toBe("p1");
+  });
+
+  it.each<[string, Partial<MessageHashInput>, Record<string, string>]>([
+    ["Mobile omits channel", { kesChannel: "Mobile" }, { apiKey: SENDER_API_KEY }],
+    ["Till adds channel", { kesChannel: "Till" }, { apiKey: SENDER_API_KEY, channel: "Till" }],
+    [
+      "Till ignores businessNumber",
+      { kesChannel: "Till", businessNumber: "123456" },
+      { apiKey: SENDER_API_KEY, channel: "Till" },
+    ],
+    [
+      "Paybill adds channel + businessNumber",
+      { kesChannel: "Paybill", businessNumber: "123456" },
+      { apiKey: SENDER_API_KEY, channel: "Paybill", businessNumber: "123456" },
+    ],
+    [
+      "Paybill without businessNumber is channel only",
+      { kesChannel: "Paybill" },
+      { apiKey: SENDER_API_KEY, channel: "Paybill" },
+    ],
+  ])("KES M-Pesa: %s", (_label, extra, expectedMetadata) => {
+    const recipient = buildOfframpRecipient(
+      { ...baseInput, institution: "SAFAKEPC", ...extra },
+      SENDER_API_KEY,
+    );
+    expect(recipient.metadata).toEqual(expectedMetadata);
+  });
+
+  it("ignores KES fields for a non-M-Pesa institution", () => {
+    const recipient = buildOfframpRecipient(
+      { ...baseInput, kesChannel: "Paybill", businessNumber: "123456" },
+      SENDER_API_KEY,
+    );
+    expect(recipient.metadata).toEqual({ apiKey: SENDER_API_KEY });
+  });
+
+  it("generates unique, URL-safe nonces", () => {
+    const nonces = new Set(Array.from({ length: 200 }, generateRecipientNonce));
+    expect(nonces.size).toBe(200);
+    for (const nonce of nonces) expect(nonce).toMatch(/^[A-Za-z0-9_-]{12}$/);
+  });
+});
+
+describe("parseAggregatorPublicKey / encryptRecipient", () => {
+  it("round-trips through SPKI, PKCS#1 and a mislabelled SPKI-body PEM", () => {
+    const spki = keys2048.publicPem;
+    const pkcs1 = createPublicKey(spki).export({ type: "pkcs1", format: "pem" }) as string;
+    const mislabelled = spki
+      .replace("BEGIN PUBLIC KEY", "BEGIN RSA PUBLIC KEY")
+      .replace("END PUBLIC KEY", "END RSA PUBLIC KEY");
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "n");
+
+    for (const pem of [spki, pkcs1, mislabelled, `\n${spki}\n`]) {
+      const key = parseAggregatorPublicKey(pem);
+      const messageHash = encryptRecipient(recipient, key);
+      expect(messageHash).toMatch(/^[A-Za-z0-9+/]+=*$/);
+      expect(decrypt(messageHash, keys2048.privatePem)).toEqual(recipient);
+    }
+  });
+
+  it("uses random padding so identical recipients encrypt differently", () => {
+    const key = parseAggregatorPublicKey(keys2048.publicPem);
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "n");
+    expect(encryptRecipient(recipient, key)).not.toBe(encryptRecipient(recipient, key));
+  });
+
+  it("rejects a non-RSA or empty key", () => {
+    const { publicKey: ed } = generateKeyPairSync("ed25519", {
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    expect(() => parseAggregatorPublicKey(ed)).toThrow(/expected rsa/);
+    expect(() => parseAggregatorPublicKey("")).toThrow(/empty/);
+  });
+
+  it("computes the PKCS#1 v1.5 budget and refuses oversized payloads", () => {
+    expect(maxPkcs1v15PlaintextBytes(parseAggregatorPublicKey(keys2048.publicPem))).toBe(245);
+    const small = parseAggregatorPublicKey(keys1024.publicPem);
+    expect(maxPkcs1v15PlaintextBytes(small)).toBe(117);
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY);
+    expect(Buffer.byteLength(JSON.stringify(recipient))).toBeGreaterThan(117);
+    expect(() => encryptRecipient(recipient, small)).toThrow(RecipientTooLongError);
+  });
+});
+
+describe("handleCreateMessageHash", () => {
+  it("returns 401 without a verified wallet header", async () => {
+    const result = await handleCreateMessageHash(makeRequest(baseInput, null));
+    expect(result.status).toBe(401);
+    expect(mockFetchAggregatorPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic 503 when the sender API key is not configured", async () => {
+    mockGetSenderApiKey.mockReturnValue("");
+    const result = await handleCreateMessageHash(makeRequest(baseInput));
+    expect(result.status).toBe(503);
+    expect(JSON.stringify(result.body)).not.toMatch(/AGGREGATOR_SENDER_API_KEY_ID/);
+  });
+
+  it("returns 400 for invalid JSON and for a bad body", async () => {
+    const badJson: MessageHashRequest = {
+      headers: makeRequest({}).headers,
+      json: async () => {
+        throw new SyntaxError("bad");
+      },
+    };
+    expect((await handleCreateMessageHash(badJson)).status).toBe(400);
+    expect(
+      (await handleCreateMessageHash(makeRequest({ ...baseInput, institution: "" }))).status,
+    ).toBe(400);
+  });
+
+  it("returns 502 when the aggregator public key cannot be fetched or is malformed", async () => {
+    mockFetchAggregatorPublicKey.mockRejectedValueOnce(new Error("ECONNRESET"));
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({ status: "error", message: "nope" });
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({ status: "success", data: 42 });
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+  });
+
+  it("returns 422 when the recipient exceeds the RSA budget", async () => {
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({
+      status: "success",
+      data: keys1024.publicPem,
+    });
+    const result = await handleCreateMessageHash(makeRequest(baseInput));
+    expect(result.status).toBe(422);
+    expect(result.body.message).toMatch(/too long/);
+  });
+
+  it("returns 200 with a messageHash the aggregator can decrypt, using the server-side key", async () => {
+    const result = await handleCreateMessageHash(
+      makeRequest({
+        ...baseInput,
+        institution: "SAFAKEPC",
+        kesChannel: "Paybill",
+        businessNumber: "654321",
+        // Client-supplied values that must be ignored:
+        metadata: { apiKey: "evil-key" },
+        apiKey: "evil-key",
+        nonce: "fixed-nonce",
+      }),
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.status).toBe("success");
+    const messageHash = (result.body.data as { messageHash: string }).messageHash;
+    const recipient = decrypt(messageHash, keys2048.privatePem) as Record<string, unknown>;
+
+    expect(recipient.metadata).toEqual({
+      apiKey: SENDER_API_KEY,
+      channel: "Paybill",
+      businessNumber: "654321",
+    });
+    expect(recipient.nonce).not.toBe("fixed-nonce");
+    expect(recipient.nonce).toMatch(/^[A-Za-z0-9_-]{12}$/);
+    expect(recipient.accountIdentifier).toBe(baseInput.accountIdentifier);
+    // A realistic KES Paybill payout must fit the production key's budget.
+    expect(Buffer.byteLength(JSON.stringify(recipient), "utf8")).toBeLessThanOrEqual(245);
+    expect(recipient).not.toHaveProperty("apiKey");
+    expect(recipient).not.toHaveProperty("refundAddress");
+  });
+});

--- a/__tests__/paymentOrderMessageHash.test.ts
+++ b/__tests__/paymentOrderMessageHash.test.ts
@@ -55,14 +55,25 @@ function makeKeys(modulusLength: number): Keys {
   return { publicPem: publicKey, privatePem: privateKey };
 }
 
-/** Decrypts the way the aggregator does (Go rsa.DecryptPKCS1v15) and parses the JSON. */
+/**
+ * Decrypts the way the aggregator does (Go rsa.DecryptPKCS1v15) and parses the
+ * JSON. Uses RSA_NO_PADDING and strips the EME-PKCS1-v1_5 padding by hand:
+ * Node's official binaries bundle an OpenSSL without implicit rejection, so
+ * privateDecrypt(RSA_PKCS1_PADDING) is refused there (CVE-2023-46809) and the
+ * suite would fail in CI. Unpadding manually also asserts the exact wire
+ * format the aggregator expects: 0x00 0x02 || PS (>= 8 non-zero bytes) || 0x00 || M.
+ */
 function decrypt(messageHashB64: string, privatePem: string): unknown {
-  return JSON.parse(
-    privateDecrypt(
-      { key: privatePem, padding: constants.RSA_PKCS1_PADDING },
-      Buffer.from(messageHashB64, "base64"),
-    ).toString("utf8"),
+  const em = privateDecrypt(
+    { key: privatePem, padding: constants.RSA_NO_PADDING },
+    Buffer.from(messageHashB64, "base64"),
   );
+  expect(em[0]).toBe(0x00);
+  expect(em[1]).toBe(0x02);
+  const separator = em.indexOf(0x00, 2);
+  expect(separator).toBeGreaterThanOrEqual(2 + 8);
+  expect(em.subarray(2, separator).includes(0x00)).toBe(false);
+  return JSON.parse(em.subarray(separator + 1).toString("utf8"));
 }
 
 function makeRequest(

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -628,9 +628,14 @@ export const fetchSupportedInstitutions = async (
  * @returns {Promise<PubkeyResponse>} The public key response
  * @throws {Error} If the API request fails
  */
+/** Bounded so a stalled aggregator surfaces as an error (axios has no default timeout). */
+const PUBKEY_TIMEOUT_MS = 10_000;
+
 export const fetchAggregatorPublicKey = async (): Promise<PubkeyResponse> => {
   try {
-    const response = await axios.get(`${AGGREGATOR_URL}/pubkey`);
+    const response = await axios.get(`${AGGREGATOR_URL}/pubkey`, {
+      timeout: PUBKEY_TIMEOUT_MS,
+    });
     return response.data;
   } catch (error) {
     console.error("Error fetching aggregator public key:", error);

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -33,6 +33,7 @@ import type {
   ReferralData,
   ApiResponse,
   SubmitReferralResult,
+  KesMpesaChannel,
 } from "../types";
 import {
   trackServerEvent,
@@ -41,6 +42,7 @@ import {
   trackApiResponse,
 } from "../lib/server-analytics";
 import config from "../lib/config";
+import { getAggregatorSenderApiKey } from "../lib/server-config";
 import {
   isGatewayOrderId,
   isStarknetOrderId,
@@ -731,7 +733,12 @@ export const fetchOrderDetails = async (
 
   const injectedToken = options?.injectedToken?.trim();
 
-  if (typeof window !== "undefined" && (accessToken?.trim() || injectedToken)) {
+  if (typeof window !== "undefined") {
+    // Browser: always go through the Noblocks proxy. The direct aggregator
+    // path below attaches the sender API key, which is server-only.
+    if (!accessToken?.trim() && !injectedToken) {
+      throw new Error("Authentication required to fetch order details");
+    }
     const headers: Record<string, string> = {};
     if (injectedToken) {
       headers["x-injected-token"] = injectedToken;
@@ -763,11 +770,9 @@ export const fetchOrderDetails = async (
       : buildV2SenderOrderUrl(id);
     const headers: Record<string, string> = {};
     if (!gatewayLookup) {
-      const apiKey = config.aggregatorSenderApiKey?.trim();
+      const apiKey = getAggregatorSenderApiKey();
       if (!apiKey) {
-        throw new Error(
-          "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured",
-        );
+        throw new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured");
       }
       headers["API-Key"] = apiKey;
     }
@@ -1675,6 +1680,63 @@ export async function createV2SenderPaymentOrder(
     { headers },
   );
   return response.data;
+}
+
+/** Recipient fields the client supplies for an offramp order; the server adds the nonce and sender API key. */
+export type OfframpMessageHashPayload = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo?: string;
+  providerId?: string;
+  kesChannel?: KesMpesaChannel;
+  businessNumber?: string;
+};
+
+/**
+ * Offramp only. Asks the server to build the encrypted recipient payload for
+ * gateway.createOrder. The server generates the nonce, injects the sender API
+ * key (which never reaches the browser), applies the KES M-Pesa metadata rules,
+ * and RSA-encrypts with the aggregator public key. Returns the base64
+ * ciphertext used as the on-chain `messageHash` argument.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
+ */
+export async function createOfframpMessageHash(
+  payload: OfframpMessageHashPayload,
+  accessToken: string | null,
+  injectedToken: string | null = null,
+): Promise<string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+  // validateStatus + manual throw: middleware 401s carry `{ error }` rather than
+  // `{ message }`, and an axios throw on 5xx would collapse to the generic
+  // server-error copy. This keeps the server's specific message when present.
+  const response = await axios.post<AggregatorEnvelope<{ messageHash: string }>>(
+    "/api/v1/payment-orders/message-hash",
+    payload,
+    { headers, validateStatus: () => true },
+  );
+  const envelope = response.data;
+  const messageHash = envelope?.data?.messageHash;
+  if (
+    response.status >= 400 ||
+    envelope?.status !== "success" ||
+    typeof messageHash !== "string" ||
+    !messageHash
+  ) {
+    throw new Error(
+      typeof envelope?.message === "string" && envelope.message
+        ? envelope.message
+        : `Could not prepare order (${response.status})`,
+    );
+  }
+  return messageHash;
 }
 
 /**

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import config from "@/app/lib/config";
+import { getAggregatorSenderApiKey } from "@/app/lib/server-config";
 import { aggregatorOriginForV2 } from "@/app/api/aggregator";
 import {
   isGatewayOrderId,
@@ -84,21 +85,22 @@ export const GET = withRateLimit(
         }
         url = `${base}/v2/orders/${chainId}/${encodeURIComponent(orderId)}`;
       } else if (isSenderPaymentOrderUuid(orderId)) {
-        if (!config.aggregatorSenderApiKey?.trim()) {
+        const senderApiKey = getAggregatorSenderApiKey();
+        if (!senderApiKey) {
           trackApiError(
             request,
             "/api/v1/payment-orders/[id]",
             "GET",
-            new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+            new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
             500,
           );
           return NextResponse.json(
-            { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+            { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
             { status: 500 },
           );
         }
         url = `${base}/v2/sender/orders/${encodeURIComponent(orderId)}`;
-        headers = { "API-Key": config.aggregatorSenderApiKey.trim() };
+        headers = { "API-Key": senderApiKey };
       } else {
         return NextResponse.json(
           {

--- a/app/api/v1/payment-orders/message-hash/route.ts
+++ b/app/api/v1/payment-orders/message-hash/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { handleCreateMessageHash } from "@/app/lib/payment-order-message-hash";
+
+// Authenticated by middleware.ts via the "/api/v1/payment-orders/:path*" matcher
+// (x-wallet-address is injected there). This static segment takes precedence
+// over the sibling [id] dynamic route. Node runtime only — crypto.publicEncrypt
+// is not available on the Edge runtime.
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const result = await handleCreateMessageHash(request);
+  return NextResponse.json(result.body, { status: result.status });
+});

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -7,6 +7,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import config from "@/app/lib/config";
+import { getAggregatorSenderApiKey } from "@/app/lib/server-config";
 import { getKycFullName } from "@/app/lib/kyc-profile-server";
 import { isOnrampFiatCurrencyCode } from "@/app/utils";
 import {
@@ -35,16 +36,17 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       );
     }
 
-    if (!config.aggregatorSenderApiKey?.trim()) {
+    const senderApiKey = getAggregatorSenderApiKey();
+    if (!senderApiKey) {
       trackApiError(
         request,
         "/api/v1/payment-orders",
         "POST",
-        new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+        new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
         500,
       );
       return NextResponse.json(
-        { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+        { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
         { status: 500 },
       );
     }
@@ -194,7 +196,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     const { data, status } = await axios.post(url, body, {
       headers: {
         "Content-Type": "application/json",
-        "API-Key": config.aggregatorSenderApiKey.trim(),
+        "API-Key": senderApiKey,
       },
       validateStatus: () => true,
     });

--- a/app/components/PWAInstallManager.tsx
+++ b/app/components/PWAInstallManager.tsx
@@ -3,10 +3,16 @@
 import React, { useEffect, useRef } from "react";
 import { useStep } from "../context/StepContext";
 
+/** How often an open tab asks the browser to re-check sw.js for a new build. */
+const SW_UPDATE_INTERVAL_MS = 15 * 60 * 1000;
+
 /**
  * Registers the PWA service worker and keeps open tabs on the current build:
  * when a new worker takes control it reloads the page — skipped on first
- * install, and deferred while a transaction step is on screen.
+ * install, and deferred while a transaction step is on screen. Idle tabs are
+ * nudged to look for a new worker on a timer and whenever they come back into
+ * view, since browsers otherwise only re-check sw.js on navigation or roughly
+ * once a day.
  */
 export default function PWAInstall() {
   const { isFormStep } = useStep();
@@ -15,6 +21,7 @@ export default function PWAInstall() {
   // update — reloading there would loop on every first visit.
   const hadControllerRef = useRef(false);
   const updatePendingRef = useRef(false);
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
 
   useEffect(() => {
     // Register service worker
@@ -23,6 +30,7 @@ export default function PWAInstall() {
         navigator.serviceWorker
           .register("/sw.js")
           .then((registration) => {
+            registrationRef.current = registration;
             console.log("SW registered: ", registration);
           })
           .catch((registrationError) => {
@@ -46,10 +54,10 @@ export default function PWAInstall() {
 
   // sw.js calls skipWaiting() + clients.claim(), so a new worker takes over
   // open pages immediately — but each page keeps running the JS it already
-  // loaded. Build-time config (NEXT_PUBLIC_* keys) lives in that JS, so a
-  // long-lived PWA tab keeps stamping stale values until it reloads. Reload as
-  // soon as a new worker takes control, unless a transaction is on screen; in
-  // that case wait until the user is back on the form.
+  // loaded. Build-time config lives in that JS, so a long-lived PWA tab keeps
+  // running stale code until it reloads. Reload as soon as a new worker takes
+  // control, unless a transaction is on screen; in that case wait until the
+  // user is back on the form.
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
     const sw = navigator.serviceWorker;
@@ -78,6 +86,42 @@ export default function PWAInstall() {
       sw.removeEventListener("controllerchange", handleControllerChange);
     };
   }, [isFormStep]);
+
+  // Ask the browser to re-check sw.js when the tab comes back into view and on
+  // a timer. When a new worker is found it installs, claims the page, and the
+  // controllerchange effect above handles the reload.
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+    const sw = navigator.serviceWorker;
+    let cancelled = false;
+
+    const checkForUpdate = async () => {
+      try {
+        const registration =
+          registrationRef.current ?? (await sw.getRegistration?.()) ?? null;
+        if (cancelled || !registration) return;
+        await registration.update();
+      } catch {
+        // Transient network failures are expected here; the next tick retries.
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") void checkForUpdate();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    const timer = window.setInterval(
+      () => void checkForUpdate(),
+      SW_UPDATE_INTERVAL_MS,
+    );
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.clearInterval(timer);
+    };
+  }, []);
 
   // This component doesn't render anything - it just sets up PWA functionality
   // The browser will show its native install prompt when appropriate

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -56,8 +56,6 @@ const config: Config = {
     );
     return Number.isFinite(parsed) ? parsed : 0;
   })(),
-  /** Sender API key UUID (aggregator dashboard). Used by server proxy and client (on-chain messageHash metadata). */
-  aggregatorSenderApiKey: (process.env.NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID || "").trim(),
   moralisWebhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
   activepiecesWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
   activepiecesSignupVerifyWebhookUrl:

--- a/app/lib/payment-order-message-hash.ts
+++ b/app/lib/payment-order-message-hash.ts
@@ -1,0 +1,394 @@
+import "server-only";
+import type { NextRequest } from "next/server";
+import {
+  constants,
+  createPublicKey,
+  publicEncrypt,
+  randomBytes,
+  type KeyObject,
+} from "crypto";
+import config from "./config";
+import { getAggregatorSenderApiKey } from "./server-config";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "./server-analytics";
+import { KES_MPESA_INSTITUTION_CODE } from "../utils";
+import { fetchAggregatorPublicKey } from "../api/aggregator";
+import type { KesMpesaChannel } from "../types";
+
+/**
+ * Server-side construction of the encrypted offramp recipient payload.
+ *
+ * Offramp orders are created on-chain by the user's wallet, and the aggregator
+ * learns which sender profile owns the order only from `metadata.apiKey`
+ * inside the RSA-encrypted recipient blob passed as `messageHash`. Building
+ * that blob here — rather than in the browser — is what keeps the sender API
+ * key out of the client bundle. The payload shape is unchanged from the
+ * previous client-side implementation, so the aggregator needs no change.
+ *
+ * Handler follows app/lib/refund-account-api.ts: a minimal request surface in,
+ * `{ status, body }` out, so it is unit-testable without NextRequest.
+ */
+
+export const MESSAGE_HASH_ENDPOINT = "/api/v1/payment-orders/message-hash";
+
+const KES_CHANNELS: readonly string[] = ["Mobile", "Till", "Paybill"];
+const MAX_ACCOUNT_IDENTIFIER = 32;
+const MAX_ACCOUNT_NAME = 100;
+/** Mirrors the memo input's maxLength in TransactionForm. */
+const MAX_MEMO = 25;
+/** Comes straight from the `?provider=` query string — bounded, not trusted. */
+const MAX_PROVIDER_ID = 64;
+const INSTITUTION_RE = /^[A-Za-z0-9_.-]{2,32}$/;
+const PROVIDER_ID_RE = /^[\w-]+$/;
+const BUSINESS_NUMBER_RE = /^\d{1,12}$/;
+/** PKCS#1 v1.5 EME: 0x00 0x02, at least 8 non-zero padding bytes, 0x00. */
+const PKCS1_V15_OVERHEAD_BYTES = 11;
+
+export type MessageHashInput = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo?: string;
+  providerId?: string;
+  kesChannel?: KesMpesaChannel;
+  businessNumber?: string;
+};
+
+/** Exactly the shape the aggregator indexer decrypts (OrderEVM.CreateOrder). */
+export type OfframpRecipient = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo: string;
+  providerId?: string;
+  nonce: string;
+  metadata: { apiKey: string; channel?: string; businessNumber?: string };
+};
+
+/** Minimal request surface used by the handler (avoids NextRequest in tests). */
+export type MessageHashRequest = {
+  headers: { get(name: string): string | null };
+  json?: () => Promise<unknown>;
+};
+
+export type MessageHashApiResult = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+export type ParseMessageHashResult =
+  | { ok: true; input: MessageHashInput }
+  | { ok: false; error: string };
+
+export class RecipientTooLongError extends Error {
+  constructor(message = "Recipient details are too long to encrypt") {
+    super(message);
+    this.name = "RecipientTooLongError";
+  }
+}
+
+/**
+ * Allowlist parser. Only the seven recipient fields the client legitimately
+ * knows are read; `metadata`, `apiKey`, `nonce` or anything else in the body
+ * is ignored by construction.
+ */
+export function parseMessageHashBody(raw: unknown): ParseMessageHashResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, error: "Request body must be a JSON object" };
+  }
+  const body = raw as Record<string, unknown>;
+
+  const accountIdentifier = requiredString(body, "accountIdentifier", MAX_ACCOUNT_IDENTIFIER);
+  if ("error" in accountIdentifier) return { ok: false, error: accountIdentifier.error };
+  const accountName = requiredString(body, "accountName", MAX_ACCOUNT_NAME);
+  if ("error" in accountName) return { ok: false, error: accountName.error };
+  const institution = requiredString(body, "institution", 32);
+  if ("error" in institution) return { ok: false, error: institution.error };
+  if (!INSTITUTION_RE.test(institution.value)) {
+    return { ok: false, error: "institution is not a valid institution code" };
+  }
+
+  const memo = optionalString(body, "memo", MAX_MEMO);
+  if ("error" in memo) return { ok: false, error: memo.error };
+  const providerId = optionalString(body, "providerId", MAX_PROVIDER_ID);
+  if ("error" in providerId) return { ok: false, error: providerId.error };
+  if (providerId.value && !PROVIDER_ID_RE.test(providerId.value)) {
+    return { ok: false, error: "providerId contains invalid characters" };
+  }
+  const kesChannel = optionalString(body, "kesChannel", 16);
+  if ("error" in kesChannel) return { ok: false, error: kesChannel.error };
+  if (kesChannel.value && !KES_CHANNELS.includes(kesChannel.value)) {
+    return { ok: false, error: "kesChannel must be one of Mobile, Till, Paybill" };
+  }
+  const businessNumber = optionalString(body, "businessNumber", 12);
+  if ("error" in businessNumber) return { ok: false, error: businessNumber.error };
+  if (businessNumber.value && !BUSINESS_NUMBER_RE.test(businessNumber.value)) {
+    return { ok: false, error: "businessNumber must be 1–12 digits" };
+  }
+
+  return {
+    ok: true,
+    input: {
+      accountIdentifier: accountIdentifier.value,
+      accountName: accountName.value,
+      institution: institution.value,
+      ...(memo.value !== undefined && { memo: memo.value }),
+      ...(providerId.value !== undefined && { providerId: providerId.value }),
+      ...(kesChannel.value !== undefined && {
+        kesChannel: kesChannel.value as KesMpesaChannel,
+      }),
+      ...(businessNumber.value !== undefined && {
+        businessNumber: businessNumber.value,
+      }),
+    },
+  };
+}
+
+function requiredString(
+  body: Record<string, unknown>,
+  key: string,
+  max: number,
+): { value: string } | { error: string } {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) {
+    return { error: `${key} is required` };
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > max) {
+    return { error: `${key} must be at most ${max} characters` };
+  }
+  return { value: trimmed };
+}
+
+function optionalString(
+  body: Record<string, unknown>,
+  key: string,
+  max: number,
+): { value: string | undefined } | { error: string } {
+  const value = body[key];
+  if (value === undefined || value === null || value === "") {
+    return { value: undefined };
+  }
+  if (typeof value !== "string") {
+    return { error: `${key} must be a string` };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return { value: undefined };
+  if (trimmed.length > max) {
+    return { error: `${key} must be at most ${max} characters` };
+  }
+  return { value: trimmed };
+}
+
+/**
+ * 12 URL-safe chars (72 bits) from a CSPRNG. The aggregator never reads the
+ * nonce; it only makes ciphertexts unique. Kept at or below the old client
+ * nonce length (13 chars) so the payload never grows against the 245-byte
+ * PKCS#1 v1.5 budget.
+ */
+export function generateRecipientNonce(): string {
+  return randomBytes(9).toString("base64url");
+}
+
+/**
+ * Builds the recipient exactly as the client used to, with the KES M-Pesa
+ * rules from TransactionPreview: `channel` is included for Till/Paybill (never
+ * "Mobile", the default), `businessNumber` only for Paybill, and both only when
+ * the institution is M-Pesa. `memo` is always present (possibly "") to keep the
+ * on-chain payload byte-compatible with the previous client build.
+ */
+export function buildOfframpRecipient(
+  input: MessageHashInput,
+  apiKey: string,
+  nonce: string = generateRecipientNonce(),
+): OfframpRecipient {
+  const metadata: OfframpRecipient["metadata"] = { apiKey };
+  if (input.institution === KES_MPESA_INSTITUTION_CODE && input.kesChannel) {
+    if (input.kesChannel !== "Mobile") {
+      metadata.channel = input.kesChannel;
+    }
+    if (input.kesChannel === "Paybill" && input.businessNumber) {
+      metadata.businessNumber = input.businessNumber;
+    }
+  }
+
+  return {
+    accountIdentifier: input.accountIdentifier,
+    accountName: input.accountName,
+    institution: input.institution,
+    memo: input.memo ?? "",
+    ...(input.providerId ? { providerId: input.providerId } : {}),
+    nonce,
+    metadata,
+  };
+}
+
+/**
+ * Parses the aggregator's `/pubkey` PEM by its DER body, not its label. The
+ * aggregator's own reference config ships a key labelled `RSA PUBLIC KEY`
+ * whose body is SPKI; Go and jsencrypt accept it, Node's PEM parser does not.
+ */
+export function parseAggregatorPublicKey(pem: string): KeyObject {
+  const base64 = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  if (!base64) {
+    throw new Error("Aggregator public key is empty");
+  }
+  const der = Buffer.from(base64, "base64");
+  let key: KeyObject;
+  try {
+    key = createPublicKey({ key: der, format: "der", type: "spki" });
+  } catch {
+    key = createPublicKey({ key: der, format: "der", type: "pkcs1" });
+  }
+  if (key.asymmetricKeyType !== "rsa") {
+    throw new Error(
+      `Aggregator public key is ${key.asymmetricKeyType ?? "unknown"}, expected rsa`,
+    );
+  }
+  return key;
+}
+
+/** Largest plaintext PKCS#1 v1.5 can carry for this key (245 bytes for the production 2047-bit key). */
+export function maxPkcs1v15PlaintextBytes(key: KeyObject): number {
+  const modulusBits = key.asymmetricKeyDetails?.modulusLength;
+  if (!modulusBits) {
+    throw new Error("Cannot determine RSA modulus length");
+  }
+  return Math.ceil(modulusBits / 8) - PKCS1_V15_OVERHEAD_BYTES;
+}
+
+/**
+ * RSA PKCS#1 v1.5 via Node crypto (CSPRNG padding). Byte-identical output
+ * format to the jsencrypt call this replaces, and what the aggregator's
+ * `rsa.DecryptPKCS1v15` expects. Never use jsencrypt server-side: without
+ * `window.crypto` it seeds its padding RNG from Math.random().
+ */
+export function encryptRecipient(recipient: unknown, key: KeyObject): string {
+  const plaintext = Buffer.from(JSON.stringify(recipient), "utf8");
+  if (plaintext.length > maxPkcs1v15PlaintextBytes(key)) {
+    throw new RecipientTooLongError();
+  }
+  try {
+    return publicEncrypt(
+      { key, padding: constants.RSA_PKCS1_PADDING },
+      plaintext,
+    ).toString("base64");
+  } catch (error) {
+    if (/too large/i.test(error instanceof Error ? error.message : "")) {
+      throw new RecipientTooLongError();
+    }
+    throw error;
+  }
+}
+
+function errorBody(message: string): Record<string, unknown> {
+  return { status: "error", message };
+}
+
+export async function handleCreateMessageHash(
+  request: MessageHashRequest,
+): Promise<MessageHashApiResult> {
+  const startTime = Date.now();
+  const req = request as unknown as NextRequest;
+  const walletAddress = request.headers.get("x-wallet-address")?.toLowerCase();
+
+  if (!walletAddress) {
+    trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error("Unauthorized"), 401);
+    return { status: 401, body: errorBody("Unauthorized") };
+  }
+
+  trackApiRequest(req, MESSAGE_HASH_ENDPOINT, "POST", { wallet_address: walletAddress });
+
+  try {
+    const apiKey = getAggregatorSenderApiKey();
+    if (!apiKey || !config.aggregatorUrl) {
+      // Env names stay server-side; the client only sees a generic 503.
+      const cause = !apiKey
+        ? "AGGREGATOR_SENDER_API_KEY_ID is not configured"
+        : "NEXT_PUBLIC_AGGREGATOR_URL is not configured";
+      console.error(`[message-hash] ${cause}`);
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error(cause), 503);
+      return { status: 503, body: errorBody("Order service temporarily unavailable") };
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json?.();
+    } catch {
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error("Invalid JSON body"), 400);
+      return { status: 400, body: errorBody("Invalid JSON body") };
+    }
+    const parsed = parseMessageHashBody(raw);
+    if (!parsed.ok) {
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error(parsed.error), 400);
+      return { status: 400, body: errorBody(parsed.error) };
+    }
+
+    let publicKey: KeyObject;
+    try {
+      const response = await fetchAggregatorPublicKey();
+      if (response?.status !== "success" || typeof response.data !== "string") {
+        throw new Error(`Unexpected /pubkey response: ${String(response?.status)}`);
+      }
+      publicKey = parseAggregatorPublicKey(response.data);
+    } catch (error) {
+      trackApiError(
+        req,
+        MESSAGE_HASH_ENDPOINT,
+        "POST",
+        error instanceof Error ? error : new Error(String(error)),
+        502,
+      );
+      return {
+        status: 502,
+        body: errorBody("Could not reach the aggregator. Please try again."),
+      };
+    }
+
+    // No pubkey cache on purpose: an aggregator key rotation would otherwise
+    // fail silently for the cache lifetime. One GET per order is negligible.
+    const recipient = buildOfframpRecipient(parsed.input, apiKey);
+
+    let messageHash: string;
+    try {
+      messageHash = encryptRecipient(recipient, publicKey);
+    } catch (error) {
+      if (error instanceof RecipientTooLongError) {
+        trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", error, 422);
+        return {
+          status: 422,
+          body: errorBody(
+            "Recipient details are too long to encrypt. Shorten the memo and try again.",
+          ),
+        };
+      }
+      throw error;
+    }
+
+    trackApiResponse(MESSAGE_HASH_ENDPOINT, "POST", 200, Date.now() - startTime, {
+      wallet_address: walletAddress,
+      institution: parsed.input.institution,
+    });
+    return {
+      status: 200,
+      body: { status: "success", message: "OK", data: { messageHash } },
+    };
+  } catch (error) {
+    console.error("[message-hash] unexpected error:", error);
+    trackApiError(
+      req,
+      MESSAGE_HASH_ENDPOINT,
+      "POST",
+      error instanceof Error ? error : new Error(String(error)),
+      500,
+      { response_time_ms: Date.now() - startTime },
+    );
+    return { status: 500, body: errorBody("Internal server error") };
+  }
+}

--- a/app/lib/server-config.ts
+++ b/app/lib/server-config.ts
@@ -60,3 +60,18 @@ export function getServerMixpanelToken(): string {
     false, // Optional - analytics can fail gracefully
   );
 }
+
+/**
+ * Aggregator sender API key (UUID from the aggregator dashboard).
+ *
+ * SERVER-ONLY. Sent as the `API-Key` header by the /api/v1/payment-orders*
+ * routes and injected into the encrypted offramp messageHash by
+ * app/lib/payment-order-message-hash.ts. Never NEXT_PUBLIC_ — the value must
+ * not reach the browser. Read lazily per call so a missing variable degrades
+ * to a 503 at request time instead of breaking `next build` (CI builds with it
+ * unset).
+ */
+export function getAggregatorSenderApiKey(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.AGGREGATOR_SENDER_API_KEY_ID || "").trim();
+}

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -19,7 +19,6 @@ import {
   getNetworkImageUrl,
   getRpcUrl,
   normalizeNetworkName,
-  publicKeyEncrypt,
   shortenAddress,
 } from "../utils";
 import { tokensEqual, toAggregatorToken } from "../lib/token-symbol";
@@ -68,7 +67,7 @@ import {
 import { useApiAuth } from "../hooks/useApiAuth";
 
 import {
-  fetchAggregatorPublicKey,
+  createOfframpMessageHash,
   fetchTokens,
   saveTransaction,
   precheckSwapTransaction,
@@ -375,57 +374,31 @@ export const TransactionPreview = ({
       network: selectedNetwork.chain.name,
     };
 
-  const prepareCreateOrderParams = async () => {
-    const senderApiKeyId = config.aggregatorSenderApiKey?.trim();
-    if (!senderApiKeyId) {
-      throw new Error(
-        "Sender API key is not configured (set NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID)",
-      );
-    }
-    const metadata: Record<string, string> = { apiKey: senderApiKeyId };
-    if (
-      !isOnramp &&
-      formValues.institution === KES_MPESA_INSTITUTION_CODE &&
-      formValues.kesChannel
-    ) {
-      // Omit Mobile channel (default phone M-Pesa); include Till/Paybill for aggregator.
-      if (formValues.kesChannel !== "Mobile") {
-        metadata.channel = formValues.kesChannel;
-      }
-      if (
-        formValues.kesChannel === "Paybill" &&
-        formValues.businessNumber?.trim()
-      ) {
-        metadata.businessNumber = formValues.businessNumber.trim();
-      }
-    }
+  type OrderAuth = { accessToken: string | null; injectedToken: string | null };
 
+  // Offramp only (onramp never reaches createOrder). The server builds the
+  // encrypted recipient — nonce and sender API key are added there, so the key
+  // never reaches the browser. Raw KES fields are sent; the server applies the
+  // channel/businessNumber rules authoritatively.
+  const prepareCreateOrderParams = async (auth: OrderAuth) => {
     const providerId =
       searchParams.get("provider") || searchParams.get("PROVIDER");
 
-    // Prepare recipient data (metadata.apiKey matches aggregator OrderEVM.CreateOrder + indexer)
-    const recipient = isOnramp
-      ? {
-        accountIdentifier: walletAddress || "",
-        accountName: recipientName || walletAddress || "",
-        institution: "Wallet",
-        ...(providerId && { providerId }),
-        nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
-        metadata,
-      }
-      : {
+    const messageHash = await createOfframpMessageHash(
+      {
         accountIdentifier: formValues.accountIdentifier,
         accountName: recipientName,
         institution: formValues.institution,
         memo: formValues.memo,
         ...(providerId && { providerId }),
-        nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
-        metadata,
-      };
-
-    // Fetch aggregator public key
-    const publicKey = await fetchAggregatorPublicKey();
-    const encryptedRecipient = publicKeyEncrypt(recipient, publicKey.data);
+        ...(formValues.kesChannel && { kesChannel: formValues.kesChannel }),
+        ...(formValues.businessNumber?.trim() && {
+          businessNumber: formValues.businessNumber.trim(),
+        }),
+      },
+      auth.accessToken,
+      auth.injectedToken,
+    );
 
     // Prepare transaction parameters
     const params = {
@@ -435,7 +408,7 @@ export const TransactionPreview = ({
       senderFeeRecipient: zeroAddress,
       senderFee: BigInt(0),
       refundAddress: activeWallet?.address as `0x${string}`,
-      messageHash: encryptedRecipient,
+      messageHash,
     };
 
     return params;
@@ -453,14 +426,14 @@ export const TransactionPreview = ({
     }
   };
 
-  const createOrder = async () => {
+  const createOrder = async (auth: OrderAuth) => {
     try {
       if (isStarknetSelected) {
         if (!starknetWalletId || !starknetPublicKey || !starknetWalletAddress) {
           throw new Error("Starknet wallet not ready");
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const accessToken = await getAccessToken();
@@ -526,7 +499,7 @@ export const TransactionPreview = ({
           throw new Error("Injected wallet not ready");
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const requiredSpend = params.amount + params.senderFee;
@@ -665,7 +638,7 @@ export const TransactionPreview = ({
           authorization = await signDelegationAuthorization(chainId);
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
         const requiredSpend = params.amount + params.senderFee;
 
@@ -785,7 +758,7 @@ export const TransactionPreview = ({
           id: selectedNetwork.chain.id,
         });
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const requiredSpend = params.amount + params.senderFee;
@@ -1101,7 +1074,7 @@ export const TransactionPreview = ({
         injectedToken,
       );
 
-      await createOrder();
+      await createOrder({ accessToken, injectedToken });
     } catch (e) {
       const msg =
         e instanceof Error ? e.message : "Unable to start this transaction.";

--- a/app/types.ts
+++ b/app/types.ts
@@ -490,7 +490,6 @@ export type Config = {
   maintenanceSchedule: string; // e.g. "Friday, February 13th, from 7:00 PM to 11:00 PM WAT"
   referralMinQualifyingVolumeUsd: number;
   referralRewardAmountUsd: number;
-  aggregatorSenderApiKey: string;
   moralisWebhookSecret: string;
   activepiecesWebhookUrl: string;
   /**

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,5 +1,4 @@
 import { createElement, type ReactElement } from "react";
-import JSEncrypt from "jsencrypt";
 import type {
   InstitutionProps,
   KesMpesaChannel,
@@ -666,24 +665,6 @@ export async function getEmailForMonitoredAddress(
     console.warn("[privy] getUserBySmartWalletAddress", normalized, e);
   }
   return null;
-}
-
-/**
- * Encrypts data using the provided public key.
- * @param data - The data to be encrypted.
- * @param publicKeyPEM - The public key in PEM format.
- * @returns The encrypted data as a base64-encoded string.
- */
-export function publicKeyEncrypt(data: unknown, publicKeyPEM: string): string {
-  const encrypt = new JSEncrypt();
-  encrypt.setPublicKey(publicKeyPEM);
-
-  const encrypted = encrypt.encrypt(JSON.stringify(data));
-  if (encrypted === false) {
-    throw new Error("Failed to encrypt data");
-  }
-
-  return encrypted;
 }
 
 /**

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,7 +16,7 @@ This document lists all environment variables used by the Noblocks application. 
    - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard
    - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
 
-   `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` is optional for local UI exploration; set it when you need live order creation against the aggregator.
+   `AGGREGATOR_SENDER_API_KEY_ID` (server-only — never `NEXT_PUBLIC_`) is optional for local UI exploration; set it when you need live order creation against the aggregator.
 
 ## Variable Reference
 
@@ -25,10 +25,6 @@ This document lists all environment variables used by the Noblocks application. 
 ```bash
 # Aggregator API base URL
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
-
-# Optional: Sender API key UUID (aggregator dashboard). Required for live order creation;
-# used by the payment-orders proxy and client for encrypted gateway.createOrder messageHash.
-NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
 
 # KYC tier monthly swap limits (USD). Omitted or empty = use defaults below.
 # Tier 3 also accepts "unlimited" (case-insensitive) to remove cap.
@@ -149,6 +145,12 @@ NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=false          # Send events from local dev whe
 # Secret for internal API endpoints
 # Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=
+
+# Server-only: Sender API key UUID (aggregator dashboard). Used by the
+# /api/v1/payment-orders* routes (API-Key header + encrypted offramp messageHash).
+# Never NEXT_PUBLIC_ — it must not reach the browser. Rotate it in the aggregator
+# dashboard if it was ever exposed in a client bundle.
+AGGREGATOR_SENDER_API_KEY_ID=
 ```
 
 ### Injected-Wallet Session Auth (SIWE)
@@ -388,6 +390,7 @@ NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 4. **Wallet Private Keys**: `CASHBACK_WALLET_PRIVATE_KEY`, `SPONSOR_EVM_WALLET_PRIVATE_KEY` control funds — use vaulted secrets in CI/CD
 5. **Internal API Key**: All internal endpoints require this — generate randomly and rotate periodically
 6. **SmileID/Dojah**: Treat as any third-party API credential — never commit raw values
+7. **Aggregator Sender API Key**: `AGGREGATOR_SENDER_API_KEY_ID` is server-only — never prefix it `NEXT_PUBLIC_`. It is both the aggregator `API-Key` credential and the value that attributes on-chain orders to our sender profile; if it was ever exposed in a client bundle, rotate it in the aggregator dashboard
 
 ## Related Documentation
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -16,6 +16,16 @@ export async function register() {
   // Skipped on the Edge runtime (middleware): dd-trace is a Node library and
   // importing it there breaks the Edge bundle.
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Non-fatal: the key is read lazily at request time (app/lib/server-config.ts),
+  // so a missing value surfaces as 503s on offramp order creation and the
+  // sender API proxies rather than a failed boot. Warn here so it is visible in
+  // container logs at deploy.
+  if (!process.env.AGGREGATOR_SENDER_API_KEY_ID?.trim()) {
+    console.warn(
+      "[startup] AGGREGATOR_SENDER_API_KEY_ID is not set — offramp order creation and /api/v1/payment-orders* will return 503",
+    );
+  }
   // Read once, here, at process startup — flipping this on a running
   // container has no effect until it restarts.
   if (process.env.DD_TRACE_ENABLED === "false") return;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "hugeicons-react": "^0.3.0",
     "jose": "^6.0.11",
     "js-cookie": "^3.0.5",
-    "jsencrypt": "^3.3.2",
     "jsonwebtoken": "^9.0.2",
     "libphonenumber-js": "^1.12.42",
     "lottie-react": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
-      jsencrypt:
-        specifier: ^3.3.2
-        version: 3.3.2
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -7706,9 +7703,6 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
-
-  jsencrypt@3.3.2:
-    resolution: {integrity: sha512-arQR1R1ESGdAxY7ZheWr12wCaF2yF47v5qpB76TtV64H1pyGudk9Hvw8Y9tb/FiTIaaTRUyaSnm5T/Y53Ghm/A==}
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -21561,8 +21555,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  jsencrypt@3.3.2: {}
 
   jsesc@3.0.2: {}
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,8 @@
 // Bump BOTH versions on any deploy that changes build-time config (e.g. a
 // NEXT_PUBLIC_* key). The activate handler below purges every cache that does
 // not match, which is the only thing that evicts a stale precached shell.
-const CACHE_NAME = 'noblocks-pwa-v4';
-const RUNTIME_CACHE = 'noblocks-runtime-v4';
+const CACHE_NAME = 'noblocks-pwa-v5';
+const RUNTIME_CACHE = 'noblocks-runtime-v5';
 const OFFLINE_URL = '/offline.html';
 
 // Static assets to cache immediately


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-790

> **Depends on #695 (KAN-789), now merged.** This PR's `sw.js` v5 bump relies on the reload-on-update handler #695 added; deploy in order.

### Description

`NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` was inlined into the client bundle at build time, and the same value is what our server routes send as the `API-Key` header to the aggregator sender API. The sender credential was therefore readable by anyone from the JS. Verified against the production build: 0 real client chunks still contained the `process.env` expression (it had been replaced by the literal), while 18 server chunks still read it at runtime.

The key was client-side for exactly one reason: **offramp** orders are created on-chain by the user's wallet (`Gateway.createOrder`), and the aggregator learns the owning sender profile only from `metadata.apiKey` inside the RSA-encrypted recipient blob passed as `messageHash`. That blob was assembled in the browser in `TransactionPreview.tsx` → `prepareCreateOrderParams()`. Onramp already went through the server proxy with the key applied server-side; it is untouched.

**What changes**

- **Key is server-only.** `AGGREGATOR_SENDER_API_KEY_ID` (the name the Supabase reconciler already uses) is read lazily per request via `getAggregatorSenderApiKey()` in `app/lib/server-config.ts`. `aggregatorSenderApiKey` is **deleted** from the shared `config` object and the `Config` type, so any client reference is now a `tsc` error rather than a silent `""`. **Hard cut, no fallback** — a fallback reference in shared code would be re-inlined into the bundle.
- **New route `POST /api/v1/payment-orders/message-hash`** (auth via the existing middleware matcher, `withRateLimit`). The client sends only the recipient fields it legitimately knows; the server allowlist-parses them, generates the nonce, injects the key, applies the KES M-Pesa `channel`/`businessNumber` rules exactly as the client did, fetches the aggregator pubkey and encrypts. Logic lives in `app/lib/payment-order-message-hash.ts` (`import "server-only"`, thin route, `{status, body}` handler — same pattern as `refund-account-api.ts`).
- **Payload shape is unchanged**, so **no aggregator change**. The `/pubkey` fetch is bounded with a 10s timeout so a stalled aggregator surfaces as a 502 rather than a hung request.
- **Client** `prepareCreateOrderParams(auth)` now calls the route and plugs the returned `messageHash` into the same 7-field params; the four `createOrder` branches (Starknet, injected, EIP-7702, smart wallet) are untouched apart from receiving `auth`. The dead onramp branch is removed.
- **Second leak path closed:** `fetchOrderDetails` had a browser-reachable fallback (no token → direct aggregator call with the key). The browser now always proxies and throws "Authentication required" without a token; the server branch uses the getter.
- **`sw.js` v4 → v5** so the reload-on-update from #695 actually fires on this deploy (it only triggers when `sw.js` changes), and **`PWAInstallManager` now calls `registration.update()`** on `visibilitychange` → visible and every 15 min, so idle PWA tabs discover the key-free bundle without waiting for a navigation.
- **jsencrypt removed** (separate commit). Its only importer was the client-side `publicKeyEncrypt`, now dead — and it must never be used server-side: without `window.crypto` it seeds RSA padding from `Math.random()`.
  The lockfile change is the three `jsencrypt@3.3.2` blocks removed by hand (pnpm in this checkout refuses any non-reinstall operation); `jsencrypt` has no dependencies, and CI's frozen-lockfile install validates the result.

**Three things found during review that shaped the implementation**

1. **PEM label trap.** Node's `createPublicKey(pem)` rejects the mislabelled `BEGIN RSA PUBLIC KEY` (SPKI body) key that the aggregator's own `.env.example` ships; Go and jsencrypt both accept it. Production's key is fine, but a staging aggregator configured from the example would 500 the route. The server parses the DER body explicitly (`spki` → `pkcs1` fallback). Covered by a test.
2. **245-byte ceiling.** The production key is 2047-bit → max PKCS#1 v1.5 plaintext is 245 bytes. The server pre-checks the byte length and returns a clear **422** instead of an opaque 500. The nonce is 12 chars (was 13) so the payload never grows. **Worth knowing:** a KES Paybill payout with a ~22-char verified name and an 11-char memo is ~249 bytes — over the limit. That was already true with the old client (same key, same padding, it just failed as "Failed to encrypt data"), so it is not a regression, but it is real; the aggregator already auto-detects a hybrid RSA+AES-GCM envelope, so lifting the ceiling is a clean follow-up.
3. **Rotation cannot be immediate.** The aggregator filters revoked keys at index time, so any order still stamped with the old key (stale PWA tab, indexing lag, reindex retries) that lands after revocation becomes sender-less. Measured on the last cutover: stale bundles kept stamping the old key for **17 days**. Multiple active keys per sender are allowed, so rotation is staged and measured (runbook below).

No migrations. No API contract changes for callers of existing routes. Existing `payment-orders` routes keep their 500 semantics; only the env name in the message changed. The new route returns a generic 503 when the key is unset (env names are not echoed to clients).

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### References

- Mitigation already shipped: #695 (KAN-789)
- Aggregator-side aside (no action here): `aggregator/.env.example:95` labels an SPKI key as `RSA PUBLIC KEY`.

### Testing

**Unit** — `__tests__/paymentOrderMessageHash.test.ts` (27 cases) and `__tests__/PWAInstallManager.test.tsx` (7 cases), all passing:

- Allowlist parser: required fields, bounds (`memo` ≤ 25 matches the form), `kesChannel`/`businessNumber` validation, empty optionals treated as absent, unknown fields (`metadata`, `apiKey`, `nonce`, `refundAddress`) dropped.
- Recipient builder: exact key set/order, `memo` always a string, `providerId` only when present, full KES matrix (Mobile / Till / Paybill ± businessNumber, non-M-Pesa ignores KES fields), 200 unique URL-safe nonces.
- Crypto: RSA **round-trip** through SPKI, PKCS#1 *and the mislabelled SPKI-body PEM*. The test decrypts with `RSA_NO_PADDING` and strips the EME-PKCS1-v1_5 padding by hand (asserting `0x00 0x02`, ≥8 non-zero PS bytes, `0x00` separator) — portable across OpenSSL builds, since the official Node binaries refuse `privateDecrypt(RSA_PKCS1_PADDING)` (CVE-2023-46809), and it verifies the exact wire format Go's `rsa.DecryptPKCS1v15` parses. Random padding; non-RSA/empty keys rejected; 245-byte budget computed and enforced.
- Handler: 401 without wallet header; generic 503 with the key unset (env name not leaked); 400 on bad JSON/body; 502 when the pubkey fetch fails or is malformed; 422 when over budget; 200 whose `messageHash` decrypts to the server-side key and server nonce while client-supplied `metadata.apiKey` / `nonce` are ignored, and which fits the 245-byte budget.
- PWA: reload skipped on first install, immediate on form step, deferred across a transaction; `update()` on visibility → visible, on the 15-min timer, not while hidden, no-op without a registration.

Full suite with stale worktrees excluded: **617/617 tests pass** (`pnpm test -- --testPathIgnorePatterns '/\.worktrees/' '/\.claude/'`). `tsc --noEmit`: no errors in touched files (13 pre-existing errors from optional deps missing in my local install — `dd-trace`, `@hyperbridge/sdk`, `pino`, `dapvatar` — unchanged). ESLint clean on all touched files. Repo greps: `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` → 0, `aggregatorSenderApiKey` in `app/` → 0, `publicKeyEncrypt`/`jsencrypt` importers → 0.

**Local `pnpm build` is blocked** in my checkout by those same four missing optional packages (all 39 Turbopack errors are `Can't resolve` for them; none reference a touched file), so CI is the compile gate for this PR. Note on the bundle check: the env *name* will still appear in client chunks as the getter's `process.env.AGGREGATOR_SENDER_API_KEY_ID` expression — `server-config.ts` is reachable from client code, exactly like the existing `MORALIS_API_KEY`/`LAYERSWAP_API_KEY` reads — and evaluates to `""` there. What must never appear is the **value**; that is verified against production JS in runbook step 7.

**Local dev server** (`.env.local` has only the unprefixed name; run with `DD_TRACE_ENABLED=false` because `dd-trace` isn't installed locally): ready in 1.8s with no startup warning; unauthenticated `POST /api/v1/payment-orders/message-hash` → `401 {"error":"Missing authentication"}` from middleware; the same request with a **forged `x-wallet-address` header** → still 401 (the middleware, not the client, owns that header); `/sw.js` serves `noblocks-pwa-v5` / `noblocks-runtime-v5`.

**Not covered here — needs a wallet, so staging:**
1. Offramp NGN (Privy): Network tab shows `POST …/message-hash` → 200; on-chain `createOrder` succeeds; the order's `metadata->>'apiKey'` in the aggregator equals the server key (proves decryption).
2. Offramp KES M-Pesa: Mobile, Till, Paybill + businessNumber → aggregator order shows channel / business number.
3. Injected-wallet offramp (`x-injected-token`), Starknet offramp (still reaches `/api/starknet/create-order`), onramp unchanged.
4. Application → Service Workers shows `noblocks-pwa-v5`; an idle tab reloads within the update interval.
5. Transactions list / status pollers still work through the proxy.

Developed on macOS 26.2, Node v22.22.2, pnpm 9.11.0.

- [x] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Deploy & rotation runbook (in this order)

1. Merge + deploy **#695**.
2. Aggregator dashboard: create a **second** sender API key for liquidity@; keep the current one active.
3. Set `AGGREGATOR_SENDER_API_KEY_ID=<new key>` in hosting env — **prod and staging/preview** — and in the Supabase edge-function secret for `reconcile-pending-orders`. **Do this before merging**: there is no fallback, and offramp returns 503 until it is set.
4. Deploy this PR. Verify one live offramp order's `metadata->>'apiKey'` equals the new key.
5. Remove `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` from hosting env; redeploy.
6. Daily until it reads zero for 24h, then revoke the old key:
   ```sql
   SELECT count(*), max(created_at) FROM payment_orders
   WHERE metadata->>'apiKey' = '<old key>' AND created_at > now() - interval '24 hours';
   ```
7. Grep the production client JS for the **new** key value → 0 hits.
8. Luminet's own key (`8bd25f4f…`) was also exposed via our bundle May 7–Aug 12 and is still in *their* live use — notify them to rotate; do **not** revoke it.

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract — N/A, no migration


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Moved aggregator sender credentials to server-only configuration.
  - Payment-order message hashes are now encrypted server-side.
  - Added authentication and rate limiting for message-hash creation.

- **Bug Fixes**
  - Improved handling of missing configuration and aggregator request failures.
  - Service workers now check for updates when returning to a visible tab and periodically, improving stale-app recovery.
  - Added timeouts for aggregator public-key requests.

- **Chores**
  - Updated environment-variable documentation and rotated service-worker cache versions.
  - Removed browser-side encryption support and its dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->