### PR TITLE
Release: main → stable (KAN-789/790 sender key, KES M-Pesa, KAN-784 offramp precision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,11 @@ LIFI_API_KEY=
 # Default slippage tolerance for bridge quotes in basis points (e.g. 50 = 0.5%)
 NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 
+# HyperFX: USDC/USDT↔cNGN on Base, Polygon, BNB Smart Chain, and Ethereum (Convert).
+# Requires NEXT_PUBLIC_BRIDGE_ENABLED=true and ALCHEMY_API_KEY (server-only ERC-4337 bundler).
+NEXT_PUBLIC_HYPERFX_ENABLED=false
+ALCHEMY_API_KEY=
+
 # Embeddable widget (/widget route, iframed by whitelisted partners)
 NEXT_PUBLIC_EMBED_ENABLED=false
 # Comma-separated origins allowed to iframe /widget (CSP frame-ancestors).

--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,6 @@
 
 # Aggregator API
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
-# Sender API key UUID (aggregator dashboard): server proxy + client on-chain messageHash
-NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
 
 # KYC tier monthly swap limits (USD). Omitted or empty = defaults below.
 # Tier 3 also accepts "unlimited" (case-insensitive) to remove the monthly cap.
@@ -98,6 +96,11 @@ NEXT_PUBLIC_ENABLE_EMAIL_IN_ANALYTICS=false
 # Internal API Security
 # Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=
+
+# Server-only: Sender API key UUID (aggregator dashboard). Used by the
+# /api/v1/payment-orders* routes (API-Key header + encrypted offramp messageHash).
+# Never NEXT_PUBLIC_ — it must not reach the browser.
+AGGREGATOR_SENDER_API_KEY_ID=
 
 # =============================================================================
 # Feature Flags

--- a/.env.example
+++ b/.env.example
@@ -124,8 +124,11 @@ NEXT_PUBLIC_TRON_ENABLED=false
 # Referral Program: show/hide all referral UI and API routes
 NEXT_PUBLIC_REFERRAL_ENABLED=true
 
-# Bridge/Swap (Convert): in-wallet cross-chain convert via NEAR Intents + LI.FI
+# Bridge/Swap (Convert): in-wallet cross-chain convert via NEAR Intents + LI.FI + Textile FX
 NEXT_PUBLIC_BRIDGE_ENABLED=false
+# Textile FX v2 RFQ: USDT↔cNGN on BSC + Celo (server key from contact@textilecredit.com)
+NEXT_PUBLIC_TEXTILE_ENABLED=false
+TEXTILE_API_KEY=
 # NEAR Intents 1Click API JWT (server-side)
 ONE_CLICK_JWT=
 # LI.FI API key (server-side, optional)

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ PR_DESCRIPTION.md
 .vercel
 .vscode
 .cursor
+.hyperbridge-cache/
 
 # debug
 npm-debug.log*

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -120,6 +120,87 @@ liability. The threshold monitors would likewise fire on staging noise.
 The first one is the one that matters. When the cron dies, nothing else
 anywhere reports it.
 
+## KYC telemetry
+
+The KYC flow reports through `app/lib/kyc-telemetry.ts`: one structured line per
+step outcome, message `kyc step`, flattened into `@kyc.*` attributes. Its
+purpose is answering "why did this user's upgrade fail?" from the Logs Explorer
+instead of asking the user what the screen said.
+
+Every exit path in the KYC routes emits exactly one line — the tier 1 OTP send
+and verify, the tier 2 ID submission and its async Smile ID callback, and the
+tier 3 address check. `/api/kyc/status` reports failures only; every KYC surface
+polls it, so its successes would bury everything else.
+
+| Attribute | Meaning |
+| --- | --- |
+| `@kyc.step` | `signup_email`, `phone_otp_send`, `phone_otp_verify`, `id_verification`, `id_callback`, `address_verification`, `status` |
+| `@kyc.outcome` | `success`, `rejected`, `error`, `noop` (see below) |
+| `@kyc.ok` | `true` only on `success` — the boolean twin of `outcome` |
+| `@kyc.detail` | **The provider's own words.** Smile ID `ResultText`, Dojah's message, the Postgres error |
+| `@kyc.reason` | Stable cause: `provider_rejected`, `attempts_exhausted`, `duplicate_id_document`, `invalid_otp`, `supabase_error`, … |
+| `@kyc.stage` | Where in the route: `provider_verify`, `profile_update`, `attempt_counter`, `otp_check`, … |
+| `@kyc.failure_category` | `classifySmileIdFailure` output: `quality`, `liveness`, `mismatch`, `database`, `general` |
+| `@kyc.wallet_address` | Lower-cased. The key support searches on |
+| `@kyc.tier_from` / `@kyc.tier_to` / `@kyc.promoted` | The tier change, and whether one happened |
+| `@kyc.attempt` / `@kyc.attempts_remaining` | How close the user is to being locked out |
+| `@kyc.provider` / `@kyc.provider_code` / `@kyc.job_id` | `smile_id`, `dojah`, `kudisms`, `twilio`, `supabase`, plus their codes |
+| `@kyc.duration_ms` / `@kyc.status_code` | Wall time and the HTTP status returned |
+
+`outcome` is the distinction that makes alerting possible. A `rejected` line is
+a legitimate refusal — a mistyped OTP, a blurry document, Smile ID saying no —
+and logs at `warn`. An `error` line is our fault, the database's, or a
+provider's, and logs at `error`. Without the split, an outage monitor would be
+drowned by users fat-fingering their OTP. `noop` (info) covers work that
+correctly did nothing, chiefly a Smile ID callback arriving after the
+synchronous path already promoted the profile.
+
+A missing `x-wallet-address` is an `error`, not a rejection: middleware matches
+every KYC route, answers unauthenticated callers with its own 401, and strips
+forged wallet headers, so a handler that finds none has a broken matcher or
+header chain rather than an unauthenticated user.
+
+### Supporting a user
+
+```text
+service:noblocks env:production @feature:kyc @kyc.wallet_address:0x1234…
+```
+
+Lower-case the address — the facet is normalised, and a checksummed address
+pasted verbatim will not match. Read `@kyc.detail` for the underlying reason,
+`@kyc.attempts_remaining` for whether they can retry, and **View Trace** for the
+request itself.
+
+### Monitors worth having
+
+As with the worker monitors above, every query is scoped `env:production`.
+**Do not drop that scope** — staging shares this Datadog org.
+
+| Monitor | Query | Why |
+| --- | --- | --- |
+| **KYC infrastructure failure → page** | `service:noblocks env:production @feature:kyc @kyc.outcome:error` | Smile ID, Dojah, or Supabase is failing upgrades; users cannot verify at all |
+| Provider outage burning attempts → Slack | `service:noblocks env:production @feature:kyc @kyc.failure_category:database` | Smile ID infrastructure failures, which refund the attempt — a spike means the provider, not our users |
+| Verified-and-lost → page | `service:noblocks env:production @feature:kyc @kyc.stage:profile_update @kyc.outcome:error` | The provider approved them and the write failed: the user spent an attempt and stayed on the old tier |
+| Callback signature failures → Slack | `service:noblocks env:production @feature:kyc @kyc.reason:invalid_signature` | A genuine Smile ID callback never fails this |
+| Rejection mix → dashboard | `service:noblocks env:production @feature:kyc @kyc.outcome:rejected`, grouped by `@kyc.reason` and `@kyc.id_type` | Which ID types and reasons dominate; the input to fixing the flow rather than individual tickets |
+
+### Client-side
+
+`reportClientError` (`app/lib/sentry.client.ts`) forwards to
+`datadogRum.addError` alongside GlitchTip, so KYC failures that never reach the
+API — a dropped request, a refused camera, a wallet rejection — surface in RUM
+Error Tracking under their `feature` tag. RUM is consent-gated, so the server
+lines remain the complete record.
+
+### PII
+
+Wallet address is logged in the clear: it is the key support needs, and it is
+what these routes already logged. Phone numbers, emails, ID numbers, dates of
+birth, names and document images are never logged. Because Smile ID and Dojah
+quote the failing input back in their rejection messages, `sanitizeDetail`
+masks runs of six or more digits and anything email-shaped before a line ships —
+short numbers like result codes stay readable.
+
 ## Verifying
 
 Deploy, wait ~60s, then in the **EU** app:
@@ -130,6 +211,7 @@ Deploy, wait ~60s, then in the **EU** app:
 | Logs flowing | Logs Explorer → `service:noblocks env:production` |
 | Trace–log correlation | Open a log line → **View Trace** is present |
 | Worker ticks | Logs → `@feature:play @worker.ran_at:*` |
+| KYC steps | Logs → `@feature:kyc @kyc.step:*` |
 | RUM | RUM → Applications |
 | Service Catalog | Software → `noblocks` |
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Visit the live site at [noblocks.xyz](https://noblocks.xyz).
      - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard → Project Settings → API
      - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
 
-   See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
+   See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
 
 3. Install dependencies and start the development server:
 

--- a/__tests__/PWAInstallManager.test.tsx
+++ b/__tests__/PWAInstallManager.test.tsx
@@ -13,6 +13,7 @@ jest.mock("../app/context/StepContext", () => ({
 type MockServiceWorkerContainer = EventTarget & {
   controller: object | null;
   register: jest.Mock;
+  getRegistration?: jest.Mock;
 };
 
 /** Installs a mock `navigator.serviceWorker`; `controller` says whether the page is already controlled. */
@@ -31,6 +32,14 @@ function installServiceWorkerMock(controller: object | null) {
 function fireControllerChange(sw: EventTarget) {
   act(() => {
     sw.dispatchEvent(new Event("controllerchange"));
+  });
+}
+
+/** Points `document.visibilityState` at a mutable value for the update-check tests. */
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
   });
 }
 
@@ -87,5 +96,73 @@ describe("PWAInstall service worker update handling", () => {
     rerender(<PWAInstall />);
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PWAInstall service worker update polling", () => {
+  let updateMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    updateMock = jest.fn().mockResolvedValue(undefined);
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete (window.navigator as { serviceWorker?: unknown }).serviceWorker;
+  });
+
+  function installWithRegistration() {
+    const sw = installServiceWorkerMock({});
+    sw.getRegistration = jest.fn().mockResolvedValue({ update: updateMock });
+    return sw;
+  }
+
+  it("asks the registration to check for an update when the tab becomes visible", async () => {
+    installWithRegistration();
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not check while the tab is hidden", async () => {
+    installWithRegistration();
+    setVisibilityState("hidden");
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("checks for an update on the periodic timer", async () => {
+    jest.useFakeTimers();
+    installWithRegistration();
+    render(<PWAInstall />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(15 * 60 * 1000);
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when no registration exists yet", async () => {
+    installServiceWorkerMock({});
+    render(<PWAInstall />);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/PWAInstallManager.test.tsx
+++ b/__tests__/PWAInstallManager.test.tsx
@@ -1,0 +1,91 @@
+/// <reference types="jest" />
+
+import { act, render } from "@testing-library/react";
+
+import PWAInstall from "../app/components/PWAInstallManager";
+
+const mockUseStep = jest.fn();
+
+jest.mock("../app/context/StepContext", () => ({
+  useStep: () => mockUseStep(),
+}));
+
+type MockServiceWorkerContainer = EventTarget & {
+  controller: object | null;
+  register: jest.Mock;
+};
+
+/** Installs a mock `navigator.serviceWorker`; `controller` says whether the page is already controlled. */
+function installServiceWorkerMock(controller: object | null) {
+  const sw = new EventTarget() as MockServiceWorkerContainer;
+  sw.controller = controller;
+  sw.register = jest.fn().mockResolvedValue({});
+  Object.defineProperty(window.navigator, "serviceWorker", {
+    configurable: true,
+    value: sw,
+  });
+  return sw;
+}
+
+/** Dispatches `controllerchange` on the mock container inside React's `act`. */
+function fireControllerChange(sw: EventTarget) {
+  act(() => {
+    sw.dispatchEvent(new Event("controllerchange"));
+  });
+}
+
+describe("PWAInstall service worker update handling", () => {
+  const originalLocation = window.location;
+  let reloadMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reloadMock = jest.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: reloadMock } as unknown as Location,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    delete (window.navigator as { serviceWorker?: unknown }).serviceWorker;
+  });
+
+  it("does not reload on the first install, when the page was not yet controlled", () => {
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    const sw = installServiceWorkerMock(null);
+
+    render(<PWAInstall />);
+    fireControllerChange(sw);
+
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads immediately when a new worker takes over on the form step", () => {
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    const sw = installServiceWorkerMock({});
+
+    render(<PWAInstall />);
+    fireControllerChange(sw);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers the reload while a transaction is on screen, then reloads on return to the form", () => {
+    mockUseStep.mockReturnValue({ isFormStep: false });
+    const sw = installServiceWorkerMock({});
+
+    const { rerender } = render(<PWAInstall />);
+    fireControllerChange(sw);
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    mockUseStep.mockReturnValue({ isFormStep: true });
+    rerender(<PWAInstall />);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/evmEarnWalletTotal.test.ts
+++ b/__tests__/evmEarnWalletTotal.test.ts
@@ -3,6 +3,7 @@ import {
   parseEarnDepositedUsd,
   resolveEvmEarnWalletDisplayTotal,
   selectedChainLiquidUsd,
+  sumAllChainLiquidUsd,
 } from "../app/lib/evmEarnWalletTotal";
 import type { CrossChainBalanceEntry } from "../app/context";
 
@@ -26,15 +27,29 @@ function entry(chainName: string, total: number): CrossChainBalanceEntry {
 }
 
 describe("evmEarnWalletTotal", () => {
-  it("sums liquid and earn for EVM earn chains", () => {
+  it("sums cross-chain liquid and earn for EVM earn chains", () => {
     const result = resolveEvmEarnWalletDisplayTotal({
       chainName: "Base",
       crossChainBalances: [entry("Base", 0.05), entry("Polygon", 1)],
       earnDepositedUsd: 0.048,
     });
-    expect(result.liquidUsd).toBe(0.05);
-    expect(result.displayTotalUsd).toBeCloseTo(0.098, 6);
+    expect(result.liquidUsd).toBe(1.05);
+    expect(result.displayTotalUsd).toBeCloseTo(1.098, 6);
     expect(result.includesEarn).toBe(true);
+  });
+
+  it("includes all chains in total when selected chain is Base", () => {
+    const result = resolveEvmEarnWalletDisplayTotal({
+      chainName: "Base",
+      crossChainBalances: [
+        entry("Base", 298.77),
+        entry("Ethereum", 200.1),
+        entry("Lisk", 200),
+      ],
+      earnDepositedUsd: 0,
+    });
+    expect(result.liquidUsd).toBeCloseTo(698.87, 2);
+    expect(result.displayTotalUsd).toBeCloseTo(698.87, 2);
   });
 
   it("does not add earn on non-earn chains", () => {
@@ -51,6 +66,12 @@ describe("evmEarnWalletTotal", () => {
     expect(
       selectedChainLiquidUsd([entry("Base", 0.05), entry("Polygon", 1)], "Base"),
     ).toBe(0.05);
+  });
+
+  it("sumAllChainLiquidUsd sums every network entry", () => {
+    expect(
+      sumAllChainLiquidUsd([entry("Base", 0.05), entry("Polygon", 1)]),
+    ).toBe(1.05);
   });
 
   it("parseEarnDepositedUsd rejects invalid values", () => {

--- a/__tests__/hyperfxBundler.test.ts
+++ b/__tests__/hyperfxBundler.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="jest" />
+
+import {
+  getHyperfxBundlerUrl,
+  requireHyperfxBundlerUrl,
+  resolveHyperfxBundlerUrl,
+} from "../app/utils";
+
+describe("HyperFX bundler URL (server)", () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    process.env = { ...env };
+    delete process.env.ALCHEMY_API_KEY;
+  });
+
+  afterAll(() => {
+    process.env = env;
+  });
+
+  it("builds Alchemy Base bundler URL from ALCHEMY_API_KEY", () => {
+    process.env.ALCHEMY_API_KEY = "test-key";
+    expect(getHyperfxBundlerUrl("Base")).toBe(
+      "https://base-mainnet.g.alchemy.com/v2/test-key",
+    );
+  });
+
+  it("builds Alchemy Polygon bundler URL from ALCHEMY_API_KEY", () => {
+    process.env.ALCHEMY_API_KEY = "test-key";
+    expect(getHyperfxBundlerUrl("Polygon")).toBe(
+      "https://polygon-mainnet.g.alchemy.com/v2/test-key",
+    );
+  });
+
+  it("returns undefined for unsupported networks", () => {
+    process.env.ALCHEMY_API_KEY = "test-key";
+    expect(getHyperfxBundlerUrl("Lisk")).toBeUndefined();
+  });
+
+  it("throws when Alchemy key is missing", () => {
+    expect(() => requireHyperfxBundlerUrl("Base")).toThrow(/bundler URL not configured/i);
+  });
+
+  it("resolveHyperfxBundlerUrl uses ALCHEMY_API_KEY on the server", async () => {
+    const originalWindow = global.window;
+    // @ts-expect-error simulate Node server runtime
+    delete global.window;
+    process.env.ALCHEMY_API_KEY = "server-key";
+    try {
+      await expect(resolveHyperfxBundlerUrl("Base")).resolves.toBe(
+        "https://base-mainnet.g.alchemy.com/v2/server-key",
+      );
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+});
+
+describe("HyperFX bundler URL (browser)", () => {
+  const env = process.env;
+  const originalWindow = global.window;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...env };
+    delete process.env.ALCHEMY_API_KEY;
+    // @ts-expect-error simulate browser runtime
+    global.window = {};
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    process.env = env;
+  });
+
+  it("fetches bundler URL from the server API in the browser", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        bundlerUrl: "https://base-mainnet.g.alchemy.com/v2/server-key",
+      }),
+    });
+
+    await expect(resolveHyperfxBundlerUrl("Base", "test-token")).resolves.toBe(
+      "https://base-mainnet.g.alchemy.com/v2/server-key",
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/bridge/hyperfx/bundler?network=Base",
+      { headers: { Authorization: "Bearer test-token" } },
+    );
+  });
+});

--- a/__tests__/hyperfxNetworks.test.ts
+++ b/__tests__/hyperfxNetworks.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="jest" />
+
+import { isHyperfxSupportedNetwork } from "../app/lib/hyperfxNetworks";
+
+describe("isHyperfxSupportedNetwork", () => {
+  it("accepts configured networks", () => {
+    expect(isHyperfxSupportedNetwork("Base")).toBe(true);
+    expect(isHyperfxSupportedNetwork("Polygon")).toBe(true);
+  });
+
+  it("rejects inherited object keys", () => {
+    expect(isHyperfxSupportedNetwork("toString")).toBe(false);
+  });
+});

--- a/__tests__/hyperfxRouting.test.ts
+++ b/__tests__/hyperfxRouting.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+
+jest.mock("../app/hooks/useEIP7702Account", () => ({
+  get7702AuthorizedImplementationForAddress: jest.fn(),
+}));
+
+jest.mock("../app/lib/bridgeFeature", () => ({
+  HYPERFX_SUPPORTED_NETWORKS: new Set([
+    "Base",
+    "Polygon",
+    "BNB Smart Chain",
+    "Ethereum",
+  ]),
+  isHyperfxSwapEnabled: jest.fn(() => true),
+}));
+
+import {
+  isHyperfxRoute,
+  selectEngine,
+  type BridgeLeg,
+} from "../app/lib/bridge";
+
+const CHAIN_ID: Record<string, number> = {
+  Base: 8453,
+  Polygon: 137,
+  "BNB Smart Chain": 56,
+  Ethereum: 1,
+  Lisk: 1135,
+};
+
+const leg = (
+  network: string,
+  token: string,
+  tokenAddress: string,
+): BridgeLeg => ({
+  network,
+  chainId: CHAIN_ID[network] ?? 137,
+  token,
+  tokenAddress,
+  decimals: 6,
+  amount: "0",
+  rawAmount: "0",
+});
+
+describe("HyperFX routing", () => {
+  it("selects hyperfx for same-chain Base USDC→cNGN when enabled", () => {
+    const from = leg("Base", "USDC", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    const to = leg("Base", "cNGN", "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F");
+    expect(isHyperfxRoute(from, to)).toBe(true);
+    expect(selectEngine(from, to)).toBe("hyperfx");
+  });
+
+  it("selects hyperfx for same-chain Polygon USDC→cNGN when enabled", () => {
+    const from = leg("Polygon", "USDC", "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359");
+    const to = leg("Polygon", "cNGN", "0x52828daa48c1a9a06f37500882b42daf0be04c3b");
+    expect(isHyperfxRoute(from, to)).toBe(true);
+    expect(selectEngine(from, to)).toBe("hyperfx");
+  });
+
+  it("selects hyperfx for same-chain Base cNGN→USDC when enabled", () => {
+    const from = leg("Base", "cNGN", "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F");
+    const to = leg("Base", "USDC", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    expect(selectEngine(from, to)).toBe("hyperfx");
+  });
+
+  it("selects hyperfx for same-chain Base USDT→cNGN when enabled", () => {
+    const from = leg("Base", "USDT", "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2");
+    const to = leg("Base", "cNGN", "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F");
+    expect(isHyperfxRoute(from, to)).toBe(true);
+    expect(selectEngine(from, to)).toBe("hyperfx");
+  });
+
+  it("selects hyperfx for same-chain Base cNGN→USDT when enabled", () => {
+    const from = leg("Base", "cNGN", "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F");
+    const to = leg("Base", "USDT", "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2");
+    expect(selectEngine(from, to)).toBe("hyperfx");
+  });
+
+  it("falls back to lifi for cross-chain cNGN legs", () => {
+    const from = leg("Base", "USDC", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    const to = leg("Polygon", "cNGN", "0xabc");
+    expect(isHyperfxRoute(from, to)).toBe(false);
+    expect(selectEngine(from, to)).toBe("lifi");
+  });
+
+  it("does not route hyperfx on Lisk (cNGN present but not on Hyperbridge)", () => {
+    const from = leg("Lisk", "USDT", "0x05D032ac25d322df992303dCa074EE7392C117b9");
+    const to = leg("Lisk", "cNGN", "0xC7aB2C35Ea37236e644C24A4E4a1911c082887c0");
+    expect(isHyperfxRoute(from, to)).toBe(false);
+    expect(selectEngine(from, to)).toBe("lifi");
+  });
+});
+
+describe("HyperFX disabled", () => {
+  beforeEach(() => {
+    const { isHyperfxSwapEnabled } = jest.requireMock("../app/lib/bridgeFeature");
+    isHyperfxSwapEnabled.mockReturnValue(false);
+  });
+
+  it("uses lifi for Base USDC→cNGN when hyperfx is off", () => {
+    const from = leg("Base", "USDC", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    const to = leg("Base", "cNGN", "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F");
+    expect(isHyperfxRoute(from, to)).toBe(false);
+    expect(selectEngine(from, to)).toBe("lifi");
+  });
+});

--- a/__tests__/hyperfxRouting.test.ts
+++ b/__tests__/hyperfxRouting.test.ts
@@ -12,6 +12,7 @@ jest.mock("../app/lib/bridgeFeature", () => ({
     "Ethereum",
   ]),
   isHyperfxSwapEnabled: jest.fn(() => true),
+  isTextileRoute: jest.fn(() => false),
 }));
 
 import {

--- a/__tests__/hyperfxStatus.test.ts
+++ b/__tests__/hyperfxStatus.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="jest" />
+
+jest.mock("@hyperbridge/sdk", () => ({
+  IntentGatewayABI: {
+    ABI: [
+      {
+        type: "event",
+        name: "OrderFilled",
+        inputs: [
+          { name: "commitment", type: "bytes32", indexed: true },
+          { name: "filler", type: "address", indexed: false },
+        ],
+      },
+    ],
+  },
+  orderCommitment: jest.fn(() => "0x0"),
+}));
+
+jest.mock("viem", () => ({
+  parseEventLogs: jest.fn(),
+}));
+
+import { resolveHyperfxOrderStatus } from "../app/lib/hyperfxStatus";
+
+describe("resolveHyperfxOrderStatus", () => {
+  const gateway = "0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716" as const;
+  const commitment =
+    "0x0e22430ea88b1aacf6e2ea4b7d67ca96583d568dee7ce4d1aca83f080d207a68" as const;
+  const order = {
+    id: commitment,
+    user: "0x" + "0".repeat(64),
+    source: "EVM-8453",
+    destination: "EVM-8453",
+    deadline: 999_999_999n,
+    nonce: 1n,
+    fees: 0n,
+    session: "0x0000000000000000000000000000000000000000",
+    predispatch: { assets: [], call: "0x" },
+    inputs: [
+      {
+        token: "0x" + "0".repeat(24) + "833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        amount: 100000n,
+      },
+    ],
+    output: {
+      beneficiary: "0x" + "0".repeat(24) + "0000000000000000000000000001",
+      assets: [],
+      call: "0x",
+    },
+  };
+
+  const emptySlot =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  function mockClient(overrides: {
+    filled?: boolean;
+    escrow?: bigint;
+    blockNumber?: bigint;
+  }) {
+    return {
+      readContract: jest.fn(async ({ functionName }: { functionName: string }) => {
+        if (functionName === "calculateCommitmentSlotHash") return "0xabc";
+        if (functionName === "_orders") return overrides.escrow ?? 0n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+      getStorageAt: jest.fn(async () =>
+        overrides.filled ? "0x01" : emptySlot,
+      ),
+      getBlockNumber: jest.fn(async () => overrides.blockNumber ?? 100n),
+      getLogs: jest.fn(async () => []),
+    } as unknown as import("viem").PublicClient;
+  }
+
+  beforeEach(() => {
+    const { parseEventLogs } = jest.requireMock("viem");
+    parseEventLogs.mockReturnValue([]);
+  });
+
+  it("returns SUCCESS with fill tx when storage slot confirms fill", async () => {
+    const fillTx =
+      "0xfilled123456789012345678901234567890123456789012345678901234567890" as const;
+    const { parseEventLogs } = jest.requireMock("viem");
+    parseEventLogs.mockReturnValue([
+      {
+        eventName: "OrderFilled",
+        args: { commitment },
+        transactionHash: fillTx,
+      },
+    ]);
+
+    const client = mockClient({ filled: true, escrow: 0n, blockNumber: 50n });
+    const result = await resolveHyperfxOrderStatus(client, gateway, order, 10n);
+    expect(result.status).toBe("SUCCESS");
+    expect(result.fillTxHash).toBe(fillTx);
+  });
+
+  it("returns SUCCESS when escrow is empty but OrderFilled log exists", async () => {
+    const fillTx =
+      "0xfilled123456789012345678901234567890123456789012345678901234567890" as const;
+    const { parseEventLogs } = jest.requireMock("viem");
+    parseEventLogs.mockReturnValue([
+      {
+        eventName: "OrderFilled",
+        args: { commitment },
+        transactionHash: fillTx,
+      },
+    ]);
+
+    const client = mockClient({ filled: false, escrow: 0n, blockNumber: 50n });
+    const result = await resolveHyperfxOrderStatus(client, gateway, order, 10n);
+    expect(result.status).toBe("SUCCESS");
+    expect(result.fillTxHash).toBe(fillTx);
+  });
+
+  it("returns PROCESSING when escrow is empty before deadline and no fill proof", async () => {
+    const client = mockClient({ filled: false, escrow: 0n, blockNumber: 50n });
+    const result = await resolveHyperfxOrderStatus(client, gateway, order, 10n);
+    expect(result.status).toBe("PROCESSING");
+  });
+
+  it("returns REFUNDED only after deadline with empty escrow and no fill", async () => {
+    const client = mockClient({
+      filled: false,
+      escrow: 0n,
+      blockNumber: 1_000_000_000_000n,
+    });
+    const result = await resolveHyperfxOrderStatus(client, gateway, order, 10n);
+    expect(result.status).toBe("REFUNDED");
+  });
+});

--- a/__tests__/kes-mpesa-channel.test.ts
+++ b/__tests__/kes-mpesa-channel.test.ts
@@ -3,6 +3,8 @@ import {
   getOfframpAccountIdentifierPlaceholder,
   formatKesMpesaAccountDisplay,
   formatRecipientInstitutionDisplay,
+  isSameSavedRecipient,
+  normalizeSavedRecipientChannel,
   getKesMpesaInstitutionLabel,
   KES_MPESA_INSTITUTION_CODE,
 } from "../app/utils";
@@ -88,5 +90,85 @@ describe("KES M-Pesa virtual institution split", () => {
         currency: "KES",
       }),
     ).toBe("Equity Bank");
+  });
+  it("treats KES M-Pesa channels as distinct saved recipients", () => {
+    const till = {
+      accountIdentifier: "123456",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+      channel: "Till" as const,
+    };
+    const paybill = {
+      accountIdentifier: "123456",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+      channel: "Paybill" as const,
+    };
+    // Same code + identifier, different rail: must not collapse or cross-delete.
+    expect(isSameSavedRecipient(till, paybill)).toBe(false);
+    expect(isSameSavedRecipient(till, { ...till })).toBe(true);
+  });
+
+  it("treats a missing channel and an empty channel as the same recipient", () => {
+    const legacy = {
+      accountIdentifier: "0712345678",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+    };
+    const empty = { ...legacy, channel: "" as const };
+    expect(isSameSavedRecipient(legacy, empty)).toBe(true);
+  });
+  it("collapses Send Money to an empty stored channel, keeps Till/Paybill", () => {
+    // Send Money must match recipients saved before channels existed,
+    // or the same phone number is stored twice ("" and "Mobile").
+    expect(normalizeSavedRecipientChannel("Mobile")).toBe("");
+    expect(normalizeSavedRecipientChannel("")).toBe("");
+    expect(normalizeSavedRecipientChannel(undefined)).toBe("");
+    expect(normalizeSavedRecipientChannel(null)).toBe("");
+    expect(normalizeSavedRecipientChannel("Till")).toBe("Till");
+    expect(normalizeSavedRecipientChannel("Paybill")).toBe("Paybill");
+  });
+
+  it("matches a legacy M-Pesa recipient against a Send Money selection", () => {
+    const legacy = {
+      accountIdentifier: "0712345678",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+    };
+    const sendMoney = { ...legacy, channel: "Mobile" as const };
+    expect(isSameSavedRecipient(legacy, sendMoney)).toBe(true);
+    // Still distinct from the business rails.
+    expect(
+      isSameSavedRecipient(sendMoney, { ...legacy, channel: "Till" as const }),
+    ).toBe(false);
+  });
+  it("keeps two Paybills with the same reference but different businesses apart", () => {
+    // "INV-001" billed by 400200 is a different payout target than by 888880.
+    const base = {
+      accountIdentifier: "INV-001",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+      channel: "Paybill" as const,
+    };
+    expect(
+      isSameSavedRecipient(
+        { ...base, businessNumber: "400200" },
+        { ...base, businessNumber: "888880" },
+      ),
+    ).toBe(false);
+    expect(
+      isSameSavedRecipient(
+        { ...base, businessNumber: "400200" },
+        { ...base, businessNumber: "400200" },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a missing and an empty business number as the same recipient", () => {
+    const base = {
+      accountIdentifier: "0712345678",
+      institutionCode: KES_MPESA_INSTITUTION_CODE,
+    };
+    expect(
+      isSameSavedRecipient(base, { ...base, businessNumber: "" }),
+    ).toBe(true);
+    expect(
+      isSameSavedRecipient(base, { ...base, businessNumber: null }),
+    ).toBe(true);
   });
 });

--- a/__tests__/kes-mpesa-channel.test.ts
+++ b/__tests__/kes-mpesa-channel.test.ts
@@ -1,0 +1,92 @@
+import {
+  expandKesMpesaInstitutions,
+  getOfframpAccountIdentifierPlaceholder,
+  formatKesMpesaAccountDisplay,
+  formatRecipientInstitutionDisplay,
+  getKesMpesaInstitutionLabel,
+  KES_MPESA_INSTITUTION_CODE,
+} from "../app/utils";
+import type { InstitutionProps } from "../app/types";
+
+describe("KES M-Pesa virtual institution split", () => {
+  const baseInstitutions: InstitutionProps[] = [
+    { name: "SAFARICOM", code: "SAFAKEPC", type: "mobile_money" },
+    { name: "AIRTEL", code: "AIRTKEPC", type: "mobile_money" },
+    { name: "Equity Bank", code: "EQTYKEPC", type: "bank" },
+  ];
+
+  it("expands SAFAKEPC into Send Money / Till / Paybill for KES", () => {
+    const expanded = expandKesMpesaInstitutions(baseInstitutions, "KES");
+    expect(expanded).toHaveLength(5);
+    const mpesa = expanded.filter((i) => i.code === KES_MPESA_INSTITUTION_CODE);
+    expect(mpesa.map((i) => i.name)).toEqual([
+      "M-PESA (Send Money)",
+      "M-PESA (Till)",
+      "M-PESA (Paybill)",
+    ]);
+    expect(mpesa.every((i) => i.code === "SAFAKEPC")).toBe(true);
+    expect(mpesa.map((i) => i.channel)).toEqual(["Mobile", "Till", "Paybill"]);
+    expect(expanded.find((i) => i.code === "AIRTKEPC")?.name).toBe("AIRTEL");
+  });
+
+  it("does not expand SAFAKEPC for non-KES currencies", () => {
+    const expanded = expandKesMpesaInstitutions(baseInstitutions, "NGN");
+    expect(expanded).toHaveLength(3);
+    expect(expanded.find((i) => i.code === "SAFAKEPC")?.name).toBe("SAFARICOM");
+  });
+
+  it("returns channel-aware placeholders", () => {
+    expect(
+      getOfframpAccountIdentifierPlaceholder("KES", "mobile_money", "Mobile"),
+    ).toBe("07XXXXXXXX");
+    expect(
+      getOfframpAccountIdentifierPlaceholder("KES", "mobile_money", "Till"),
+    ).toBe("Till number (5–7 digits)");
+    expect(
+      getOfframpAccountIdentifierPlaceholder("KES", "mobile_money", "Paybill"),
+    ).toBe("Account / reference");
+  });
+
+  it("formats preview/history account lines", () => {
+    expect(formatKesMpesaAccountDisplay("0712345678", "Mobile")).toBe(
+      "0712345678 • M-PESA",
+    );
+    expect(formatKesMpesaAccountDisplay("123456", "Till")).toBe(
+      "Till • 123456 • M-PESA",
+    );
+    expect(formatKesMpesaAccountDisplay("INV-001", "Paybill", "400200")).toBe(
+      "Paybill • 400200 / INV-001 • M-PESA",
+    );
+    expect(getKesMpesaInstitutionLabel("Till")).toBe("M-PESA (Till)");
+  });
+
+  it("labels legacy channel-less KES M-Pesa recipients as generic M-PESA", () => {
+    const expanded = expandKesMpesaInstitutions(baseInstitutions, "KES");
+    // Without a channel, never pick a channel-specific name off the expanded list.
+    expect(
+      formatRecipientInstitutionDisplay(KES_MPESA_INSTITUTION_CODE, expanded, {
+        currency: "KES",
+      }),
+    ).toBe("M-PESA");
+    expect(
+      formatRecipientInstitutionDisplay(KES_MPESA_INSTITUTION_CODE, expanded, {
+        currency: "KES",
+        accountIdentifier: "0712345678",
+      }),
+    ).toBe("0712345678 • M-PESA");
+  });
+
+  it("keeps the account identifier in non-M-Pesa account lines", () => {
+    expect(
+      formatRecipientInstitutionDisplay("EQTYKEPC", baseInstitutions, {
+        currency: "KES",
+        accountIdentifier: "1234567890",
+      }),
+    ).toBe("1234567890 • Equity Bank");
+    expect(
+      formatRecipientInstitutionDisplay("EQTYKEPC", baseInstitutions, {
+        currency: "KES",
+      }),
+    ).toBe("Equity Bank");
+  });
+});

--- a/__tests__/kyc-telemetry.test.ts
+++ b/__tests__/kyc-telemetry.test.ts
@@ -1,0 +1,284 @@
+/**
+ * KYC telemetry: step outcomes → flattened `@kyc.*` Datadog facets, the PII
+ * masking that guards them, and emission through the shared pino logger.
+ */
+// Relative specifier: jest's moduleNameMapper rewrites "@/x" to "<rootDir>/app/x",
+// which cannot resolve the "@/app/..." form that jest.mock needs to match.
+// The mock is built inside the factory because jest hoists this call above any
+// const declared above it.
+jest.mock("../app/lib/logger", () => {
+  const mock = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return { __esModule: true, default: mock, logger: mock };
+});
+
+// dd-trace is patched into the process at boot in production; here it only
+// needs to hand back a span whose tags the assertions can read.
+const addTags = jest.fn();
+const activeSpan: { addTags: jest.Mock } | null = { addTags };
+jest.mock("dd-trace", () => ({
+  __esModule: true,
+  default: {
+    scope: () => ({ active: () => (activeSpan as unknown) }),
+  },
+}));
+
+import loggerModule from "../app/lib/logger";
+
+const mockLogger = loggerModule as unknown as {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+};
+
+import {
+  KYC_EVENT_MESSAGE,
+  buildKycLog,
+  createKycReporter,
+  emitKycEvent,
+  sanitizeDetail,
+} from "@/app/lib/kyc-telemetry";
+
+const kycAttrs = (log: { attributes: Record<string, unknown> }) =>
+  log.attributes.kyc as Record<string, unknown>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("buildKycLog", () => {
+  it("flattens a successful tier 2 upgrade as info", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "success",
+      walletAddress: "0xAbCdEf",
+      tierFrom: 1,
+      tierTo: 2,
+      jobId: "job-1",
+      durationMs: 940,
+    });
+
+    expect(log.message).toBe(KYC_EVENT_MESSAGE);
+    expect(log.status).toBe("info");
+    expect(log.attributes.feature).toBe("kyc");
+    expect(kycAttrs(log)).toMatchObject({
+      step: "id_verification",
+      outcome: "success",
+      ok: true,
+      promoted: true,
+      tier_from: 1,
+      tier_to: 2,
+      duration_ms: 940,
+    });
+  });
+
+  it("lower-cases the wallet address so a search matches any casing", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "success",
+      walletAddress: "0xAbCdEf0123",
+    });
+
+    expect(kycAttrs(log).wallet_address).toBe("0xabcdef0123");
+  });
+
+  it("carries the provider's own rejection text at warn", () => {
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "rejected",
+      reason: "provider_rejected",
+      detail: "Selfie does not match ID photo",
+      failureCategory: "mismatch",
+      providerCode: 1012,
+      attempt: 2,
+      attemptsRemaining: 1,
+    });
+
+    expect(log.status).toBe("warn");
+    expect(kycAttrs(log)).toMatchObject({
+      outcome: "rejected",
+      ok: false,
+      reason: "provider_rejected",
+      detail: "Selfie does not match ID photo",
+      failure_category: "mismatch",
+      // Stringified so the facet has one type whatever the provider returns.
+      provider_code: "1012",
+      attempt: 2,
+      attempts_remaining: 1,
+    });
+  });
+
+  it("logs an infrastructure failure at error with error.* for Error Tracking", () => {
+    const log = buildKycLog({
+      step: "address_verification",
+      outcome: "error",
+      reason: "provider_request_failed",
+      error: new TypeError("fetch failed"),
+    });
+
+    expect(log.status).toBe("error");
+    expect(log.attributes.error).toMatchObject({
+      kind: "TypeError",
+      message: "fetch failed",
+    });
+  });
+
+  it("masks the stack too — its first line repeats the message", () => {
+    const error = new Error("ID 12345678901 could not be verified");
+    const log = buildKycLog({
+      step: "id_verification",
+      outcome: "error",
+      error,
+    });
+
+    const shipped = log.attributes.error as { message: string; stack: string };
+    expect(shipped.message).toBe("ID [digits] could not be verified");
+    expect(shipped.stack).toContain("ID [digits] could not be verified");
+    expect(shipped.stack).not.toContain("12345678901");
+  });
+
+  it("logs a no-op callback at info without claiming a promotion", () => {
+    const log = buildKycLog({
+      step: "id_callback",
+      outcome: "noop",
+      reason: "already_verified",
+    });
+
+    expect(log.status).toBe("info");
+    expect(kycAttrs(log).ok).toBe(false);
+  });
+
+  it("drops empty facets rather than shipping nulls", () => {
+    const log = buildKycLog({
+      step: "status",
+      outcome: "error",
+      detail: null,
+      jobId: "",
+      tierFrom: undefined,
+    });
+
+    const attrs = kycAttrs(log);
+    expect(attrs).not.toHaveProperty("detail");
+    expect(attrs).not.toHaveProperty("job_id");
+    expect(attrs).not.toHaveProperty("tier_from");
+    // A real zero still has to survive.
+    expect(kycAttrs(buildKycLog({ step: "status", outcome: "error", tierFrom: 0 })).tier_from).toBe(0);
+  });
+
+  it("omits `promoted` when only one side of the tier change is known", () => {
+    const log = buildKycLog({
+      step: "phone_otp_verify",
+      outcome: "rejected",
+      tierFrom: 0,
+    });
+
+    expect(kycAttrs(log)).not.toHaveProperty("promoted");
+  });
+});
+
+describe("sanitizeDetail", () => {
+  // Smile ID and Dojah quote the input that failed, so a rejection message can
+  // arrive carrying the very ID number we must never log.
+  it("masks ID-number-length digit runs", () => {
+    expect(sanitizeDetail("ID 12345678901 could not be verified")).toBe(
+      "ID [digits] could not be verified",
+    );
+  });
+
+  it("leaves short numbers — result codes, tiers — readable", () => {
+    expect(sanitizeDetail("ResultCode 1012 on tier 2")).toBe(
+      "ResultCode 1012 on tier 2",
+    );
+  });
+
+  it("masks email addresses", () => {
+    expect(sanitizeDetail("no record for user@example.com")).toBe(
+      "no record for [email]",
+    );
+  });
+
+  it("truncates a pathological message", () => {
+    const masked = sanitizeDetail("x".repeat(900));
+    expect(masked).toHaveLength(501);
+    expect(masked.endsWith("…")).toBe(true);
+  });
+});
+
+describe("emitKycEvent", () => {
+  it("routes each outcome to the matching pino level", () => {
+    emitKycEvent({ step: "phone_otp_send", outcome: "success" });
+    emitKycEvent({ step: "phone_otp_send", outcome: "rejected" });
+    emitKycEvent({ step: "phone_otp_send", outcome: "error" });
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: "kyc" }),
+      KYC_EVENT_MESSAGE,
+    );
+  });
+
+  it("mirrors the identifying facets onto the active APM span", () => {
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "rejected",
+      reason: "provider_rejected",
+      stage: "provider_verify",
+      targetTier: 2,
+    });
+
+    expect(addTags).toHaveBeenCalledWith({
+      "kyc.step": "id_verification",
+      "kyc.outcome": "rejected",
+      "kyc.reason": "provider_rejected",
+      "kyc.stage": "provider_verify",
+      "kyc.target_tier": 2,
+    });
+  });
+
+  it("never throws, whatever the caller passes", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() =>
+      emitKycEvent({
+        step: "id_verification",
+        outcome: "error",
+        error: circular,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("createKycReporter", () => {
+  it("binds base facets and stamps a duration on every exit", () => {
+    const report = createKycReporter({
+      step: "id_verification",
+      walletAddress: "0xabc",
+      targetTier: 2,
+      provider: "smile_id",
+    });
+
+    report.rejected({ reason: "attempts_exhausted", statusCode: 429 });
+
+    const [attributes] = mockLogger.warn.mock.calls[0];
+    expect(attributes.kyc).toMatchObject({
+      step: "id_verification",
+      wallet_address: "0xabc",
+      target_tier: 2,
+      provider: "smile_id",
+      reason: "attempts_exhausted",
+      status_code: 429,
+    });
+    expect(typeof attributes.kyc.duration_ms).toBe("number");
+  });
+
+  it("lets a call override a base facet — the callback learns its wallet late", () => {
+    const report = createKycReporter({ step: "id_callback", targetTier: 2 });
+
+    report.success({ walletAddress: "0xlate", tierFrom: 1, tierTo: 2 });
+
+    const [attributes] = mockLogger.info.mock.calls[0];
+    expect(attributes.kyc.wallet_address).toBe("0xlate");
+  });
+});

--- a/__tests__/paymentOrderMessageHash.test.ts
+++ b/__tests__/paymentOrderMessageHash.test.ts
@@ -1,0 +1,371 @@
+/// <reference types="jest" />
+
+import {
+  constants,
+  createPublicKey,
+  generateKeyPairSync,
+  privateDecrypt,
+} from "crypto";
+
+const SENDER_API_KEY = "11111111-2222-3333-4444-555555555555";
+
+const mockGetSenderApiKey = jest.fn<string, []>(() => SENDER_API_KEY);
+const mockFetchAggregatorPublicKey = jest.fn();
+
+jest.mock("server-only", () => ({}));
+jest.mock("../app/lib/config", () => ({
+  __esModule: true,
+  default: { aggregatorUrl: "https://aggregator.test/v1" },
+}));
+jest.mock("../app/lib/server-config", () => ({
+  getAggregatorSenderApiKey: () => mockGetSenderApiKey(),
+}));
+jest.mock("../app/lib/server-analytics", () => ({
+  trackApiRequest: jest.fn(),
+  trackApiResponse: jest.fn(),
+  trackApiError: jest.fn(),
+}));
+jest.mock("../app/api/aggregator", () => ({
+  fetchAggregatorPublicKey: () => mockFetchAggregatorPublicKey(),
+}));
+// Avoid loading the full utils module (react, sonner, viem) for one constant.
+jest.mock("../app/utils", () => ({ KES_MPESA_INSTITUTION_CODE: "SAFAKEPC" }));
+
+import {
+  buildOfframpRecipient,
+  encryptRecipient,
+  generateRecipientNonce,
+  handleCreateMessageHash,
+  maxPkcs1v15PlaintextBytes,
+  parseAggregatorPublicKey,
+  parseMessageHashBody,
+  RecipientTooLongError,
+  type MessageHashInput,
+  type MessageHashRequest,
+} from "../app/lib/payment-order-message-hash";
+
+type Keys = { publicPem: string; privatePem: string };
+
+function makeKeys(modulusLength: number): Keys {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    modulusLength,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicPem: publicKey, privatePem: privateKey };
+}
+
+/**
+ * Decrypts the way the aggregator does (Go rsa.DecryptPKCS1v15) and parses the
+ * JSON. Uses RSA_NO_PADDING and strips the EME-PKCS1-v1_5 padding by hand:
+ * Node's official binaries bundle an OpenSSL without implicit rejection, so
+ * privateDecrypt(RSA_PKCS1_PADDING) is refused there (CVE-2023-46809) and the
+ * suite would fail in CI. Unpadding manually also asserts the exact wire
+ * format the aggregator expects: 0x00 0x02 || PS (>= 8 non-zero bytes) || 0x00 || M.
+ */
+function decrypt(messageHashB64: string, privatePem: string): unknown {
+  const em = privateDecrypt(
+    { key: privatePem, padding: constants.RSA_NO_PADDING },
+    Buffer.from(messageHashB64, "base64"),
+  );
+  expect(em[0]).toBe(0x00);
+  expect(em[1]).toBe(0x02);
+  const separator = em.indexOf(0x00, 2);
+  expect(separator).toBeGreaterThanOrEqual(2 + 8);
+  expect(em.subarray(2, separator).includes(0x00)).toBe(false);
+  return JSON.parse(em.subarray(separator + 1).toString("utf8"));
+}
+
+function makeRequest(
+  body: unknown,
+  wallet: string | null = "0xabc",
+): MessageHashRequest {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "x-wallet-address" ? wallet : null,
+    },
+    json: async () => body,
+  };
+}
+
+const baseInput: MessageHashInput = {
+  accountIdentifier: "0123456789",
+  accountName: "ADAEZE OKONKWO",
+  institution: "GTBINGLA",
+  memo: "Sept salary",
+};
+
+let keys2048: Keys;
+let keys1024: Keys;
+
+beforeAll(() => {
+  keys2048 = makeKeys(2048);
+  keys1024 = makeKeys(1024);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSenderApiKey.mockReturnValue(SENDER_API_KEY);
+  mockFetchAggregatorPublicKey.mockResolvedValue({
+    status: "success",
+    message: "OK",
+    data: `\n${keys2048.publicPem}\n`,
+  });
+});
+
+describe("parseMessageHashBody", () => {
+  it("accepts the base offramp input and drops unknown fields", () => {
+    const result = parseMessageHashBody({
+      ...baseInput,
+      metadata: { apiKey: "evil" },
+      apiKey: "evil",
+      nonce: "fixed",
+      refundAddress: "0xdead",
+    });
+    expect(result).toEqual({ ok: true, input: baseInput });
+  });
+
+  it.each([
+    ["accountIdentifier", "accountIdentifier is required"],
+    ["accountName", "accountName is required"],
+    ["institution", "institution is required"],
+  ])("rejects a missing %s", (field, error) => {
+    const body = { ...baseInput } as Record<string, unknown>;
+    delete body[field];
+    expect(parseMessageHashBody(body)).toEqual({ ok: false, error });
+  });
+
+  it("rejects a non-object body", () => {
+    expect(parseMessageHashBody(null).ok).toBe(false);
+    expect(parseMessageHashBody([]).ok).toBe(false);
+    expect(parseMessageHashBody("x").ok).toBe(false);
+  });
+
+  it("rejects an invalid kesChannel and a non-numeric businessNumber", () => {
+    expect(parseMessageHashBody({ ...baseInput, kesChannel: "Bank" })).toEqual({
+      ok: false,
+      error: "kesChannel must be one of Mobile, Till, Paybill",
+    });
+    expect(
+      parseMessageHashBody({ ...baseInput, businessNumber: "12a4" }).ok,
+    ).toBe(false);
+  });
+
+  it("bounds memo and providerId", () => {
+    expect(parseMessageHashBody({ ...baseInput, memo: "x".repeat(26) }).ok).toBe(false);
+    expect(
+      parseMessageHashBody({ ...baseInput, providerId: "not valid!" }).ok,
+    ).toBe(false);
+    expect(
+      parseMessageHashBody({ ...baseInput, providerId: "prov_123-abc" }),
+    ).toEqual({ ok: true, input: { ...baseInput, providerId: "prov_123-abc" } });
+  });
+
+  it("treats empty optional strings as absent", () => {
+    const result = parseMessageHashBody({
+      ...baseInput,
+      memo: "",
+      kesChannel: "",
+      businessNumber: "  ",
+    });
+    expect(result).toEqual({
+      ok: true,
+      input: {
+        accountIdentifier: baseInput.accountIdentifier,
+        accountName: baseInput.accountName,
+        institution: baseInput.institution,
+      },
+    });
+  });
+});
+
+describe("buildOfframpRecipient", () => {
+  it("produces exactly the keys the aggregator decrypts, in order", () => {
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "nonce1");
+    expect(Object.keys(recipient)).toEqual([
+      "accountIdentifier",
+      "accountName",
+      "institution",
+      "memo",
+      "nonce",
+      "metadata",
+    ]);
+    expect(recipient.metadata).toEqual({ apiKey: SENDER_API_KEY });
+    expect(recipient.nonce).toBe("nonce1");
+  });
+
+  it("always serialises memo as a string and includes providerId only when given", () => {
+    const { memo: _memo, ...noMemo } = baseInput;
+    expect(buildOfframpRecipient(noMemo, SENDER_API_KEY).memo).toBe("");
+    expect("providerId" in buildOfframpRecipient(noMemo, SENDER_API_KEY)).toBe(false);
+    expect(
+      buildOfframpRecipient({ ...baseInput, providerId: "p1" }, SENDER_API_KEY)
+        .providerId,
+    ).toBe("p1");
+  });
+
+  it.each<[string, Partial<MessageHashInput>, Record<string, string>]>([
+    ["Mobile omits channel", { kesChannel: "Mobile" }, { apiKey: SENDER_API_KEY }],
+    ["Till adds channel", { kesChannel: "Till" }, { apiKey: SENDER_API_KEY, channel: "Till" }],
+    [
+      "Till ignores businessNumber",
+      { kesChannel: "Till", businessNumber: "123456" },
+      { apiKey: SENDER_API_KEY, channel: "Till" },
+    ],
+    [
+      "Paybill adds channel + businessNumber",
+      { kesChannel: "Paybill", businessNumber: "123456" },
+      { apiKey: SENDER_API_KEY, channel: "Paybill", businessNumber: "123456" },
+    ],
+    [
+      "Paybill without businessNumber is channel only",
+      { kesChannel: "Paybill" },
+      { apiKey: SENDER_API_KEY, channel: "Paybill" },
+    ],
+  ])("KES M-Pesa: %s", (_label, extra, expectedMetadata) => {
+    const recipient = buildOfframpRecipient(
+      { ...baseInput, institution: "SAFAKEPC", ...extra },
+      SENDER_API_KEY,
+    );
+    expect(recipient.metadata).toEqual(expectedMetadata);
+  });
+
+  it("ignores KES fields for a non-M-Pesa institution", () => {
+    const recipient = buildOfframpRecipient(
+      { ...baseInput, kesChannel: "Paybill", businessNumber: "123456" },
+      SENDER_API_KEY,
+    );
+    expect(recipient.metadata).toEqual({ apiKey: SENDER_API_KEY });
+  });
+
+  it("generates unique, URL-safe nonces", () => {
+    const nonces = new Set(Array.from({ length: 200 }, generateRecipientNonce));
+    expect(nonces.size).toBe(200);
+    for (const nonce of nonces) expect(nonce).toMatch(/^[A-Za-z0-9_-]{12}$/);
+  });
+});
+
+describe("parseAggregatorPublicKey / encryptRecipient", () => {
+  it("round-trips through SPKI, PKCS#1 and a mislabelled SPKI-body PEM", () => {
+    const spki = keys2048.publicPem;
+    const pkcs1 = createPublicKey(spki).export({ type: "pkcs1", format: "pem" }) as string;
+    const mislabelled = spki
+      .replace("BEGIN PUBLIC KEY", "BEGIN RSA PUBLIC KEY")
+      .replace("END PUBLIC KEY", "END RSA PUBLIC KEY");
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "n");
+
+    for (const pem of [spki, pkcs1, mislabelled, `\n${spki}\n`]) {
+      const key = parseAggregatorPublicKey(pem);
+      const messageHash = encryptRecipient(recipient, key);
+      expect(messageHash).toMatch(/^[A-Za-z0-9+/]+=*$/);
+      expect(decrypt(messageHash, keys2048.privatePem)).toEqual(recipient);
+    }
+  });
+
+  it("uses random padding so identical recipients encrypt differently", () => {
+    const key = parseAggregatorPublicKey(keys2048.publicPem);
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY, "n");
+    expect(encryptRecipient(recipient, key)).not.toBe(encryptRecipient(recipient, key));
+  });
+
+  it("rejects a non-RSA or empty key", () => {
+    const { publicKey: ed } = generateKeyPairSync("ed25519", {
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    expect(() => parseAggregatorPublicKey(ed)).toThrow(/expected rsa/);
+    expect(() => parseAggregatorPublicKey("")).toThrow(/empty/);
+  });
+
+  it("computes the PKCS#1 v1.5 budget and refuses oversized payloads", () => {
+    expect(maxPkcs1v15PlaintextBytes(parseAggregatorPublicKey(keys2048.publicPem))).toBe(245);
+    const small = parseAggregatorPublicKey(keys1024.publicPem);
+    expect(maxPkcs1v15PlaintextBytes(small)).toBe(117);
+    const recipient = buildOfframpRecipient(baseInput, SENDER_API_KEY);
+    expect(Buffer.byteLength(JSON.stringify(recipient))).toBeGreaterThan(117);
+    expect(() => encryptRecipient(recipient, small)).toThrow(RecipientTooLongError);
+  });
+});
+
+describe("handleCreateMessageHash", () => {
+  it("returns 401 without a verified wallet header", async () => {
+    const result = await handleCreateMessageHash(makeRequest(baseInput, null));
+    expect(result.status).toBe(401);
+    expect(mockFetchAggregatorPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic 503 when the sender API key is not configured", async () => {
+    mockGetSenderApiKey.mockReturnValue("");
+    const result = await handleCreateMessageHash(makeRequest(baseInput));
+    expect(result.status).toBe(503);
+    expect(JSON.stringify(result.body)).not.toMatch(/AGGREGATOR_SENDER_API_KEY_ID/);
+  });
+
+  it("returns 400 for invalid JSON and for a bad body", async () => {
+    const badJson: MessageHashRequest = {
+      headers: makeRequest({}).headers,
+      json: async () => {
+        throw new SyntaxError("bad");
+      },
+    };
+    expect((await handleCreateMessageHash(badJson)).status).toBe(400);
+    expect(
+      (await handleCreateMessageHash(makeRequest({ ...baseInput, institution: "" }))).status,
+    ).toBe(400);
+  });
+
+  it("returns 502 when the aggregator public key cannot be fetched or is malformed", async () => {
+    mockFetchAggregatorPublicKey.mockRejectedValueOnce(new Error("ECONNRESET"));
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({ status: "error", message: "nope" });
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({ status: "success", data: 42 });
+    expect((await handleCreateMessageHash(makeRequest(baseInput))).status).toBe(502);
+  });
+
+  it("returns 422 when the recipient exceeds the RSA budget", async () => {
+    mockFetchAggregatorPublicKey.mockResolvedValueOnce({
+      status: "success",
+      data: keys1024.publicPem,
+    });
+    const result = await handleCreateMessageHash(makeRequest(baseInput));
+    expect(result.status).toBe(422);
+    expect(result.body.message).toMatch(/too long/);
+  });
+
+  it("returns 200 with a messageHash the aggregator can decrypt, using the server-side key", async () => {
+    const result = await handleCreateMessageHash(
+      makeRequest({
+        ...baseInput,
+        institution: "SAFAKEPC",
+        kesChannel: "Paybill",
+        businessNumber: "654321",
+        // Client-supplied values that must be ignored:
+        metadata: { apiKey: "evil-key" },
+        apiKey: "evil-key",
+        nonce: "fixed-nonce",
+      }),
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.status).toBe("success");
+    const messageHash = (result.body.data as { messageHash: string }).messageHash;
+    const recipient = decrypt(messageHash, keys2048.privatePem) as Record<string, unknown>;
+
+    expect(recipient.metadata).toEqual({
+      apiKey: SENDER_API_KEY,
+      channel: "Paybill",
+      businessNumber: "654321",
+    });
+    expect(recipient.nonce).not.toBe("fixed-nonce");
+    expect(recipient.nonce).toMatch(/^[A-Za-z0-9_-]{12}$/);
+    expect(recipient.accountIdentifier).toBe(baseInput.accountIdentifier);
+    // A realistic KES Paybill payout must fit the production key's budget.
+    expect(Buffer.byteLength(JSON.stringify(recipient), "utf8")).toBeLessThanOrEqual(245);
+    expect(recipient).not.toHaveProperty("apiKey");
+    expect(recipient).not.toHaveProperty("refundAddress");
+  });
+});

--- a/__tests__/quoteTokenAmountForFiat.test.ts
+++ b/__tests__/quoteTokenAmountForFiat.test.ts
@@ -1,0 +1,106 @@
+import {
+  MAX_QUOTE_DECIMALS,
+  ONRAMP_FIAT_DECIMALS,
+  getQuoteDecimals,
+  quoteTokenAmountForFiat,
+} from "../app/utils";
+
+/** What the aggregator pays out: token amount x rate, rounded to the fiat's decimals. */
+const payout = (tokenAmount: number, rate: number) =>
+  Math.round(tokenAmount * rate * 100) / 100;
+
+describe("quoteTokenAmountForFiat", () => {
+  it("pays the full quote for the KAN-784 order that came up short", () => {
+    // 50000 / 1370.79 = 36.47531714..., which 4dp rounding cut to 36.4753 and
+    // the aggregator paid out as NGN 49,999.98.
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 6);
+
+    expect(amount).toBe(36.475318);
+    expect(payout(amount, 1370.79)).toBe(50000);
+    expect(payout(36.4753, 1370.79)).toBe(49999.98); // the old behaviour
+  });
+
+  it("never quotes below the fiat the recipient was promised", () => {
+    const rate = 1370.79;
+    for (let fiat = 1000; fiat <= 200000; fiat += 137) {
+      const amount = quoteTokenAmountForFiat(fiat, rate, 6);
+      expect(amount * rate).toBeGreaterThanOrEqual(fiat);
+      expect(payout(amount, rate)).toBeGreaterThanOrEqual(fiat);
+    }
+  });
+
+  it("overpays by at most one subunit", () => {
+    const rate = 1370.79;
+    for (let fiat = 1000; fiat <= 200000; fiat += 137) {
+      const amount = quoteTokenAmountForFiat(fiat, rate, 6);
+      expect(amount - fiat / rate).toBeLessThanOrEqual(1e-6);
+    }
+  });
+
+  it("does not charge an extra subunit for an exact division", () => {
+    expect(quoteTokenAmountForFiat(1400, 1400, 6)).toBe(1);
+    expect(quoteTokenAmountForFiat(4112.37, 1370.79, 6)).toBe(3);
+    expect(quoteTokenAmountForFiat(68539.5, 1370.79, 6)).toBe(50);
+  });
+
+  it("caps precision so 18-decimal tokens keep a readable amount", () => {
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 18);
+
+    expect(amount).toBe(36.475318);
+    expect(payout(amount, 1370.79)).toBe(50000);
+  });
+
+  it("honours a token coarser than the cap", () => {
+    const amount = quoteTokenAmountForFiat(50000, 1370.79, 2);
+
+    expect(amount).toBe(36.48);
+    expect(payout(amount, 1370.79)).toBeGreaterThanOrEqual(50000);
+  });
+
+  it("returns 0 rather than NaN for unusable input", () => {
+    expect(quoteTokenAmountForFiat(50000, 0, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(50000, -1, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(NaN, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(50000, NaN, 6)).toBe(0);
+  });
+
+  it("returns 0 for a nonpositive fiat target rather than a negative amount", () => {
+    // Rounding up through zero would also round the wrong way: Math.ceil(-729.5)
+    // is -729, shrinking the magnitude instead of growing it.
+    expect(quoteTokenAmountForFiat(-1, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(-50000, 1370.79, 6)).toBe(0);
+    expect(quoteTokenAmountForFiat(0, 1370.79, 6)).toBe(0);
+  });
+});
+
+describe("onramp Send precision", () => {
+  // `amountSent` is fiat on onramp, so it must not follow the token's decimals:
+  // the form picks ONRAMP_FIAT_DECIMALS over quoteDecimals when isSwapped.
+  const amountSentDecimals = (isSwapped: boolean, tokenDecimals: number) =>
+    isSwapped ? ONRAMP_FIAT_DECIMALS : getQuoteDecimals(tokenDecimals);
+
+  it("keeps four places on onramp whatever the token's precision", () => {
+    expect(amountSentDecimals(true, 6)).toBe(4);
+    expect(amountSentDecimals(true, 18)).toBe(4);
+    expect(amountSentDecimals(true, 2)).toBe(4);
+  });
+
+  it("follows the token only on offramp", () => {
+    expect(amountSentDecimals(false, 6)).toBe(6);
+    expect(amountSentDecimals(false, 18)).toBe(MAX_QUOTE_DECIMALS);
+    expect(amountSentDecimals(false, 2)).toBe(2);
+  });
+});
+
+describe("getQuoteDecimals", () => {
+  it("caps at the quote maximum", () => {
+    expect(getQuoteDecimals(18)).toBe(MAX_QUOTE_DECIMALS);
+    expect(getQuoteDecimals(6)).toBe(6);
+    expect(getQuoteDecimals(2)).toBe(2);
+  });
+
+  it("falls back to the cap when the token is unknown", () => {
+    expect(getQuoteDecimals(undefined)).toBe(MAX_QUOTE_DECIMALS);
+    expect(getQuoteDecimals(0)).toBe(MAX_QUOTE_DECIMALS);
+  });
+});

--- a/__tests__/smileIdIdValidation.test.ts
+++ b/__tests__/smileIdIdValidation.test.ts
@@ -1,0 +1,94 @@
+import {
+  getJobTypeForIdType,
+  validateSmileIdIdInfo,
+} from "../app/lib/smileIdIdValidation";
+import idTypesData from "../app/api/kyc/smile-id/id_types.json";
+
+// V_NIN (Virtual NIN) was offered for Nigeria but is not enabled on our Smile ID
+// account, so every job submitted under it failed at the provider after burning one
+// of the user's three tier 2 attempts. These tests pin the removal: it must be gone
+// from the catalogue the KYC modal renders, and it must no longer be treated as a
+// job-type-5 NIN-family type by the validator.
+
+const nigeriaIdTypes = idTypesData.continents
+  .flatMap((continent) => continent.countries)
+  .find((country) => country.code === "NG")?.id_types;
+
+describe("Nigeria ID type catalogue", () => {
+  it("no longer offers V_NIN", () => {
+    expect(nigeriaIdTypes).toBeDefined();
+    expect(nigeriaIdTypes?.map((t) => t.type)).not.toContain("V_NIN");
+  });
+
+  it("keeps the supported biometric paths to tier 2", () => {
+    expect(nigeriaIdTypes?.map((t) => t.type)).toEqual(
+      expect.arrayContaining(["BVN", "NIN_SLIP"]),
+    );
+  });
+
+  it("does not offer V_NIN for any other country", () => {
+    const everyPair = idTypesData.continents
+      .flatMap((continent) => continent.countries)
+      .flatMap((country) => country.id_types.map((t) => t.type));
+    expect(everyPair).not.toContain("V_NIN");
+  });
+});
+
+describe("getJobTypeForIdType", () => {
+  it("keeps the remaining NIN family on job type 5", () => {
+    for (const idType of ["BVN", "NIN", "NIN_SLIP", "NIN_V2"]) {
+      expect(getJobTypeForIdType(idType)).toBe(5);
+    }
+  });
+
+  it("no longer routes V_NIN to job type 5", () => {
+    expect(getJobTypeForIdType("V_NIN")).not.toBe(5);
+  });
+
+  it("still routes DRIVERS_LICENSE to job type 6 and others to job type 1", () => {
+    expect(getJobTypeForIdType("DRIVERS_LICENSE")).toBe(6);
+    expect(getJobTypeForIdType("PASSPORT")).toBe(1);
+  });
+});
+
+describe("validateSmileIdIdInfo", () => {
+  it("accepts an 11-digit NIN slip", () => {
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "NIN_SLIP",
+        id_number: "12345678901",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a short NIN slip with the NIN-specific message", () => {
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "NIN_SLIP",
+        id_number: "1234",
+      }),
+    ).toEqual({ ok: false, message: "Enter a valid 11-digit NIN." });
+  });
+
+  it("still requires country and id_type", () => {
+    expect(validateSmileIdIdInfo({ country: "", id_type: "" })).toEqual({
+      ok: false,
+      message: "Country and ID type are required.",
+    });
+  });
+
+  it("no longer applies 11-digit NIN validation to V_NIN", () => {
+    // V_NIN now falls through to the job-type-1 branch, where an unmatched
+    // country|type pair carries no authority rule. The route rejects it against
+    // the catalogue before it ever reaches Smile ID.
+    expect(
+      validateSmileIdIdInfo({
+        country: "NG",
+        id_type: "V_NIN",
+        id_number: "1234",
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/__tests__/textileRouting.test.ts
+++ b/__tests__/textileRouting.test.ts
@@ -1,0 +1,297 @@
+/// <reference types="jest" />
+
+jest.mock("../app/hooks/useEIP7702Account", () => ({
+  get7702AuthorizedImplementationForAddress: jest.fn(),
+}));
+
+jest.mock("../app/lib/config", () => ({
+  __esModule: true,
+  default: {
+    bridgeEnabled: true,
+    textileEnabled: true,
+  },
+}));
+
+import {
+  engineFromQuote,
+  normalizeTextileQuote,
+  selectEngine,
+  type BridgeLeg,
+} from "../app/lib/bridge";
+import { isTextileRoute } from "../app/lib/bridgeFeature";
+
+const leg = (
+  network: string,
+  chainId: number,
+  token: string,
+  tokenAddress: string,
+): BridgeLeg => ({
+  network,
+  chainId,
+  token,
+  tokenAddress,
+  decimals: token === "USDT" && network === "BNB Smart Chain" ? 18 : 6,
+  amount: "100",
+  rawAmount: "100000000",
+});
+
+const BSC_USDT = leg(
+  "BNB Smart Chain",
+  56,
+  "USDT",
+  "0x55d398326f99059ff775485246999027b3197955",
+);
+const BSC_CNGN = leg(
+  "BNB Smart Chain",
+  56,
+  "cNGN",
+  "0xa8aea66b361a8d53e8865c62d142167af28af058",
+);
+const CELO_USDT = leg(
+  "Celo",
+  42220,
+  "USDT",
+  "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+);
+const CELO_CNGN = leg(
+  "Celo",
+  42220,
+  "cNGN",
+  "0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f",
+);
+const BASE_USDC = leg(
+  "Base",
+  8453,
+  "USDC",
+  "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+);
+const BSC_USDC = leg(
+  "BNB Smart Chain",
+  56,
+  "USDC",
+  "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+);
+
+describe("textile routing", () => {
+  it("selects textile for same-chain USDT↔cNGN on BSC", () => {
+    expect(selectEngine(BSC_USDT, BSC_CNGN)).toBe("textile");
+    expect(selectEngine(BSC_CNGN, BSC_USDT)).toBe("textile");
+  });
+
+  it("selects textile for same-chain USDT↔cNGN on Celo", () => {
+    expect(selectEngine(CELO_USDT, CELO_CNGN)).toBe("textile");
+    expect(selectEngine(CELO_CNGN, CELO_USDT)).toBe("textile");
+  });
+
+  it("does not select textile for USDC↔cNGN on BSC", () => {
+    expect(isTextileRoute(BSC_USDC, BSC_CNGN)).toBe(false);
+    expect(selectEngine(BSC_USDC, BSC_CNGN)).toBe("lifi");
+  });
+
+  it("does not select textile for cross-chain USDT↔cNGN", () => {
+    expect(isTextileRoute(BSC_USDT, CELO_CNGN)).toBe(false);
+    expect(selectEngine(BSC_USDT, CELO_CNGN)).toBe("lifi");
+  });
+
+  it("does not select textile for non-cNGN pairs on BSC", () => {
+    expect(selectEngine(BSC_USDC, BASE_USDC)).toBe("near");
+  });
+});
+
+describe("engineFromQuote", () => {
+  it("maps textile-swap quotes to the textile engine", () => {
+    expect(
+      engineFromQuote({
+        kind: "textile-swap",
+        amountOut: "100",
+        feeReceivingToken: "0",
+        chainId: 56,
+        sellToken: "0xabc",
+        buyToken: "0xdef",
+        sellAmount: "1000000",
+        toDecimals: 6,
+        raw: {},
+      }),
+    ).toBe("textile");
+  });
+});
+
+describe("normalizeTextileQuote (v2 RFQ preview)", () => {
+  const baseParams = {
+    chainId: 56,
+    sellToken: "0x55d398326f99059ff775485246999027b3197955",
+    buyToken: "0xa8aea66b361a8d53e8865c62d142167af28af058",
+    sellAmount: "1000000000000000000",
+    toDecimals: 6,
+  };
+
+  it("accepts preview status with buyAmount", () => {
+    const result = normalizeTextileQuote(
+      {
+        data: {
+          status: "preview",
+          sellAmount: "1000000000000000000",
+          buyAmount: "1625000000",
+          feeAmount: "99990",
+          takerPays: "1000000000000000000",
+          rateRay: "1625000000000000000000000000",
+        },
+      },
+      baseParams,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.amountOut).toBe("1625");
+    expect(result?.sellAmount).toBe("1000000000000000000");
+  });
+
+  it("rejects no_quote preview", () => {
+    const result = normalizeTextileQuote(
+      {
+        data: {
+          status: "no_quote",
+          reason: "no_valid_quote",
+        },
+      },
+      baseParams,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects zero buyAmount", () => {
+    const result = normalizeTextileQuote(
+      {
+        data: {
+          status: "preview",
+          buyAmount: "0",
+        },
+      },
+      baseParams,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects missing status", () => {
+    const result = normalizeTextileQuote(
+      {
+        data: {
+          buyAmount: "1625000000",
+        },
+      },
+      baseParams,
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("textileServer validation", () => {
+  const validBscPreview = {
+    chainId: 56,
+    sellToken: "0x55d398326f99059ff775485246999027b3197955",
+    buyToken: "0xa8aea66b361a8d53e8865c62d142167af28af058",
+    sellAmount: "1000000000000000000",
+  };
+
+  const validBscRequest = {
+    ...validBscPreview,
+    taker: "0x0000000000000000000000000000000000000001",
+  };
+
+  it("parseJsonObjectBody rejects null and arrays", () => {
+    const { parseJsonObjectBody } = require("../app/lib/textileServer");
+
+    expect(parseJsonObjectBody(null).ok).toBe(false);
+    expect(parseJsonObjectBody([]).ok).toBe(false);
+    expect(parseJsonObjectBody({ chainId: 56 }).ok).toBe(true);
+  });
+
+  it("validateTextilePreviewBody accepts BSC USDT to cNGN", () => {
+    const { validateTextilePreviewBody } = require("../app/lib/textileServer");
+
+    expect(validateTextilePreviewBody(validBscPreview).ok).toBe(true);
+  });
+
+  it("validateTextilePreviewBody rejects missing sellAmount", () => {
+    const { validateTextilePreviewBody } = require("../app/lib/textileServer");
+
+    const { sellAmount: _, ...rest } = validBscPreview;
+    expect(validateTextilePreviewBody(rest).ok).toBe(false);
+  });
+
+  it("validateTextileRequestBody requires taker", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(validateTextileRequestBody(validBscPreview).ok).toBe(false);
+    expect(validateTextileRequestBody(validBscRequest).ok).toBe(true);
+  });
+
+  it("validateTextileRequestBody rejects unsupported chainId", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileRequestBody({ ...validBscRequest, chainId: 8453 }).ok,
+    ).toBe(false);
+  });
+
+  it("validateTextileRequestBody rejects non-positive sellAmount", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileRequestBody({ ...validBscRequest, sellAmount: "0" }).ok,
+    ).toBe(false);
+  });
+
+  it("validateTextileRequestBody rejects invalid addresses", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileRequestBody({ ...validBscRequest, taker: "not-an-address" }).ok,
+    ).toBe(false);
+  });
+
+  it("validateTextileRequestBody rejects unsupported token pairs", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileRequestBody({
+        ...validBscRequest,
+        buyToken: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("validateTextileRequestBody accepts Celo USDT to cNGN", () => {
+    const { validateTextileRequestBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileRequestBody({
+        chainId: 42220,
+        sellToken: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        buyToken: "0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f",
+        sellAmount: "1000000",
+        taker: "0x0000000000000000000000000000000000000001",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("validateTextileSubmitBody accepts rfqId alias swapId", () => {
+    const { validateTextileSubmitBody } = require("../app/lib/textileServer");
+
+    expect(
+      validateTextileSubmitBody({
+        rfqId: "rfq_abc",
+        txHash: "0xabc",
+      }).ok,
+    ).toBe(true);
+
+    expect(
+      validateTextileSubmitBody({
+        swapId: "rfq_legacy",
+        txHash: "0xabc",
+      }).ok,
+    ).toBe(true);
+  });
+});

--- a/app/api/aggregator.ts
+++ b/app/api/aggregator.ts
@@ -33,6 +33,7 @@ import type {
   ReferralData,
   ApiResponse,
   SubmitReferralResult,
+  KesMpesaChannel,
 } from "../types";
 import {
   trackServerEvent,
@@ -41,6 +42,7 @@ import {
   trackApiResponse,
 } from "../lib/server-analytics";
 import config from "../lib/config";
+import { getAggregatorSenderApiKey } from "../lib/server-config";
 import {
   isGatewayOrderId,
   isStarknetOrderId,
@@ -626,9 +628,14 @@ export const fetchSupportedInstitutions = async (
  * @returns {Promise<PubkeyResponse>} The public key response
  * @throws {Error} If the API request fails
  */
+/** Bounded so a stalled aggregator surfaces as an error (axios has no default timeout). */
+const PUBKEY_TIMEOUT_MS = 10_000;
+
 export const fetchAggregatorPublicKey = async (): Promise<PubkeyResponse> => {
   try {
-    const response = await axios.get(`${AGGREGATOR_URL}/pubkey`);
+    const response = await axios.get(`${AGGREGATOR_URL}/pubkey`, {
+      timeout: PUBKEY_TIMEOUT_MS,
+    });
     return response.data;
   } catch (error) {
     console.error("Error fetching aggregator public key:", error);
@@ -731,7 +738,12 @@ export const fetchOrderDetails = async (
 
   const injectedToken = options?.injectedToken?.trim();
 
-  if (typeof window !== "undefined" && (accessToken?.trim() || injectedToken)) {
+  if (typeof window !== "undefined") {
+    // Browser: always go through the Noblocks proxy. The direct aggregator
+    // path below attaches the sender API key, which is server-only.
+    if (!accessToken?.trim() && !injectedToken) {
+      throw new Error("Authentication required to fetch order details");
+    }
     const headers: Record<string, string> = {};
     if (injectedToken) {
       headers["x-injected-token"] = injectedToken;
@@ -763,11 +775,9 @@ export const fetchOrderDetails = async (
       : buildV2SenderOrderUrl(id);
     const headers: Record<string, string> = {};
     if (!gatewayLookup) {
-      const apiKey = config.aggregatorSenderApiKey?.trim();
+      const apiKey = getAggregatorSenderApiKey();
       if (!apiKey) {
-        throw new Error(
-          "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured",
-        );
+        throw new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured");
       }
       headers["API-Key"] = apiKey;
     }
@@ -1675,6 +1685,63 @@ export async function createV2SenderPaymentOrder(
     { headers },
   );
   return response.data;
+}
+
+/** Recipient fields the client supplies for an offramp order; the server adds the nonce and sender API key. */
+export type OfframpMessageHashPayload = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo?: string;
+  providerId?: string;
+  kesChannel?: KesMpesaChannel;
+  businessNumber?: string;
+};
+
+/**
+ * Offramp only. Asks the server to build the encrypted recipient payload for
+ * gateway.createOrder. The server generates the nonce, injects the sender API
+ * key (which never reaches the browser), applies the KES M-Pesa metadata rules,
+ * and RSA-encrypts with the aggregator public key. Returns the base64
+ * ciphertext used as the on-chain `messageHash` argument.
+ * Injected wallets authenticate via `x-injected-token`; Privy via Bearer.
+ */
+export async function createOfframpMessageHash(
+  payload: OfframpMessageHashPayload,
+  accessToken: string | null,
+  injectedToken: string | null = null,
+): Promise<string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (injectedToken) {
+    headers["x-injected-token"] = injectedToken;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+  // validateStatus + manual throw: middleware 401s carry `{ error }` rather than
+  // `{ message }`, and an axios throw on 5xx would collapse to the generic
+  // server-error copy. This keeps the server's specific message when present.
+  const response = await axios.post<AggregatorEnvelope<{ messageHash: string }>>(
+    "/api/v1/payment-orders/message-hash",
+    payload,
+    { headers, validateStatus: () => true },
+  );
+  const envelope = response.data;
+  const messageHash = envelope?.data?.messageHash;
+  if (
+    response.status >= 400 ||
+    envelope?.status !== "success" ||
+    typeof messageHash !== "string" ||
+    !messageHash
+  ) {
+    throw new Error(
+      typeof envelope?.message === "string" && envelope.message
+        ? envelope.message
+        : `Could not prepare order (${response.status})`,
+    );
+  }
+  return messageHash;
 }
 
 /**

--- a/app/api/bridge/hyperfx/bundler/route.ts
+++ b/app/api/bridge/hyperfx/bundler/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { getPrivyUserIdFromRequest } from "@/app/lib/privy";
+import { requireHyperfxBundlerUrl } from "@/app/utils";
+import {
+  HYPERFX_SUPPORTED_NETWORKS,
+  isHyperfxSwapEnabled,
+} from "@/app/lib/bridgeFeature";
+
+/** Authenticated fallback for client-side HyperFX execution (prefer quote.bundlerUrl). */
+export const GET = withRateLimit(async (request: NextRequest) => {
+  if (!isHyperfxSwapEnabled()) {
+    return NextResponse.json({ error: "HyperFX is not enabled" }, { status: 404 });
+  }
+
+  const userId = await getPrivyUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const network = request.nextUrl.searchParams.get("network")?.trim() ?? "";
+  if (!network) {
+    return NextResponse.json({ error: "network is required" }, { status: 400 });
+  }
+
+  if (!HYPERFX_SUPPORTED_NETWORKS.has(network)) {
+    return NextResponse.json(
+      { error: `HyperFX is not supported on ${network}` },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const bundlerUrl = requireHyperfxBundlerUrl(network);
+    return NextResponse.json({ bundlerUrl });
+  } catch {
+    return NextResponse.json(
+      { error: "HyperFX bundler is not configured" },
+      { status: 500 },
+    );
+  }
+});

--- a/app/api/bridge/hyperfx/quote/route.ts
+++ b/app/api/bridge/hyperfx/quote/route.ts
@@ -1,0 +1,265 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  EvmChain,
+  IntentGateway,
+  IntentsCoprocessor,
+  createQueryClient,
+} from "@hyperbridge/sdk";
+import { formatUnits, parseUnits } from "viem";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import { getRpcUrl } from "@/app/utils";
+import { requireHyperfxBundlerUrl } from "@/app/utils";
+import {
+  HYPERFX_SUPPORTED_NETWORKS,
+  isHyperfxSwapEnabled,
+} from "@/app/lib/bridgeFeature";
+import { getHyperfxNetworkConfig } from "@/app/lib/hyperfxNetworks";
+import type { HyperfxIntentQuote } from "@/app/lib/bridge";
+
+const UPSTREAM_TIMEOUT_MS = 20_000;
+const QUOTE_TTL_MS = 5 * 60 * 1000;
+
+const WS_URL =
+  process.env.HYPERBRIDGE_WS_URL || "wss://nexus.rpc.polytope.technology";
+const INDEXER_URL =
+  process.env.HYPERBRIDGE_INDEXER_URL ||
+  "https://nexus.indexer.polytope.technology";
+
+function normalizeTokenSymbol(symbol: string): string {
+  const s = symbol.trim().toLowerCase();
+  if (s === "cngn") return "cNGN";
+  if (s === "usdc") return "USDC";
+  if (s === "usdt") return "USDT";
+  return symbol.trim();
+}
+
+function isHyperfxQuotePair(fromToken: string, toToken: string): boolean {
+  const stables = new Set(["USDC", "USDT"]);
+  return (
+    (stables.has(fromToken) && toToken === "cNGN") ||
+    (fromToken === "cNGN" && stables.has(toToken))
+  );
+}
+
+function resolveTokenAddress(
+  chain: Awaited<ReturnType<typeof EvmChain.create>>,
+  sourceId: string,
+  symbol: string,
+): string | null {
+  const sym = symbol.toLowerCase();
+  if (sym === "usdc") {
+    return chain.configService.getUsdcAsset(sourceId) ?? null;
+  }
+  if (sym === "usdt") {
+    return chain.configService.getUsdtAsset(sourceId) ?? null;
+  }
+  if (sym === "cngn") {
+    return chain.configService.getCNgnAsset(sourceId) ?? null;
+  }
+  return null;
+}
+
+function resolveTokenDecimals(
+  chain: Awaited<ReturnType<typeof EvmChain.create>>,
+  sourceId: string,
+  symbol: string,
+): number {
+  const sym = symbol.toLowerCase();
+  if (sym === "usdc") {
+    return chain.configService.getUsdcDecimals(sourceId) ?? 6;
+  }
+  if (sym === "usdt") {
+    return chain.configService.getUsdtDecimals(sourceId) ?? 6;
+  }
+  if (sym === "cngn") {
+    return chain.configService.getCNgnDecimals(sourceId) ?? 6;
+  }
+  return 6;
+}
+
+function resolveQuoteChainId(network: string, chainIdRaw: string | null): number {
+  const networkCfg = getHyperfxNetworkConfig(network);
+  const defaultChainId = networkCfg?.chainId ?? 8453;
+  if (!chainIdRaw?.trim()) {
+    return defaultChainId;
+  }
+  const parsed = Number(chainIdRaw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return defaultChainId;
+  }
+  if (networkCfg && parsed !== networkCfg.chainId) {
+    return networkCfg.chainId;
+  }
+  return parsed;
+}
+
+function feeInReceivingToken(
+  feeInInput: bigint,
+  amountIn: bigint,
+  amountOut: bigint,
+): bigint {
+  if (amountIn <= BigInt(0)) {
+    return feeInInput;
+  }
+  return (feeInInput * amountOut) / amountIn;
+}
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+
+  if (!isHyperfxSwapEnabled()) {
+    return NextResponse.json({ error: "HyperFX is not enabled" }, { status: 404 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const network = searchParams.get("network")?.trim() ?? "";
+    const fromToken = normalizeTokenSymbol(searchParams.get("fromToken") ?? "");
+    const toToken = normalizeTokenSymbol(searchParams.get("toToken") ?? "");
+    const fromAmount = searchParams.get("fromAmount")?.trim() ?? "";
+
+    trackApiRequest(request, "/api/bridge/hyperfx/quote", "GET", {
+      network,
+      from_token: fromToken,
+      to_token: toToken,
+    });
+
+    if (!network || !fromToken || !toToken || !fromAmount) {
+      return NextResponse.json(
+        { error: "network, fromToken, toToken, and fromAmount are required" },
+        { status: 400 },
+      );
+    }
+
+    if (!HYPERFX_SUPPORTED_NETWORKS.has(network)) {
+      return NextResponse.json(
+        { error: `HyperFX is not supported on ${network}` },
+        { status: 422 },
+      );
+    }
+
+    if (!isHyperfxQuotePair(fromToken, toToken)) {
+      return NextResponse.json(
+        { error: "HyperFX only supports USDC/USDT↔cNGN pairs" },
+        { status: 422 },
+      );
+    }
+
+    const parsedAmount = Number(fromAmount);
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      return NextResponse.json(
+        { error: "fromAmount must be a positive number" },
+        { status: 400 },
+      );
+    }
+
+    const rpcUrl = getRpcUrl(network);
+    if (!rpcUrl) {
+      return NextResponse.json(
+        { error: `RPC URL not configured for ${network}` },
+        { status: 500 },
+      );
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("HyperFX quote timed out")),
+        UPSTREAM_TIMEOUT_MS,
+      );
+    });
+
+    const quotePromise = (async (): Promise<HyperfxIntentQuote> => {
+      const bundlerUrl = requireHyperfxBundlerUrl(network);
+      const chain = await EvmChain.create(rpcUrl, bundlerUrl);
+      const coprocessor = await IntentsCoprocessor.connect(WS_URL);
+      try {
+        const queryClient = createQueryClient({ url: INDEXER_URL });
+        const gateway = (
+          await IntentGateway.create(chain, chain, coprocessor)
+        ).withQueryClient(queryClient);
+
+        const sourceId = chain.config.stateMachineId;
+        const tokenIn = resolveTokenAddress(chain, sourceId, fromToken);
+        const tokenOut = resolveTokenAddress(chain, sourceId, toToken);
+        if (!tokenIn || !tokenOut) {
+          throw new Error(`Token pair not configured for ${network}`);
+        }
+
+        const fromDecimals = resolveTokenDecimals(chain, sourceId, fromToken);
+        const toDecimals = resolveTokenDecimals(chain, sourceId, toToken);
+        const amountIn = parseUnits(fromAmount, fromDecimals);
+        const chainId = resolveQuoteChainId(
+          network,
+          searchParams.get("chainId"),
+        );
+
+        const quote = await gateway.quoteIntent({
+          tokenIn: tokenIn as `0x${string}`,
+          tokenOut: tokenOut as `0x${string}`,
+          amountIn,
+        });
+
+        const amountOutFormatted = formatUnits(quote.amountOut, toDecimals);
+        const protocolFeeBps = Number(quote.quoteMetadata?.protocolFeeBps ?? 5);
+        const feeRaw = (amountIn * BigInt(protocolFeeBps)) / BigInt(10000);
+        const feeInReceiving = feeInReceivingToken(
+          feeRaw,
+          amountIn,
+          quote.amountOut,
+        );
+        const feeFormatted = formatUnits(feeInReceiving, toDecimals);
+
+        return {
+          kind: "hyperfx-intent",
+          amountOut: amountOutFormatted,
+          fee: feeFormatted,
+          amountIn: fromAmount,
+          rawAmountIn: amountIn.toString(),
+          rawAmountOut: quote.amountOut.toString(),
+          tokenIn,
+          tokenOut,
+          network,
+          chainId,
+          protocolFeeBps,
+          expiresAt: Date.now() + QUOTE_TTL_MS,
+          bundlerUrl,
+        };
+      } finally {
+        await coprocessor.disconnect().catch(() => undefined);
+      }
+    })();
+
+    let quote: HyperfxIntentQuote;
+    try {
+      quote = await Promise.race([quotePromise, timeout]);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    trackApiResponse(
+      "/api/bridge/hyperfx/quote",
+      "GET",
+      200,
+      Date.now() - startTime,
+      { network, from_token: fromToken, to_token: toToken },
+    );
+
+    return NextResponse.json({ quote });
+  } catch (err) {
+    trackApiError(request, "/api/bridge/hyperfx/quote", "GET", err as Error, 502, {
+      response_time_ms: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to fetch HyperFX quote" },
+      { status: 502 },
+    );
+  }
+});

--- a/app/api/bridge/hyperfx/status/route.ts
+++ b/app/api/bridge/hyperfx/status/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createPublicClient, http, parseEventLogs } from "viem";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { getRpcUrl } from "@/app/utils";
+import type { BridgeStatusResult } from "@/app/lib/bridge";
+import {
+  HYPERFX_GATEWAY_BY_NETWORK,
+  HYPERFX_INTENT_GATEWAY_ABI,
+  orderFromOrderPlacedLog,
+  resolveHyperfxOrderStatus,
+} from "@/app/lib/hyperfxStatus";
+import { HYPERFX_VIEM_CHAIN_BY_NETWORK } from "@/app/lib/hyperfxNetworks";
+
+const CHAIN_BY_NETWORK = HYPERFX_VIEM_CHAIN_BY_NETWORK;
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const txHash = request.nextUrl.searchParams.get("txHash")?.trim();
+  const network = request.nextUrl.searchParams.get("network")?.trim() || "Base";
+
+  if (!txHash || !/^0x[0-9a-fA-F]{64}$/.test(txHash)) {
+    return NextResponse.json({ error: "Valid txHash is required" }, { status: 400 });
+  }
+
+  const gateway = HYPERFX_GATEWAY_BY_NETWORK[network];
+  const chain = CHAIN_BY_NETWORK[network];
+  const rpcUrl = getRpcUrl(network);
+  if (!gateway || !chain || !rpcUrl) {
+    return NextResponse.json({ error: `Unsupported network: ${network}` }, { status: 422 });
+  }
+
+  const client = createPublicClient({ chain, transport: http(rpcUrl) });
+  const receipt = await client.getTransactionReceipt({ hash: txHash as `0x${string}` });
+
+  const placed = parseEventLogs({
+    abi: HYPERFX_INTENT_GATEWAY_ABI,
+    logs: receipt.logs.filter((log) => log.address.toLowerCase() === gateway.toLowerCase()),
+  }).find((event) => event.eventName === "OrderPlaced");
+
+  if (!placed) {
+    const result: BridgeStatusResult = { status: "PROCESSING", txHash };
+    return NextResponse.json(result);
+  }
+
+  const order = orderFromOrderPlacedLog(placed.args);
+
+  const resolved = await resolveHyperfxOrderStatus(
+    client,
+    gateway,
+    order,
+    receipt.blockNumber,
+  );
+
+  if (resolved.status === "SUCCESS") {
+    const result: BridgeStatusResult = {
+      status: "SUCCESS",
+      txHash,
+      destinationTxHash: resolved.fillTxHash ?? txHash,
+    };
+    return NextResponse.json(result);
+  }
+
+  if (resolved.status === "REFUNDED") {
+    const result: BridgeStatusResult = { status: "REFUNDED", txHash };
+    return NextResponse.json(result);
+  }
+
+  if (resolved.status === "FAILED") {
+    const result: BridgeStatusResult = { status: "FAILED", txHash };
+    return NextResponse.json(result);
+  }
+
+  const result: BridgeStatusResult = { status: "PROCESSING", txHash };
+  return NextResponse.json(result);
+});

--- a/app/api/bridge/textile/quote/route.ts
+++ b/app/api/bridge/textile/quote/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import {
+  TEXTILE_API_V2_BASE,
+  TEXTILE_PREVIEW_TIMEOUT_MS,
+  textileAuthHeaders,
+  parseJsonObjectBody,
+  validateTextilePreviewBody,
+} from "@/app/lib/textileServer";
+
+/** Proxies Textile v2 RFQ preview (indicative price while user types). */
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+  try {
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const objectBody = parseJsonObjectBody(parsed);
+    if (!objectBody.ok) {
+      return NextResponse.json({ error: objectBody.error }, { status: 400 });
+    }
+
+    const body = objectBody.body;
+    const validation = validateTextilePreviewBody(body);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    trackApiRequest(request, "/api/bridge/textile/quote", "POST", {
+      chain_id: body.chainId,
+      sell_token: body.sellToken,
+      buy_token: body.buyToken,
+    });
+
+    const { data, status } = await axios.post(
+      `${TEXTILE_API_V2_BASE}/rfq/preview`,
+      {
+        chainId: body.chainId,
+        sellToken: body.sellToken,
+        buyToken: body.buyToken,
+        sellAmount: body.sellAmount,
+      },
+      {
+        headers: {
+          ...textileAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        validateStatus: () => true,
+        timeout: TEXTILE_PREVIEW_TIMEOUT_MS,
+      },
+    );
+
+    trackApiResponse(
+      "/api/bridge/textile/quote",
+      "POST",
+      status,
+      Date.now() - startTime,
+    );
+
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    trackApiError(request, "/api/bridge/textile/quote", "POST", err as Error, 502, {
+      response_time_ms: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to fetch Textile RFQ preview" },
+      { status: 502 },
+    );
+  }
+});

--- a/app/api/bridge/textile/status/route.ts
+++ b/app/api/bridge/textile/status/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import {
+  TEXTILE_API_V2_BASE,
+  TEXTILE_UPSTREAM_TIMEOUT_MS,
+  textileAuthHeaders,
+  textileRfqClaimHeaders,
+} from "@/app/lib/textileServer";
+
+export const GET = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+  try {
+    const rfqId =
+      request.nextUrl.searchParams.get("rfqId") ??
+      request.nextUrl.searchParams.get("swapId");
+    if (!rfqId) {
+      return NextResponse.json({ error: "rfqId required" }, { status: 400 });
+    }
+
+    const claimToken =
+      request.nextUrl.searchParams.get("claimToken") ??
+      request.headers.get("X-Rfq-Claim") ??
+      undefined;
+
+    trackApiRequest(request, "/api/bridge/textile/status", "GET", {
+      rfq_id: rfqId,
+    });
+
+    const { data, status } = await axios.get(
+      `${TEXTILE_API_V2_BASE}/rfq/${encodeURIComponent(rfqId)}`,
+      {
+        headers: {
+          ...textileAuthHeaders(),
+          ...textileRfqClaimHeaders(claimToken),
+        },
+        validateStatus: () => true,
+        timeout: TEXTILE_UPSTREAM_TIMEOUT_MS,
+      },
+    );
+
+    trackApiResponse(
+      "/api/bridge/textile/status",
+      "GET",
+      status,
+      Date.now() - startTime,
+    );
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    trackApiError(request, "/api/bridge/textile/status", "GET", err as Error, 502, {
+      response_time_ms: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to fetch Textile RFQ status" },
+      { status: 502 },
+    );
+  }
+});

--- a/app/api/bridge/textile/submit/route.ts
+++ b/app/api/bridge/textile/submit/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import {
+  TEXTILE_API_V2_BASE,
+  TEXTILE_UPSTREAM_TIMEOUT_MS,
+  textileAuthHeaders,
+  textileRfqClaimHeaders,
+  parseJsonObjectBody,
+  validateTextileSubmitBody,
+} from "@/app/lib/textileServer";
+
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+  try {
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const objectBody = parseJsonObjectBody(parsed);
+    if (!objectBody.ok) {
+      return NextResponse.json({ error: objectBody.error }, { status: 400 });
+    }
+
+    const body = objectBody.body;
+    const validation = validateTextileSubmitBody(body);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    const claimToken =
+      typeof body.claimToken === "string" ? body.claimToken : undefined;
+
+    trackApiRequest(request, "/api/bridge/textile/submit", "POST", {
+      rfq_id: validation.rfqId,
+    });
+
+    const { data, status } = await axios.post(
+      `${TEXTILE_API_V2_BASE}/rfq/${encodeURIComponent(validation.rfqId)}/submit`,
+      { txHash: body.txHash },
+      {
+        headers: {
+          ...textileAuthHeaders(),
+          ...textileRfqClaimHeaders(claimToken),
+          "Content-Type": "application/json",
+        },
+        validateStatus: () => true,
+        timeout: TEXTILE_UPSTREAM_TIMEOUT_MS,
+      },
+    );
+
+    trackApiResponse(
+      "/api/bridge/textile/submit",
+      "POST",
+      status,
+      Date.now() - startTime,
+    );
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    trackApiError(request, "/api/bridge/textile/submit", "POST", err as Error, 502, {
+      response_time_ms: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to submit Textile RFQ transaction" },
+      { status: 502 },
+    );
+  }
+});

--- a/app/api/bridge/textile/swap/route.ts
+++ b/app/api/bridge/textile/swap/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "@/app/lib/server-analytics";
+import {
+  TEXTILE_API_V2_BASE,
+  TEXTILE_RFQ_REQUEST_TIMEOUT_MS,
+  textileAuthHeaders,
+  parseJsonObjectBody,
+  validateTextileRequestBody,
+} from "@/app/lib/textileServer";
+
+/** Proxies Textile v2 RFQ request (firm quote + transactions on confirm). */
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const startTime = Date.now();
+  try {
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const objectBody = parseJsonObjectBody(parsed);
+    if (!objectBody.ok) {
+      return NextResponse.json({ error: objectBody.error }, { status: 400 });
+    }
+
+    const body = objectBody.body;
+    const validation = validateTextileRequestBody(body);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    trackApiRequest(request, "/api/bridge/textile/swap", "POST", {
+      chain_id: body.chainId,
+      sell_token: body.sellToken,
+      buy_token: body.buyToken,
+    });
+
+    const { data, status } = await axios.post(
+      `${TEXTILE_API_V2_BASE}/rfq/request`,
+      {
+        chainId: body.chainId,
+        sellToken: body.sellToken,
+        buyToken: body.buyToken,
+        sellAmount: body.sellAmount,
+        taker: body.taker,
+      },
+      {
+        headers: {
+          ...textileAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        validateStatus: () => true,
+        timeout: TEXTILE_RFQ_REQUEST_TIMEOUT_MS,
+      },
+    );
+
+    trackApiResponse(
+      "/api/bridge/textile/swap",
+      "POST",
+      status,
+      Date.now() - startTime,
+    );
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    trackApiError(request, "/api/bridge/textile/swap", "POST", err as Error, 502, {
+      response_time_ms: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to request Textile RFQ" },
+      { status: 502 },
+    );
+  }
+});

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/lib/server-analytics";
 import { getEmailForMonitoredAddress } from "@/app/utils";
 import config from "@/app/lib/config";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 /**
  * Fires the Tier 1 "verify your phone to start swapping" email (Activepieces → Brevo)
@@ -16,12 +17,21 @@ import config from "@/app/lib/config";
  */
 export const POST = withRateLimit(async (request: NextRequest) => {
   const startTime = Date.now();
+  // The nudge that starts tier 1. When it silently fails the user is never
+  // told to verify their phone, and nothing else reports it.
+  const report = createKycReporter({ step: "signup_email", targetTier: 1 });
+  // Read outside the try so the catch below can still name the user. The
+  // header is set by the middleware and reading it cannot throw.
+  const walletAddress = request.headers.get("x-wallet-address");
 
   try {
     trackApiRequest(request, "/api/kyc/signup-email", "POST");
 
-    const walletAddress = request.headers.get("x-wallet-address");
     if (!walletAddress) {
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/signup-email",
@@ -37,9 +47,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const webhookUrl = config.activepiecesSignupVerifyWebhookUrl;
     if (!webhookUrl) {
-      console.error(
-        "[activepieces] ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL not set — skipping signup email",
-      );
+      report.failed({
+        walletAddress,
+        stage: "signup_email_dispatch",
+        reason: "missing_webhook_config",
+        detail: "ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL is not set",
+        statusCode: 200,
+      });
       return NextResponse.json({ success: true, skipped: true });
     }
 
@@ -47,6 +61,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     // wallet/passkey signups without an email are silently skipped.
     const email = await getEmailForMonitoredAddress(walletAddress);
     if (!email) {
+      // Wallet and passkey signups have no email — expected, not a failure.
+      report.noop({
+        walletAddress,
+        stage: "signup_email_dispatch",
+        reason: "no_email_on_identity",
+        statusCode: 200,
+      });
       return NextResponse.json({ success: true, skipped: true });
     }
 
@@ -77,8 +98,22 @@ export const POST = withRateLimit(async (request: NextRequest) => {
 
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/kyc/signup-email", "POST", 200, responseTime);
+    report.success({
+      walletAddress,
+      stage: "signup_email_dispatch",
+      statusCode: 200,
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
+    // Covers the webhook's own non-2xx, which is thrown above.
+    report.failed({
+      walletAddress,
+      stage: "signup_email_dispatch",
+      reason: "webhook_failed",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(
       request,
       "/api/kyc/signup-email",

--- a/app/api/kyc/smile-id/callback/route.ts
+++ b/app/api/kyc/smile-id/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/app/lib/supabase";
 import { getSmileIdJobStatus } from "@/app/lib/smileID";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 // The callback signature only covers timestamp + partner_id (per SmileID's
 // protocol), NOT the body. A captured (timestamp, signature) pair could be
@@ -41,10 +42,23 @@ function confirmSmileSignature(
 }
 
 export async function POST(request: NextRequest) {
+  // The wallet is only known once the body is parsed, so the reporter starts
+  // without one and each call supplies it as soon as it is available.
+  const report = createKycReporter({
+    step: "id_callback",
+    targetTier: 2,
+    provider: "smile_id",
+  });
+
   let body: Record<string, any>;
   try {
     body = await request.json();
   } catch {
+    report.rejected({
+      stage: "request_validation",
+      reason: "invalid_json",
+      statusCode: 400,
+    });
     return NextResponse.json({ status: "error", message: "Invalid JSON" }, { status: 400 });
   }
 
@@ -52,7 +66,13 @@ export async function POST(request: NextRequest) {
   const apiKey = process.env.SMILE_IDENTITY_API_KEY;
 
   if (!partnerId || !apiKey) {
-    console.error("[smile-id/callback] Missing SMILE_IDENTITY_PARTNER_ID or SMILE_IDENTITY_API_KEY");
+    report.failed({
+      stage: "provider_config",
+      reason: "missing_provider_config",
+      detail:
+        "SMILE_IDENTITY_PARTNER_ID or SMILE_IDENTITY_API_KEY is not set",
+      statusCode: 500,
+    });
     return NextResponse.json({ status: "error", message: "Server misconfiguration" }, { status: 500 });
   }
 
@@ -60,6 +80,11 @@ export async function POST(request: NextRequest) {
   const { timestamp, signature } = body;
 
   if (!timestamp || !signature) {
+    report.rejected({
+      stage: "signature_check",
+      reason: "missing_signature_fields",
+      statusCode: 400,
+    });
     return NextResponse.json(
       { status: "error", message: "Missing signature fields" },
       { status: 400 },
@@ -74,7 +99,12 @@ export async function POST(request: NextRequest) {
   );
 
   if (!isValid) {
-    console.warn("[smile-id/callback] Signature verification failed", { timestamp });
+    // Worth alerting on: a genuine Smile ID callback never fails this.
+    report.rejected({
+      stage: "signature_check",
+      reason: "invalid_signature",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Invalid signature" },
       { status: 401 },
@@ -87,7 +117,11 @@ export async function POST(request: NextRequest) {
     timestampMs === null ||
     Math.abs(Date.now() - timestampMs) > MAX_CALLBACK_AGE_MS
   ) {
-    console.warn("[smile-id/callback] Stale or unparseable timestamp", { timestamp });
+    report.rejected({
+      stage: "signature_check",
+      reason: "stale_callback",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Stale callback" },
       { status: 401 },
@@ -103,7 +137,11 @@ export async function POST(request: NextRequest) {
     : rawUserId;
 
   if (!walletAddress) {
-    console.error("[smile-id/callback] Could not extract wallet address", { rawUserId });
+    report.failed({
+      stage: "request_validation",
+      reason: "missing_user_identifier",
+      statusCode: 400,
+    });
     return NextResponse.json(
       { status: "error", message: "Missing user identifier" },
       { status: 400 },
@@ -128,19 +166,42 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
 
   if (fetchError) {
-    console.error("[smile-id/callback] Failed to fetch profile", { walletAddress, fetchError });
+    report.failed({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: fetchError.code,
+      detail: fetchError.message,
+      jobId,
+      statusCode: 500,
+    });
     // Return 500 so SmileID retries delivery.
     return NextResponse.json({ status: "error", message: "Database error" }, { status: 500 });
   }
 
   if (!existing) {
-    console.warn("[smile-id/callback] No KYC profile found for wallet", { walletAddress });
+    report.rejected({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "no_kyc_profile",
+      jobId,
+      statusCode: 200,
+    });
     return NextResponse.json({ status: "ok", action: "none" });
   }
 
   // Already verified at tier 2+ — the sync response handled it; nothing to do.
   if (existing.verified && Number(existing.tier) >= 2) {
-    console.log("[smile-id/callback] Profile already verified, skipping", { walletAddress });
+    // The expected path: the synchronous submission already promoted them.
+    report.noop({
+      walletAddress,
+      stage: "profile_fetch",
+      reason: "already_verified",
+      tierFrom: Number(existing.tier) || 0,
+      jobId,
+      statusCode: 200,
+    });
     return NextResponse.json({ status: "ok", action: "already_verified" });
   }
 
@@ -148,8 +209,12 @@ export async function POST(request: NextRequest) {
   // Body fields are not covered by the callback signature; only proceed if
   // SmileID's signed job_status API reports the same success.
   if (!jobId) {
-    console.warn("[smile-id/callback] Missing job_id, cannot confirm job — no action", {
+    report.rejected({
       walletAddress,
+      stage: "job_status_confirm",
+      reason: "missing_job_id",
+      tierFrom: Number(existing.tier) || 0,
+      statusCode: 200,
     });
     return NextResponse.json({ status: "ok", action: "none" });
   }
@@ -168,12 +233,20 @@ export async function POST(request: NextRequest) {
     if (!confirmed) {
       // Covers failed/incomplete jobs too: SmileID sends callbacks for those,
       // and the signed status is the only outcome we act on.
-      console.log("[smile-id/callback] job_status did not confirm verification — no action", {
+      // A failed or still-incomplete job. Smile ID calls back for both, and
+      // the signed status is the only outcome we act on — so this is where an
+      // asynchronously rejected upgrade becomes visible.
+      report.rejected({
         walletAddress,
+        stage: "job_status_confirm",
+        reason: "provider_rejected",
+        detail:
+          (jobStatus?.result?.ResultText as string) ??
+          `job_complete=${jobStatus?.job_complete} job_success=${jobStatus?.job_success}`,
+        providerCode: jobStatus?.result?.ResultCode,
+        tierFrom: Number(existing.tier) || 0,
         jobId,
-        job_complete: jobStatus?.job_complete,
-        job_success: jobStatus?.job_success,
-        ResultCode: jobStatus?.result?.ResultCode,
+        statusCode: 200,
       });
       return NextResponse.json({ status: "ok", action: "none" });
     }
@@ -181,10 +254,14 @@ export async function POST(request: NextRequest) {
     const statusResult = (jobStatus?.result ?? {}) as Record<string, any>;
     signedIdInfo = statusResult.id_info ?? statusResult.ID_Info ?? {};
   } catch (e) {
-    console.error("[smile-id/callback] job_status confirmation failed", {
+    report.failed({
       walletAddress,
+      stage: "job_status_confirm",
+      reason: "provider_status_failed",
+      detail: e instanceof Error ? e.message : String(e),
+      error: e,
       jobId,
-      error: e instanceof Error ? e.message : e,
+      statusCode: 500,
     });
     // 500 so SmileID retries once the status API is reachable again.
     return NextResponse.json(
@@ -235,9 +312,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (idOwnerError) {
-      console.error("[smile-id/callback] ID ownership check failed", {
+      report.failed({
         walletAddress,
-        idOwnerError,
+        stage: "duplicate_id_check",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: idOwnerError.code,
+        detail: idOwnerError.message,
+        jobId,
+        statusCode: 500,
       });
       // Transient: 500 so SmileID retries.
       return NextResponse.json(
@@ -247,10 +330,14 @@ export async function POST(request: NextRequest) {
     }
 
     if (idOwner) {
-      console.warn(
-        "[smile-id/callback] ID document already verified on another wallet — skipping tier promotion",
-        { walletAddress, jobId },
-      );
+      report.rejected({
+        walletAddress,
+        stage: "duplicate_id_check",
+        reason: "duplicate_id_document",
+        tierFrom: currentTier,
+        jobId,
+        statusCode: 200,
+      });
       // 200: the conflict is permanent, so retrying would loop forever.
       return NextResponse.json({
         status: "ok",
@@ -275,24 +362,43 @@ export async function POST(request: NextRequest) {
     // Same conflict, lost to a concurrent verification after the check above.
     // Still permanent — do not ask SmileID to retry.
     if (updateError.code === "23505") {
-      console.warn(
-        "[smile-id/callback] Tier promotion hit the verified-ID unique index",
-        { walletAddress, jobId },
-      );
+      report.rejected({
+        walletAddress,
+        stage: "profile_update",
+        reason: "duplicate_id_document",
+        provider: "supabase",
+        providerCode: updateError.code,
+        tierFrom: currentTier,
+        jobId,
+        statusCode: 200,
+      });
       return NextResponse.json({
         status: "ok",
         action: "duplicate_id_conflict",
       });
     }
-    console.error("[smile-id/callback] Failed to update profile", { walletAddress, updateError });
+    report.failed({
+      walletAddress,
+      stage: "profile_update",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: updateError.code,
+      detail: updateError.message,
+      tierFrom: currentTier,
+      jobId,
+      statusCode: 500,
+    });
     // Return 500 so SmileID retries.
     return NextResponse.json({ status: "error", message: "Database update failed" }, { status: 500 });
   }
 
-  console.log("[smile-id/callback] Profile verified via async callback", {
+  report.success({
     walletAddress,
+    stage: "profile_update",
+    tierFrom: currentTier,
+    tierTo: newTier,
     jobId,
-    newTier,
+    statusCode: 200,
   });
 
   // Notify once, only on the first promotion to tier 2. Earlier guards already

--- a/app/api/kyc/smile-id/id_types.json
+++ b/app/api/kyc/smile-id/id_types.json
@@ -439,8 +439,7 @@
             { "type": "REGISTRATION_CERTIFICATE", "verification_method": "doc_verification" },
             { "type": "RESIDENT_ID", "verification_method": "doc_verification" },
             { "type": "TRAVEL_DOC", "verification_method": "doc_verification" },
-            { "type": "VOTER_ID", "verification_method": "doc_verification" },
-            { "type": "V_NIN", "verification_method": "biometric_kyc" }
+            { "type": "VOTER_ID", "verification_method": "doc_verification" }
           ]
         },
         {

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -11,6 +11,7 @@ import idTypesData from "./id_types.json";
 
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, emitKycEvent } from "@/app/lib/kyc-telemetry";
 
 /**
  * Country|ID-type pairs the app actually offers. The KYC modal builds its
@@ -55,6 +56,13 @@ export async function POST(request: NextRequest) {
   // Rate limit check
   const rateLimitResult = await rateLimit(request);
   if (!rateLimitResult.success) {
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "rejected",
+      targetTier: 2,
+      reason: "rate_limited",
+      statusCode: 429,
+    });
     return NextResponse.json(
       {
         status: "error",
@@ -68,11 +76,30 @@ export async function POST(request: NextRequest) {
   const walletAddress = request.headers.get("x-wallet-address");
 
   if (!walletAddress) {
+    // Not an unauthenticated user: middleware matches this route, turns those
+    // away with its own 401, and strips forged wallet headers. Reaching the
+    // handler without one means the matcher or header propagation broke.
+    emitKycEvent({
+      step: "id_verification",
+      outcome: "error",
+      targetTier: 2,
+      reason: "unauthorized",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { status: "error", message: "Unauthorized" },
       { status: 401 },
     );
   }
+
+  // Every exit below reports through this, so no verification outcome — least
+  // of all a provider rejection — leaves the route without a Datadog line.
+  const report = createKycReporter({
+    step: "id_verification",
+    walletAddress,
+    targetTier: 2,
+    provider: "smile_id",
+  });
 
   try {
     const body = await request.json();
@@ -80,6 +107,11 @@ export async function POST(request: NextRequest) {
 
     // Validate required fields
     if (!images || !Array.isArray(images) || images.length === 0) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "invalid_images",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { status: "error", message: "Invalid images data" },
         { status: 400 },
@@ -88,6 +120,11 @@ export async function POST(request: NextRequest) {
 
     // Validate id_info for Job Type 1 (Biometric KYC)
     if (!id_info?.country || !id_info?.id_type) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_id_info",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -97,9 +134,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Country|ID-type is known from here on: carried on every line so
+    // "which ID types fail most" is a group-by rather than an investigation.
+    const idContext = {
+      idCountry: id_info.country,
+      idType: id_info.id_type,
+    };
+
     // Reject unsupported pairs before the attempt counter is incremented, so a
     // request Smile ID can never verify does not burn one of the user's tries.
     if (!isSupportedCountryIdType(id_info.country, id_info.id_type)) {
+      report.rejected({
+        ...idContext,
+        stage: "request_validation",
+        reason: "unsupported_id_type",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -118,6 +168,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
     if (profileFetchError) {
+      report.failed({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: profileFetchError.code,
+        detail: profileFetchError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -128,6 +187,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!existingProfile) {
+      report.rejected({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "no_kyc_profile",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -139,6 +204,13 @@ export async function POST(request: NextRequest) {
     }
 
     if (existingProfile.tier < 1) {
+      report.rejected({
+        ...idContext,
+        stage: "profile_fetch",
+        reason: "phone_verification_required",
+        tierFrom: Number(existingProfile.tier) || 0,
+        statusCode: 403,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -149,18 +221,38 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const tierFrom = Number(existingProfile.tier) || 0;
+
     // Tier 2 allows up to 3 attempts
+    const MAX_ATTEMPTS = 3;
     const { data: newAttemptCount, error: rpcError } = await supabaseAdmin.rpc(
       "increment_kyc_attempts",
-      { p_wallet_address: walletAddress, p_max_attempts: 3 },
+      { p_wallet_address: walletAddress, p_max_attempts: MAX_ATTEMPTS },
     );
     if (rpcError) {
+      report.failed({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: rpcError.code,
+        detail: rpcError.message,
+        tierFrom,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { status: "error", message: "Failed to process verification attempt." },
         { status: 500 },
       );
     }
     if (newAttemptCount === -1) {
+      report.rejected({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "no_kyc_profile",
+        tierFrom,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -170,6 +262,17 @@ export async function POST(request: NextRequest) {
       );
     }
     if (newAttemptCount === -2) {
+      // The user is now stuck until support intervenes — the one rejection
+      // that always needs a human, so it must be findable by wallet address.
+      report.rejected({
+        ...idContext,
+        stage: "attempt_counter",
+        reason: "attempts_exhausted",
+        tierFrom,
+        attempt: MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -178,6 +281,11 @@ export async function POST(request: NextRequest) {
         { status: 429 },
       );
     }
+
+    const attemptContext = {
+      attempt: Number(newAttemptCount) || null,
+      attemptsRemaining: Math.max(0, MAX_ATTEMPTS - (Number(newAttemptCount) || 0)),
+    };
 
     // Use server utility to submit SmileID job
     type SmileIdResultType = {
@@ -201,11 +309,33 @@ export async function POST(request: NextRequest) {
       user_id = result.user_id;
     } catch (err) {
       if (err instanceof SmileIdValidationError) {
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "provider_submit",
+          reason: "id_info_validation_failed",
+          detail: err.message,
+          tierFrom,
+          statusCode: 400,
+        });
         return NextResponse.json(
           { status: "error", message: err.message },
           { status: 400 },
         );
       }
+      // Misconfiguration and Smile ID transport failures both land here, and
+      // both look identical to the user ("verification failed").
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "provider_submit",
+        reason: "provider_request_failed",
+        detail: err instanceof Error ? err.message : String(err),
+        error: err,
+        tierFrom,
+        jobType: getJobTypeForIdType(id_info.id_type),
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -237,23 +367,55 @@ export async function POST(request: NextRequest) {
         smileIdResult?.ResultText || "SmileID verification failed";
       const category = classifySmileIdFailure(errorMessage);
 
+      const isInfrastructureFailure = category === "database";
+
+      // The line support reads. `detail` is Smile ID's own ResultText — the
+      // actual reason the upgrade failed — and the category decides whether
+      // this is a user-facing rejection or an outage worth paging on.
+      const outcomeContext = {
+        ...idContext,
+        ...attemptContext,
+        // The refund below restores the try, so report what the user can
+        // actually retry with rather than the pre-refund count. If the refund
+        // itself fails it gets its own line.
+        attemptsRemaining: isInfrastructureFailure
+          ? Math.max(0, MAX_ATTEMPTS - Math.max(0, newAttemptCount - 1))
+          : attemptContext.attemptsRemaining,
+        stage: "provider_verify",
+        detail: errorMessage,
+        failureCategory: category,
+        providerCode: smileIdResult?.ResultCode,
+        jobId: job_id,
+        jobType: getJobTypeForIdType(id_info.id_type),
+        tierFrom,
+        statusCode: 400,
+      };
+      if (isInfrastructureFailure) {
+        report.failed({ ...outcomeContext, reason: "provider_unavailable" });
+      } else {
+        report.rejected({ ...outcomeContext, reason: "provider_rejected" });
+      }
+
       // Infrastructure outages should not count against the user's attempt quota
       // regardless of job type (Job Type 1, 5, or 6). Restore the counter that
       // was incremented above so they can retry freely.
-      if (category === "database") {
-        console.warn("[smile-id] infrastructure failure detected — restoring attempt counter", {
-          walletAddress,
-          jobType: getJobTypeForIdType(id_info.id_type),
-          resultText: errorMessage,
-        });
+      if (isInfrastructureFailure) {
         const { error: restoreError } = await supabaseAdmin
           .from("user_kyc_profiles")
           .update({ attempts: Math.max(0, newAttemptCount - 1) })
           .eq("wallet_address", walletAddress);
         if (restoreError) {
-          console.error("[smile-id] failed to restore attempt counter after infrastructure failure", {
-            walletAddress,
-            error: restoreError.message,
+          // The user keeps a try they should have been refunded — silent to
+          // them, and only visible here.
+          report.failed({
+            ...idContext,
+            ...attemptContext,
+            stage: "attempt_restore",
+            reason: "supabase_error",
+            provider: "supabase",
+            providerCode: restoreError.code,
+            detail: restoreError.message,
+            tierFrom,
           });
         }
       }
@@ -302,9 +464,7 @@ export async function POST(request: NextRequest) {
     ];
 
     // Tier 2 (ID) only after Tier 1 (phone): do not promote from tier 0 straight to 2
-    const currentTier = Number(existingProfile?.tier) || 0;
-    const newTier =
-      currentTier >= 1 ? Math.max(currentTier, 2) : currentTier;
+    const newTier = tierFrom >= 1 ? Math.max(tierFrom, 2) : tierFrom;
 
     const derivedFullName =
       smileIdInfo.full_name ||
@@ -338,12 +498,35 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
       if (idOwnerError) {
+        report.failed({
+          ...idContext,
+          ...attemptContext,
+          stage: "duplicate_id_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: idOwnerError.code,
+          detail: idOwnerError.message,
+          tierFrom,
+          jobId: job_id,
+          statusCode: 500,
+        });
         return NextResponse.json(
           { status: "error", message: "Failed to save KYC data" },
           { status: 500 },
         );
       }
       if (idOwner) {
+        // Smile ID verified them; we refused. Support cannot resolve this
+        // without knowing it happened, and the user is told to contact them.
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "duplicate_id_check",
+          reason: "duplicate_id_document",
+          tierFrom,
+          jobId: job_id,
+          statusCode: 409,
+        });
         return NextResponse.json(
           {
             status: "error",
@@ -379,6 +562,17 @@ export async function POST(request: NextRequest) {
       // 23505: partial unique index on verified ID documents (concurrent
       // verification of the same document on another non-injected wallet).
       if (supabaseError.code === "23505") {
+        report.rejected({
+          ...idContext,
+          ...attemptContext,
+          stage: "profile_update",
+          reason: "duplicate_id_document",
+          provider: "supabase",
+          providerCode: supabaseError.code,
+          tierFrom,
+          jobId: job_id,
+          statusCode: 409,
+        });
         return NextResponse.json(
           {
             status: "error",
@@ -388,6 +582,20 @@ export async function POST(request: NextRequest) {
           { status: 409 },
         );
       }
+      // Verification passed and the write failed: the worst case, because the
+      // user has spent an attempt on a document that did verify.
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: supabaseError.code,
+        detail: supabaseError.message,
+        tierFrom,
+        jobId: job_id,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -399,6 +607,16 @@ export async function POST(request: NextRequest) {
 
     // Verify that a row was actually updated
     if (!updatedProfile || updatedProfile.length === 0) {
+      report.failed({
+        ...idContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "no_rows_updated",
+        provider: "supabase",
+        tierFrom,
+        jobId: job_id,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           status: "error",
@@ -419,13 +637,24 @@ export async function POST(request: NextRequest) {
     // skips when the profile is already verified, so this won't double-send).
     // Resolve the recipient from the authenticated wallet (never the client-supplied
     // `email`) and dispatch after the response so webhook latency can't block KYC.
-    if (newTier >= 2 && currentTier < 2) {
+    if (newTier >= 2 && tierFrom < 2) {
       notifyKycResultEmail(walletAddress, {
         event: "kyc_result",
         status: "success",
         tier: newTier,
       });
     }
+
+    report.success({
+      ...idContext,
+      ...attemptContext,
+      stage: "profile_update",
+      tierFrom,
+      tierTo: newTier,
+      jobId: job_id,
+      jobType: getJobTypeForIdType(id_info.id_type),
+      statusCode: 200,
+    });
 
     return NextResponse.json({
       status: "success",
@@ -436,6 +665,13 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     return NextResponse.json(
       {
         status: "error",

--- a/app/api/kyc/smile-id/route.ts
+++ b/app/api/kyc/smile-id/route.ts
@@ -7,8 +7,28 @@ import {
   type SmileIDIdInfo,
 } from "@/app/lib/smileID";
 
+import idTypesData from "./id_types.json";
+
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+
+/**
+ * Country|ID-type pairs the app actually offers. The KYC modal builds its
+ * dropdown from the same catalogue, so any other pair reaching this route is a
+ * stale or hand-crafted request for a product we have not enabled on Smile ID.
+ */
+const SUPPORTED_COUNTRY_ID_TYPES: ReadonlySet<string> = new Set(
+  idTypesData.continents.flatMap((continent) =>
+    continent.countries.flatMap((country) =>
+      country.id_types.map((idType) => `${country.code}|${idType.type}`),
+    ),
+  ),
+);
+
+function isSupportedCountryIdType(country: string, idType: string): boolean {
+  const key = `${country.trim().toUpperCase()}|${idType.trim().toUpperCase()}`;
+  return SUPPORTED_COUNTRY_ID_TYPES.has(key);
+}
 
 type SmileFailureCategory = "database" | "quality" | "liveness" | "mismatch" | "general";
 
@@ -72,6 +92,18 @@ export async function POST(request: NextRequest) {
         {
           status: "error",
           message: "Missing id_info: country and id_type are required",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Reject unsupported pairs before the attempt counter is incremented, so a
+    // request Smile ID can never verify does not burn one of the user's tries.
+    if (!isSupportedCountryIdType(id_info.country, id_info.id_type)) {
+      return NextResponse.json(
+        {
+          status: "error",
+          message: "Unsupported ID type for the selected country.",
         },
         { status: 400 },
       );

--- a/app/api/kyc/status/route.ts
+++ b/app/api/kyc/status/route.ts
@@ -9,17 +9,25 @@ import {
   trackApiResponse,
   trackApiError,
 } from "@/app/lib/server-analytics";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
+  // Failures only. Every KYC surface polls this endpoint, so logging its
+  // successes would bury the upgrade steps that matter.
+  const report = createKycReporter({ step: "status" });
+  // Get the wallet address from the header set by the middleware. Read outside
+  // the try so the catch below can still name the user.
+  const walletAddress = request.headers.get("x-wallet-address");
 
   try {
     trackApiRequest(request, "/api/kyc/status", "GET");
 
-    // Get the wallet address from the header set by the middleware
-    const walletAddress = request.headers.get("x-wallet-address");
-
     if (!walletAddress) {
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/kyc/status",
@@ -41,6 +49,15 @@ export async function GET(request: NextRequest) {
       .maybeSingle();
 
     if (kycProfileError) {
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: kycProfileError.code,
+        detail: kycProfileError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/kyc/status",
@@ -69,6 +86,17 @@ export async function GET(request: NextRequest) {
       pooledWalletCount = scope.wallets.length;
       scopeWallets = scope.wallets;
     } catch (scopeError) {
+      // The identity scope decides which tier and limit the UI shows, so a
+      // failure here reads to the user as a lost verification.
+      report.failed({
+        walletAddress,
+        stage: "identity_scope",
+        reason: "identity_scope_failed",
+        detail:
+          scopeError instanceof Error ? scopeError.message : String(scopeError),
+        error: scopeError,
+        statusCode: 500,
+      });
       trackApiError(request, "/api/kyc/status", "GET", scopeError as Error, 500);
       return NextResponse.json(
         { success: false, error: "Failed to load KYC profile" },
@@ -93,10 +121,19 @@ export async function GET(request: NextRequest) {
         identityHasVerifiedPhone =
           await identityScopeHasVerifiedPhone(scopeWallets);
       } catch (phoneScopeError) {
-        console.error(
-          "[kyc/status] identity phone lookup failed:",
-          phoneScopeError,
-        );
+        // Fail-soft: the per-wallet answer still stands, but a tier 2 user
+        // whose phone lives on a sibling wallet can loop on the phone gate.
+        report.failed({
+          walletAddress,
+          stage: "identity_phone_lookup",
+          reason: "identity_phone_lookup_failed",
+          detail:
+            phoneScopeError instanceof Error
+              ? phoneScopeError.message
+              : String(phoneScopeError),
+          error: phoneScopeError,
+          tierFrom: tier,
+        });
       }
     }
 
@@ -113,6 +150,14 @@ export async function GET(request: NextRequest) {
       fullName: kycProfile?.full_name || null,
     });
   } catch (error) {
+    report.failed({
+      walletAddress,
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(request, '/api/kyc/status', 'GET', error as Error, 500);
     
     return NextResponse.json(

--- a/app/api/kyc/tier3-verify/route.ts
+++ b/app/api/kyc/tier3-verify/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/lib/dojah";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, emitKycEvent } from "@/app/lib/kyc-telemetry";
 const KYC_BUCKET = process.env.KYC_DOCUMENTS_BUCKET || "kyc-documents";
 // Countries where a street address cannot be meaningfully validated (PO Box culture,
 // no formal street addressing, etc.). Expand as needed.
@@ -30,6 +31,13 @@ const MIME_TO_EXT: Record<string, string> = {
 export async function POST(request: NextRequest) {
   const rateLimitResult = await rateLimit(request);
   if (!rateLimitResult.success) {
+    emitKycEvent({
+      step: "address_verification",
+      outcome: "rejected",
+      targetTier: 3,
+      reason: "rate_limited",
+      statusCode: 429,
+    });
     return NextResponse.json(
       { success: false, error: "Too many requests. Please try again later." },
       { status: 429 },
@@ -38,11 +46,28 @@ export async function POST(request: NextRequest) {
 
   const walletAddress = request.headers.get("x-wallet-address");
   if (!walletAddress) {
+    // Not an unauthenticated user: middleware matches this route, turns those
+    // away with its own 401, and strips forged wallet headers. Reaching the
+    // handler without one means the matcher or header propagation broke.
+    emitKycEvent({
+      step: "address_verification",
+      outcome: "error",
+      targetTier: 3,
+      reason: "unauthorized",
+      statusCode: 401,
+    });
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 401 },
     );
   }
+
+  const report = createKycReporter({
+    step: "address_verification",
+    walletAddress,
+    targetTier: 3,
+    provider: "dojah",
+  });
 
   try {
     const formData = await request.formData();
@@ -62,6 +87,12 @@ export async function POST(request: NextRequest) {
 
     const validatedDocumentType = documentType.trim();
     if (validatedDocumentType !== ALLOWED_DOCUMENT_TYPE) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "unsupported_document_type",
+        detail: validatedDocumentType || "(empty)",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -73,12 +104,22 @@ export async function POST(request: NextRequest) {
     }
 
     if (!file || file.size === 0) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_document",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Document file is required" },
         { status: 400 },
       );
     }
     if (!countryCode?.trim()) {
+      report.rejected({
+        stage: "request_validation",
+        reason: "missing_country",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Country is required" },
         { status: 400 },
@@ -93,6 +134,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (fetchError) {
+      report.failed({
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: fetchError.code,
+        detail: fetchError.message,
+        idCountry: trimmedCountry,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -103,6 +153,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!currentProfile) {
+      report.rejected({
+        stage: "profile_fetch",
+        reason: "no_kyc_profile",
+        idCountry: trimmedCountry,
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -115,6 +171,13 @@ export async function POST(request: NextRequest) {
 
     const currentTier = Number(currentProfile.tier) ?? 0;
     if (currentTier !== 2) {
+      report.rejected({
+        stage: "profile_fetch",
+        reason: "tier_prerequisite_missing",
+        tierFrom: currentTier,
+        idCountry: trimmedCountry,
+        statusCode: 403,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -125,8 +188,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Country and starting tier are known from here on — carried on every line
+    // so tier 3 failures can be grouped by corridor.
+    const addressContext = {
+      idCountry: trimmedCountry,
+      tierFrom: currentTier,
+    };
+
     // Validate file and address fields before consuming an attempt — cheap checks first
     if (file.size > MAX_FILE_BYTES) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "file_too_large",
+        detail: `${file.size} bytes`,
+        statusCode: 413,
+      });
       return NextResponse.json(
         { success: false, error: "File too large; maximum 5 MB" },
         { status: 413 },
@@ -136,6 +213,13 @@ export async function POST(request: NextRequest) {
     if (
       !ALLOWED_MIME_TYPES.includes(mime as (typeof ALLOWED_MIME_TYPES)[number])
     ) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "unsupported_file_type",
+        detail: mime || "(none)",
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -150,6 +234,12 @@ export async function POST(request: NextRequest) {
       !STREET_ADDRESS_OPTIONAL_COUNTRIES.has(trimmedCountry.toUpperCase()) &&
       !streetAddress?.trim()
     ) {
+      report.rejected({
+        ...addressContext,
+        stage: "request_validation",
+        reason: "missing_street_address",
+        statusCode: 400,
+      });
       return NextResponse.json(
         { success: false, error: "Street address is required" },
         { status: 400 },
@@ -157,17 +247,33 @@ export async function POST(request: NextRequest) {
     }
 
     // Tier 3 allows up to 5 attempts (document issues are more common than ID issues)
+    const MAX_ATTEMPTS = 5;
     const { data: newAttemptCount, error: rpcError } = await supabaseAdmin.rpc(
       "increment_kyc_attempts",
-      { p_wallet_address: walletAddress, p_max_attempts: 5 },
+      { p_wallet_address: walletAddress, p_max_attempts: MAX_ATTEMPTS },
     );
     if (rpcError) {
+      report.failed({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: rpcError.code,
+        detail: rpcError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { success: false, error: "Failed to process verification attempt." },
         { status: 500 },
       );
     }
     if (newAttemptCount === -1) {
+      report.rejected({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "no_kyc_profile",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -178,6 +284,14 @@ export async function POST(request: NextRequest) {
       );
     }
     if (newAttemptCount === -2) {
+      report.rejected({
+        ...addressContext,
+        stage: "attempt_counter",
+        reason: "attempts_exhausted",
+        attempt: MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -187,6 +301,14 @@ export async function POST(request: NextRequest) {
         { status: 429 },
       );
     }
+
+    const attemptContext = {
+      attempt: Number(newAttemptCount) || null,
+      attemptsRemaining: Math.max(
+        0,
+        MAX_ATTEMPTS - (Number(newAttemptCount) || 0),
+      ),
+    };
 
     const nameExt = file.name?.split(".").pop();
     const ext =
@@ -215,6 +337,17 @@ export async function POST(request: NextRequest) {
         ? `${msg} Create the "${KYC_BUCKET}" bucket in Supabase (Dashboard → Storage, or migration), or set KYC_DOCUMENTS_BUCKET to an existing private bucket.`
         : msg ||
           "Failed to upload document. Ensure the KYC storage bucket exists.";
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "document_upload",
+        // A missing bucket is a deployment fault, not a transient one — worth
+        // telling apart at a glance in the Logs Explorer.
+        reason: bucketMissing ? "storage_bucket_missing" : "storage_error",
+        provider: "supabase",
+        detail: msg,
+        statusCode: 500,
+      });
       return NextResponse.json(
         { success: false, error: errorText },
         { status: 500 },
@@ -229,6 +362,15 @@ export async function POST(request: NextRequest) {
     const signedUrl = signedUrlData?.signedUrl;
     if (signError || !signedUrl) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "signed_url",
+        reason: "storage_error",
+        provider: "supabase",
+        detail: signError?.message ?? "no signed URL returned",
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -250,19 +392,31 @@ export async function POST(request: NextRequest) {
       const msg =
         dojahResult?.entity?.result?.message ||
         "Document could not be verified as a valid proof of address.";
-      console.error("[tier3-verify] Dojah verification failed", {
-        resultStatus: dojahResult?.entity?.result?.status,
-        resultMessage: dojahResult?.entity?.result?.message,
-        providerName: dojahResult?.entity?.provider_name,
+      // Dojah's own words for why the utility bill was refused — the tier 3
+      // equivalent of Smile ID's ResultText.
+      report.rejected({
+        ...addressContext,
+        ...attemptContext,
+        stage: "provider_verify",
+        reason: "provider_rejected",
+        detail: msg,
+        providerCode: dojahResult?.entity?.result?.status,
+        statusCode: 400,
       });
       const { error: removeError } = await supabaseAdmin.storage
         .from(KYC_BUCKET)
         .remove([path]);
       if (removeError) {
-        console.warn(
-          "[tier3-verify] failed to remove uploaded doc after Dojah failure",
-          removeError.message,
-        );
+        // The rejected document stays in the bucket — a retention problem
+        // rather than a user-facing one.
+        report.failed({
+          ...addressContext,
+          ...attemptContext,
+          stage: "document_cleanup",
+          reason: "storage_error",
+          provider: "supabase",
+          detail: removeError.message,
+        });
       }
       notifyKycResultEmail(walletAddress, {
         event: "kyc_result",
@@ -316,6 +470,18 @@ export async function POST(request: NextRequest) {
 
     if (supabaseError) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      // Dojah approved the document and we failed to record it: the user has
+      // spent an attempt and is still on tier 2.
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: supabaseError.code,
+        detail: supabaseError.message,
+        statusCode: 500,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -327,6 +493,14 @@ export async function POST(request: NextRequest) {
 
     if (!updatedProfile || updatedProfile.length === 0) {
       await supabaseAdmin.storage.from(KYC_BUCKET).remove([path]);
+      report.failed({
+        ...addressContext,
+        ...attemptContext,
+        stage: "profile_update",
+        reason: "no_rows_updated",
+        provider: "supabase",
+        statusCode: 404,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -343,6 +517,14 @@ export async function POST(request: NextRequest) {
       tier: 3,
     });
 
+    report.success({
+      ...addressContext,
+      ...attemptContext,
+      stage: "profile_update",
+      tierTo: Math.max(currentTier, 3),
+      statusCode: 200,
+    });
+
     return NextResponse.json({
       success: true,
       message: "Tier 3 address verification completed",
@@ -350,7 +532,15 @@ export async function POST(request: NextRequest) {
     });
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
-    console.error("[tier3-verify] unexpected error", err);
+    // Dojah transport failures throw rather than returning a result, so this
+    // catch is a real verification outcome, not just a safety net.
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: raw,
+      error: err,
+      statusCode: 500,
+    });
     // Dojah often returns JSON in the thrown message; avoid double-encoding for clients.
     let message = raw;
     if (raw.trim().startsWith("{")) {

--- a/app/api/phone/send-otp/route.ts
+++ b/app/api/phone/send-otp/route.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../lib/server-analytics";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { isInjectedUserId } from "@/app/lib/injected-identity";
+import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 function hashOTP(otp: string): string {
   return createHash("sha256").update(otp).digest("hex");
@@ -26,23 +27,17 @@ function clampKycTier(tier: unknown): number {
   return Math.min(Math.max(Math.trunc(n), 0), 4);
 }
 
-function logSupabaseError(scope: string, err: { message?: string; code?: string; details?: string; hint?: string }) {
-  const fields = {
-    message: err.message ?? "(no message)",
-    code: err.code,
-    details: err.details,
-    hint: err.hint,
-  };
-  console.error(`[send-otp] ${scope}:`, fields.message, fields);
-}
-
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
+  // Tier 1 starts here: an OTP that never arrives is the first thing support
+  // is asked about, and until now nothing recorded the provider's answer.
+  const report = createKycReporter({ step: "phone_otp_send", targetTier: 1 });
 
   try {
     // Rate limit check
     const rateLimitResult = await rateLimit(request);
     if (!rateLimitResult.success) {
+      report.rejected({ reason: "rate_limited", statusCode: 429 });
       return NextResponse.json(
         { success: false, error: "Too many requests. Please try again later." },
         { status: 429 },
@@ -59,6 +54,10 @@ export async function POST(request: NextRequest) {
     const userId = request.headers.get("x-user-id");
 
     if (!walletAddress) {
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -73,6 +72,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!phoneNumber) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "missing_phone_number",
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -92,6 +97,15 @@ export async function POST(request: NextRequest) {
     // Validate phone number
     const validation = validatePhoneNumber(phoneNumber);
     if (!validation.isValid) {
+      // Never log the number itself — the country it parsed to is enough to
+      // tell a corridor problem from a user typo.
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "invalid_phone_format",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -111,6 +125,13 @@ export async function POST(request: NextRequest) {
       validation.country &&
       validation.country !== countryIso.trim().toUpperCase()
     ) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "phone_country_mismatch",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -139,10 +160,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
     if (profileFetchError) {
-      logSupabaseError(
-        "Supabase profile fetch failed",
-        profileFetchError,
-      );
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: profileFetchError.code,
+        detail: profileFetchError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -186,10 +212,15 @@ export async function POST(request: NextRequest) {
         .maybeSingle();
 
       if (phoneOwnerError) {
-        logSupabaseError(
-          "Supabase phone uniqueness check failed",
-          phoneOwnerError,
-        );
+        report.failed({
+          walletAddress,
+          stage: "phone_uniqueness_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: phoneOwnerError.code,
+          detail: phoneOwnerError.message,
+          statusCode: 500,
+        });
         return NextResponse.json(
           { success: false, error: "Failed to validate phone number" },
           { status: 500 },
@@ -197,6 +228,15 @@ export async function POST(request: NextRequest) {
       }
 
       if (phoneOwner) {
+        // Common and confusing for the user — they are told to use a different
+        // number with no explanation of which account holds this one.
+        report.rejected({
+          walletAddress,
+          stage: "phone_uniqueness_check",
+          reason: "duplicate_phone_number",
+          idCountry: validation.country,
+          statusCode: 409,
+        });
         trackApiError(
           request,
           "/api/phone/send-otp",
@@ -232,10 +272,16 @@ export async function POST(request: NextRequest) {
     }
 
     if (!result.success) {
-      console.error("[send-otp] OTP provider failed:", {
-        error: result.error,
-        message: result.message,
-        provider: validation.provider,
+      // The SMS never went out. Provider-side, so it reads as an error rather
+      // than a rejection: KudiSMS and Twilio outages page us, not the user.
+      report.failed({
+        walletAddress,
+        stage: "otp_provider",
+        reason: "otp_send_failed",
+        provider: isNigerian ? "kudisms" : "twilio",
+        detail: result.error || result.message,
+        idCountry: validation.country,
+        statusCode: 400,
       });
       const responseTime = Date.now() - startTime;
       trackApiResponse(
@@ -284,7 +330,17 @@ export async function POST(request: NextRequest) {
       );
 
     if (dbError) {
-      logSupabaseError("Supabase upsert (user_kyc_profiles) failed", dbError);
+      // The OTP was sent but the hash was not stored, so the code the user is
+      // about to receive can never verify.
+      report.failed({
+        walletAddress,
+        stage: "profile_upsert",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: dbError.code,
+        detail: dbError.message,
+        statusCode: 500,
+      });
       trackApiError(
         request,
         "/api/phone/send-otp",
@@ -324,6 +380,15 @@ export async function POST(request: NextRequest) {
     const responseTime = Date.now() - startTime;
     trackApiResponse("/api/phone/send-otp", "POST", 200, responseTime);
 
+    report.success({
+      walletAddress,
+      stage: "otp_provider",
+      provider: isNigerian ? "kudisms" : "twilio",
+      idCountry: validation.country,
+      tierFrom: Number(existingProfile?.tier) || 0,
+      statusCode: 200,
+    });
+
     return NextResponse.json({
       success: result.success,
       message: result.message,
@@ -331,7 +396,13 @@ export async function POST(request: NextRequest) {
       phoneNumber: validation.internationalFormat,
     });
   } catch (error) {
-    console.error("[send-otp] POST uncaught exception:", error);
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(request, "/api/phone/send-otp", "POST", error as Error, 500);
 
     return NextResponse.json(

--- a/app/api/phone/verify-otp/route.ts
+++ b/app/api/phone/verify-otp/route.ts
@@ -10,6 +10,7 @@ import { validatePhoneNumber } from "@/app/lib/phone-validation";
 import { checkTwilioVerifyCode } from "@/app/lib/phone-verification";
 import { rateLimit } from "@/app/lib/rate-limit";
 import { notifyKycResultEmail } from "@/app/lib/activepieces-kyc-result";
+import { createKycReporter, type KycReporter } from "@/app/lib/kyc-telemetry";
 
 const MAX_ATTEMPTS = 3;
 
@@ -48,6 +49,7 @@ async function promoteVerifiedPhone(
   e164: string,
   currentTier: number,
   isInjected: boolean,
+  report: KycReporter,
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
   if (!isInjected) {
     const { data: phoneOwner, error: ownerError } = await supabaseAdmin
@@ -61,6 +63,16 @@ async function promoteVerifiedPhone(
       .maybeSingle();
 
     if (ownerError) {
+      report.failed({
+        walletAddress,
+        stage: "phone_uniqueness_check",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: ownerError.code,
+        detail: ownerError.message,
+        tierFrom: currentTier,
+        statusCode: 500,
+      });
       return {
         ok: false,
         status: 500,
@@ -68,6 +80,14 @@ async function promoteVerifiedPhone(
       };
     }
     if (phoneOwner) {
+      // They entered the right code and still cannot proceed.
+      report.rejected({
+        walletAddress,
+        stage: "phone_uniqueness_check",
+        reason: "duplicate_phone_number",
+        tierFrom: currentTier,
+        statusCode: 409,
+      });
       return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
     }
   }
@@ -97,8 +117,27 @@ async function promoteVerifiedPhone(
   if (updateError) {
     // Still reachable: two non-injected wallets racing to verify the same number.
     if (updateError.code === "23505") {
+      report.rejected({
+        walletAddress,
+        stage: "promotion",
+        reason: "duplicate_phone_number",
+        provider: "supabase",
+        providerCode: updateError.code,
+        tierFrom: currentTier,
+        statusCode: 409,
+      });
       return { ok: false, status: 409, error: PHONE_IN_USE_ERROR };
     }
+    report.failed({
+      walletAddress,
+      stage: "promotion",
+      reason: "supabase_error",
+      provider: "supabase",
+      providerCode: updateError.code,
+      detail: updateError.message,
+      tierFrom: currentTier,
+      statusCode: 500,
+    });
     return {
       ok: false,
       status: 500,
@@ -107,6 +146,13 @@ async function promoteVerifiedPhone(
   }
 
   if (!updatedRow) {
+    report.rejected({
+      walletAddress,
+      stage: "promotion",
+      reason: "superseded_by_newer_otp",
+      tierFrom: currentTier,
+      statusCode: 409,
+    });
     return {
       ok: false,
       status: 409,
@@ -115,15 +161,25 @@ async function promoteVerifiedPhone(
     };
   }
 
+  report.success({
+    walletAddress,
+    stage: "promotion",
+    tierFrom: currentTier,
+    tierTo: currentTier === 0 ? 1 : currentTier,
+    statusCode: 200,
+  });
+
   return { ok: true };
 }
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
+  const report = createKycReporter({ step: "phone_otp_verify", targetTier: 1 });
 
   try {
     const rateLimitResult = await rateLimit(request);
     if (!rateLimitResult.success) {
+      report.rejected({ reason: "rate_limited", statusCode: 429 });
       return NextResponse.json(
         { success: false, error: "Too many requests. Please try again later." },
         { status: 429 },
@@ -139,6 +195,10 @@ export async function POST(request: NextRequest) {
     const walletAddress = request.headers.get("x-wallet-address");
 
     if (!walletAddress) {
+      // Not an unauthenticated user: middleware matches these routes, turns
+      // those away with its own 401, and strips forged wallet headers. Reaching
+      // the handler without one means the matcher or header propagation broke.
+      report.failed({ reason: "unauthorized", statusCode: 401 });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -153,6 +213,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!phoneNumber || !otpCode) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "missing_fields",
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -169,6 +235,13 @@ export async function POST(request: NextRequest) {
     // Normalize phone number to E.164 format for consistent querying
     const validation = validatePhoneNumber(phoneNumber);
     if (!validation.isValid || !validation.e164Format) {
+      report.rejected({
+        walletAddress,
+        stage: "request_validation",
+        reason: "invalid_phone_format",
+        idCountry: validation.country,
+        statusCode: 400,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -193,6 +266,15 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (fetchError) {
+      report.failed({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "supabase_error",
+        provider: "supabase",
+        providerCode: fetchError.code,
+        detail: fetchError.message,
+        statusCode: 500,
+      });
       trackApiError(request, "/api/phone/verify-otp", "POST", fetchError, 500);
       return NextResponse.json(
         { success: false, error: "Failed to fetch verification record" },
@@ -208,6 +290,13 @@ export async function POST(request: NextRequest) {
     ) {
       const responseTime = Date.now() - startTime;
       trackApiResponse("/api/phone/verify-otp", "POST", 200, responseTime);
+      report.noop({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "already_verified",
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 200,
+      });
       return NextResponse.json({
         success: true,
         message: "Phone number already verified",
@@ -219,6 +308,12 @@ export async function POST(request: NextRequest) {
       !verification ||
       verification.pending_phone_number !== validation.e164Format
     ) {
+      report.rejected({
+        walletAddress,
+        stage: "profile_fetch",
+        reason: "no_pending_verification",
+        statusCode: 404,
+      });
       trackApiError(
         request,
         "/api/phone/verify-otp",
@@ -239,6 +334,15 @@ export async function POST(request: NextRequest) {
         otpCode,
       );
       if (!checkResult.success) {
+        report.rejected({
+          walletAddress,
+          stage: "otp_check",
+          reason: "invalid_otp",
+          provider: "twilio",
+          detail: checkResult.error,
+          tierFrom: Number(verification.tier) || 0,
+          statusCode: 400,
+        });
         trackApiError(
           request,
           "/api/phone/verify-otp",
@@ -262,6 +366,7 @@ export async function POST(request: NextRequest) {
         validation.e164Format,
         Number(verification.tier) || 0,
         verification.is_injected_wallet === true,
+        report,
       );
       if (!promotion.ok) {
         trackApiError(
@@ -290,7 +395,18 @@ export async function POST(request: NextRequest) {
 
     // KudiSMS path: expiry, attempts, and DB OTP comparison
     const expiresRaw = verification.expires_at;
+    const rejectExpired = (reason: string) => {
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason,
+        provider: "kudisms",
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 400,
+      });
+    };
     if (expiresRaw == null || expiresRaw === "") {
+      rejectExpired("otp_expiry_missing");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
@@ -298,12 +414,14 @@ export async function POST(request: NextRequest) {
     }
     const expiresDate = new Date(expiresRaw as string);
     if (Number.isNaN(expiresDate.getTime())) {
+      rejectExpired("otp_expiry_unparseable");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
       );
     }
     if (new Date() > expiresDate) {
+      rejectExpired("otp_expired");
       return NextResponse.json(
         { success: false, error: "OTP has expired. Please request a new one." },
         { status: 400 },
@@ -311,6 +429,16 @@ export async function POST(request: NextRequest) {
     }
 
     if (verification.otp_attempts >= MAX_ATTEMPTS) {
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason: "attempts_exhausted",
+        provider: "kudisms",
+        attempt: Number(verification.otp_attempts) || MAX_ATTEMPTS,
+        attemptsRemaining: 0,
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 429,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -329,6 +457,15 @@ export async function POST(request: NextRequest) {
         });
 
       if (attemptsError) {
+        report.failed({
+          walletAddress,
+          stage: "otp_check",
+          reason: "supabase_error",
+          provider: "supabase",
+          providerCode: attemptsError.code,
+          detail: attemptsError.message,
+          statusCode: 500,
+        });
         trackApiError(
           request,
           "/api/phone/verify-otp",
@@ -344,6 +481,15 @@ export async function POST(request: NextRequest) {
 
       // Null means attempts limit was already reached mid-flight
       if (updatedAttempts === null || updatedAttempts === undefined) {
+        report.rejected({
+          walletAddress,
+          stage: "otp_check",
+          reason: "attempts_exhausted",
+          provider: "kudisms",
+          attemptsRemaining: 0,
+          tierFrom: Number(verification.tier) || 0,
+          statusCode: 429,
+        });
         return NextResponse.json(
           {
             success: false,
@@ -354,6 +500,16 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      report.rejected({
+        walletAddress,
+        stage: "otp_check",
+        reason: "invalid_otp",
+        provider: "kudisms",
+        attempt: Number(updatedAttempts) || null,
+        attemptsRemaining: Math.max(0, MAX_ATTEMPTS - Number(updatedAttempts)),
+        tierFrom: Number(verification.tier) || 0,
+        statusCode: 400,
+      });
       return NextResponse.json(
         {
           success: false,
@@ -371,6 +527,7 @@ export async function POST(request: NextRequest) {
       validation.e164Format,
       Number(verification.tier) || 0,
       verification.is_injected_wallet === true,
+      report,
     );
     if (!promotion.ok) {
       trackApiError(
@@ -398,6 +555,13 @@ export async function POST(request: NextRequest) {
       phoneNumber: phoneNumber,
     });
   } catch (error) {
+    report.failed({
+      stage: "unhandled",
+      reason: "unexpected_error",
+      detail: error instanceof Error ? error.message : String(error),
+      error,
+      statusCode: 500,
+    });
     trackApiError(
       request,
       "/api/phone/verify-otp",

--- a/app/api/v1/payment-orders/[id]/route.ts
+++ b/app/api/v1/payment-orders/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import config from "@/app/lib/config";
+import { getAggregatorSenderApiKey } from "@/app/lib/server-config";
 import { aggregatorOriginForV2 } from "@/app/api/aggregator";
 import {
   isGatewayOrderId,
@@ -84,21 +85,22 @@ export const GET = withRateLimit(
         }
         url = `${base}/v2/orders/${chainId}/${encodeURIComponent(orderId)}`;
       } else if (isSenderPaymentOrderUuid(orderId)) {
-        if (!config.aggregatorSenderApiKey?.trim()) {
+        const senderApiKey = getAggregatorSenderApiKey();
+        if (!senderApiKey) {
           trackApiError(
             request,
             "/api/v1/payment-orders/[id]",
             "GET",
-            new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+            new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
             500,
           );
           return NextResponse.json(
-            { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+            { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
             { status: 500 },
           );
         }
         url = `${base}/v2/sender/orders/${encodeURIComponent(orderId)}`;
-        headers = { "API-Key": config.aggregatorSenderApiKey.trim() };
+        headers = { "API-Key": senderApiKey };
       } else {
         return NextResponse.json(
           {

--- a/app/api/v1/payment-orders/message-hash/route.ts
+++ b/app/api/v1/payment-orders/message-hash/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/app/lib/rate-limit";
+import { handleCreateMessageHash } from "@/app/lib/payment-order-message-hash";
+
+// Authenticated by middleware.ts via the "/api/v1/payment-orders/:path*" matcher
+// (x-wallet-address is injected there). This static segment takes precedence
+// over the sibling [id] dynamic route. Node runtime only — crypto.publicEncrypt
+// is not available on the Edge runtime.
+export const POST = withRateLimit(async (request: NextRequest) => {
+  const result = await handleCreateMessageHash(request);
+  return NextResponse.json(result.body, { status: result.status });
+});

--- a/app/api/v1/payment-orders/route.ts
+++ b/app/api/v1/payment-orders/route.ts
@@ -7,6 +7,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import config from "@/app/lib/config";
+import { getAggregatorSenderApiKey } from "@/app/lib/server-config";
 import { getKycFullName } from "@/app/lib/kyc-profile-server";
 import { isOnrampFiatCurrencyCode } from "@/app/utils";
 import {
@@ -35,16 +36,17 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       );
     }
 
-    if (!config.aggregatorSenderApiKey?.trim()) {
+    const senderApiKey = getAggregatorSenderApiKey();
+    if (!senderApiKey) {
       trackApiError(
         request,
         "/api/v1/payment-orders",
         "POST",
-        new Error("NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured"),
+        new Error("AGGREGATOR_SENDER_API_KEY_ID is not configured"),
         500,
       );
       return NextResponse.json(
-        { success: false, error: "NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID is not configured" },
+        { success: false, error: "AGGREGATOR_SENDER_API_KEY_ID is not configured" },
         { status: 500 },
       );
     }
@@ -194,7 +196,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     const { data, status } = await axios.post(url, body, {
       headers: {
         "Content-Type": "application/json",
-        "API-Key": config.aggregatorSenderApiKey.trim(),
+        "API-Key": senderApiKey,
       },
       validateStatus: () => true,
     });

--- a/app/api/v1/recipients/route.ts
+++ b/app/api/v1/recipients/route.ts
@@ -8,7 +8,7 @@ import {
   trackBusinessEvent,
 } from "@/app/lib/server-analytics";
 import { isValidEvmAddressCaseInsensitive } from "@/app/lib/validation";
-import { NGN_NUBAN_LENGTH } from "@/app/utils";
+import { normalizeSavedRecipientChannel, NGN_NUBAN_LENGTH } from "@/app/utils";
 import type {
   RecipientDetailsWithId,
   SavedRecipientsResponse,
@@ -95,6 +95,10 @@ export const GET = withRateLimit(async (request: NextRequest) => {
         institutionCode: recipient.institution_code,
         accountIdentifier: recipient.account_identifier,
         type: recipient.type,
+        ...(recipient.channel ? { channel: recipient.channel } : {}),
+        ...(recipient.business_number
+          ? { businessNumber: recipient.business_number }
+          : {}),
       })) || [];
 
     // Transform wallet recipients
@@ -172,8 +176,17 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     });
 
     const body = await request.json();
-    const { name, institution, institutionCode, accountIdentifier, type, currency, walletAddress: walletAddressFromBody } =
-      body;
+    const {
+      name,
+      institution,
+      institutionCode,
+      accountIdentifier,
+      type,
+      currency,
+      walletAddress: walletAddressFromBody,
+      channel,
+      businessNumber,
+    } = body;
 
     // Handle wallet recipients (onramp)
     if (type === "wallet") {
@@ -409,6 +422,13 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     }
 
     // Insert recipient (upsert on unique constraint) - store sanitized digits so DB has consistent format
+    const channelValue =
+      typeof channel === "string" ? normalizeSavedRecipientChannel(channel) : "";
+    // "" rather than null: business_number is part of the recipient unique key, and
+    // Postgres treats NULLs as distinct, which would defeat the upsert.
+    const businessNumberValue =
+      typeof businessNumber === "string" ? businessNumber.trim() : "";
+
     const { data, error } = await supabaseAdmin
       .from("saved_recipients")
       .upsert(
@@ -420,10 +440,12 @@ export const POST = withRateLimit(async (request: NextRequest) => {
           institution_code: trimmedInstitutionCode,
           account_identifier: currency === "NGN" ? sanitizedIdentifier.replace(/\D/g, "") : sanitizedIdentifier,
           type,
+          channel: channelValue,
+          business_number: businessNumberValue,
         },
         {
           onConflict:
-            "normalized_wallet_address,institution_code,account_identifier",
+            "normalized_wallet_address,institution_code,account_identifier,channel,business_number",
         },
       )
       .select()
@@ -442,6 +464,10 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       institutionCode: data.institution_code,
       accountIdentifier: data.account_identifier,
       type: data.type,
+      ...(data.channel ? { channel: data.channel } : {}),
+      ...(data.business_number
+        ? { businessNumber: data.business_number }
+        : {}),
     };
 
     const response: SaveRecipientResponse = {

--- a/app/api/v1/recipients/route.ts
+++ b/app/api/v1/recipients/route.ts
@@ -8,6 +8,7 @@ import {
   trackBusinessEvent,
 } from "@/app/lib/server-analytics";
 import { isValidEvmAddressCaseInsensitive } from "@/app/lib/validation";
+import { NGN_NUBAN_LENGTH } from "@/app/utils";
 import type {
   RecipientDetailsWithId,
   SavedRecipientsResponse,
@@ -342,8 +343,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     // Only enforce NUBAN digit-length validation for NGN recipients
     if (currency === "NGN") {
       const digits = sanitizedIdentifier.replace(/\D/g, "");
-      const requiredLen = trimmedInstitutionCode === "SAFAKEPC" ? 6 : 10;
-      if (digits.length !== requiredLen) {
+      if (digits.length !== NGN_NUBAN_LENGTH) {
         trackApiError(
           request,
           "/api/v1/recipients",
@@ -354,10 +354,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
         return NextResponse.json(
           {
             success: false,
-            error:
-              requiredLen === 10
-                ? "Please enter a valid 10-digit account number."
-                : "Please enter a valid 6-digit account number.",
+            error: "Please enter a valid 10-digit account number.",
           },
           { status: 400 },
         );

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -9,7 +9,7 @@ import { AnimatedModal, AnimatedFeedbackItem } from "@/app/components/AnimatedCo
 import { SearchInput } from "@/app/components/recipient/SearchInput";
 import { InputError } from "@/app/components/InputError";
 import type { InstitutionProps, RefundAccountDetails } from "@/app/types";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { primaryBtnClasses, secondaryBtnClasses } from "@/app/components/Styles";
 import { useKYC } from "@/app/context";
@@ -98,18 +98,15 @@ export function AddRefundAccountModal({
     }
 
     const digits = accountNumber.replace(/\D/g, "");
-    const requiredLen = selectedInstitution.code === "SAFAKEPC" ? 6 : 10;
 
     if (currency === "NGN") {
       if (digits.length === 0) {
         setAccountNumberError(null);
         return;
       }
-      if (digits.length !== requiredLen) {
+      if (digits.length !== NGN_NUBAN_LENGTH) {
         setAccountNumberError(
-          requiredLen === 6
-            ? `Please enter a valid 6-digit account number (${digits.length} entered).`
-            : `Please enter a valid 10-digit account number (${digits.length} entered).`,
+          `Please enter a valid 10-digit account number (${digits.length} entered).`,
         );
         return;
       }

--- a/app/components/MainPageContent.tsx
+++ b/app/components/MainPageContent.tsx
@@ -322,6 +322,8 @@ export function MainPageContent() {
       accountIdentifier: "",
       accountType: "bank",
       walletAddress: "",
+      kesChannel: "",
+      businessNumber: "",
       swapMode: initialSwapMode,
       /** Must match `swapMode` or tabs vs recipient/rates disagree (e.g. Base defaults on-ramp). */
       isSwapped: initialSwapMode === "onramp",

--- a/app/components/PWAInstallManager.tsx
+++ b/app/components/PWAInstallManager.tsx
@@ -1,8 +1,21 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+import { useStep } from "../context/StepContext";
 
+/**
+ * Registers the PWA service worker and keeps open tabs on the current build:
+ * when a new worker takes control it reloads the page — skipped on first
+ * install, and deferred while a transaction step is on screen.
+ */
 export default function PWAInstall() {
+  const { isFormStep } = useStep();
+  // True once this page has been controlled by a service worker. The first
+  // controllerchange after an uncontrolled load is the initial install, not an
+  // update — reloading there would loop on every first visit.
+  const hadControllerRef = useRef(false);
+  const updatePendingRef = useRef(false);
+
   useEffect(() => {
     // Register service worker
     if ("serviceWorker" in navigator) {
@@ -30,6 +43,41 @@ export default function PWAInstall() {
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
   }, []);
+
+  // sw.js calls skipWaiting() + clients.claim(), so a new worker takes over
+  // open pages immediately — but each page keeps running the JS it already
+  // loaded. Build-time config (NEXT_PUBLIC_* keys) lives in that JS, so a
+  // long-lived PWA tab keeps stamping stale values until it reloads. Reload as
+  // soon as a new worker takes control, unless a transaction is on screen; in
+  // that case wait until the user is back on the form.
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+    const sw = navigator.serviceWorker;
+    if (sw.controller) hadControllerRef.current = true;
+
+    const reloadIfSafe = () => {
+      if (!updatePendingRef.current || !isFormStep) return;
+      updatePendingRef.current = false;
+      window.location.reload();
+    };
+
+    const handleControllerChange = () => {
+      if (!hadControllerRef.current) {
+        hadControllerRef.current = true;
+        return;
+      }
+      updatePendingRef.current = true;
+      reloadIfSafe();
+    };
+
+    sw.addEventListener("controllerchange", handleControllerChange);
+    // The step may have just returned to the form with an update pending.
+    reloadIfSafe();
+
+    return () => {
+      sw.removeEventListener("controllerchange", handleControllerChange);
+    };
+  }, [isFormStep]);
 
   // This component doesn't render anything - it just sets up PWA functionality
   // The browser will show its native install prompt when appropriate

--- a/app/components/PWAInstallManager.tsx
+++ b/app/components/PWAInstallManager.tsx
@@ -3,10 +3,16 @@
 import React, { useEffect, useRef } from "react";
 import { useStep } from "../context/StepContext";
 
+/** How often an open tab asks the browser to re-check sw.js for a new build. */
+const SW_UPDATE_INTERVAL_MS = 15 * 60 * 1000;
+
 /**
  * Registers the PWA service worker and keeps open tabs on the current build:
  * when a new worker takes control it reloads the page — skipped on first
- * install, and deferred while a transaction step is on screen.
+ * install, and deferred while a transaction step is on screen. Idle tabs are
+ * nudged to look for a new worker on a timer and whenever they come back into
+ * view, since browsers otherwise only re-check sw.js on navigation or roughly
+ * once a day.
  */
 export default function PWAInstall() {
   const { isFormStep } = useStep();
@@ -15,6 +21,7 @@ export default function PWAInstall() {
   // update — reloading there would loop on every first visit.
   const hadControllerRef = useRef(false);
   const updatePendingRef = useRef(false);
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
 
   useEffect(() => {
     // Register service worker
@@ -23,6 +30,7 @@ export default function PWAInstall() {
         navigator.serviceWorker
           .register("/sw.js")
           .then((registration) => {
+            registrationRef.current = registration;
             console.log("SW registered: ", registration);
           })
           .catch((registrationError) => {
@@ -46,10 +54,10 @@ export default function PWAInstall() {
 
   // sw.js calls skipWaiting() + clients.claim(), so a new worker takes over
   // open pages immediately — but each page keeps running the JS it already
-  // loaded. Build-time config (NEXT_PUBLIC_* keys) lives in that JS, so a
-  // long-lived PWA tab keeps stamping stale values until it reloads. Reload as
-  // soon as a new worker takes control, unless a transaction is on screen; in
-  // that case wait until the user is back on the form.
+  // loaded. Build-time config lives in that JS, so a long-lived PWA tab keeps
+  // running stale code until it reloads. Reload as soon as a new worker takes
+  // control, unless a transaction is on screen; in that case wait until the
+  // user is back on the form.
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
     const sw = navigator.serviceWorker;
@@ -78,6 +86,42 @@ export default function PWAInstall() {
       sw.removeEventListener("controllerchange", handleControllerChange);
     };
   }, [isFormStep]);
+
+  // Ask the browser to re-check sw.js when the tab comes back into view and on
+  // a timer. When a new worker is found it installs, claims the page, and the
+  // controllerchange effect above handles the reload.
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+    const sw = navigator.serviceWorker;
+    let cancelled = false;
+
+    const checkForUpdate = async () => {
+      try {
+        const registration =
+          registrationRef.current ?? (await sw.getRegistration?.()) ?? null;
+        if (cancelled || !registration) return;
+        await registration.update();
+      } catch {
+        // Transient network failures are expected here; the next tick retries.
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") void checkForUpdate();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    const timer = window.setInterval(
+      () => void checkForUpdate(),
+      SW_UPDATE_INTERVAL_MS,
+    );
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.clearInterval(timer);
+    };
+  }, []);
 
   // This component doesn't render anything - it just sets up PWA functionality
   // The browser will show its native install prompt when appropriate

--- a/app/components/PlayPromo.tsx
+++ b/app/components/PlayPromo.tsx
@@ -488,7 +488,7 @@ export function PlayPromoButton() {
 
   return (
     <motion.div
-      className="pointer-events-none fixed left-0 right-0 top-[72px] z-30"
+      className="pointer-events-none fixed left-0 right-0 top-[78px] z-30"
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: "easeOut" }}

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -208,7 +208,9 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   const engine: BridgeEngine | null = quote
     ? quote.kind === "lifi-tx"
       ? "lifi"
-      : "near"
+      : quote.kind === "hyperfx-intent"
+        ? "hyperfx"
+        : "near"
     : from && to
       ? selectEngine(from, to)
       : null;
@@ -295,7 +297,13 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     try {
       setIsFinalizing(true);
       const { txHash, depositRefId } = await execute(quote, fromWithAmount);
-      const resolvedEngine: BridgeEngine = quote.kind === "lifi-tx" ? "lifi" : "near";
+      const resolvedEngine: BridgeEngine =
+        quote.kind === "lifi-tx"
+          ? "lifi"
+          : quote.kind === "hyperfx-intent"
+            ? "hyperfx"
+            : "near";
+      const initialDbStatus = "pending";
 
       // Injected wallets authenticate saves via the x-injected-token session
       // JWT (interactive: the user just executed a convert, so a re-prompt on
@@ -318,12 +326,17 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
             fee: bridgeFeeInReceivingToken(quote),
             recipient: {
               account_name: "Convert",
-              institution: quote.kind === "lifi-tx" ? "LI.FI" : "NEAR Intents",
+              institution:
+                quote.kind === "lifi-tx"
+                  ? "LI.FI"
+                  : quote.kind === "hyperfx-intent"
+                    ? "HyperFX"
+                    : "NEAR Intents",
               account_identifier: txHash,
               // network is the source; persist the destination here (no schema change).
               to_network: to.network,
             },
-            status: "pending",
+            status: initialDbStatus,
             network: from.network,
             txHash,
             orderId: depositRefId,

--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -7,7 +7,13 @@ import { useNetwork } from "@/app/context/NetworksContext";
 import { useStarknet } from "@/app/context/StarknetContext";
 import { useBalance, useTokens, useInjectedWallet } from "@/app/context";
 import { useBridgeQuote, useBridgeExecute, useBridgeStatus } from "@/app/hooks/bridge";
-import { selectEngine, toRawAmount, bridgeFeeInReceivingToken } from "@/app/lib/bridge";
+import {
+  selectEngine,
+  engineFromQuote,
+  bridgeInstitutionLabel,
+  toRawAmount,
+  bridgeFeeInReceivingToken,
+} from "@/app/lib/bridge";
 import type { BridgeLeg, BridgeEngine } from "@/app/lib/bridge";
 import { minOffRampTokenAmount } from "@/app/lib/marketLiquidity";
 import { BridgeRouteSelector } from "./BridgeRouteSelector";
@@ -206,11 +212,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   // once a quote lands it is the source of truth, because a NEAR pair with no solver
   // inventory (USDT on Base, any Lisk/Celo leg) falls back to LI.FI inside useBridgeQuote.
   const engine: BridgeEngine | null = quote
-    ? quote.kind === "lifi-tx"
-      ? "lifi"
-      : quote.kind === "hyperfx-intent"
-        ? "hyperfx"
-        : "near"
+    ? engineFromQuote(quote)
     : from && to
       ? selectEngine(from, to)
       : null;
@@ -297,12 +299,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     try {
       setIsFinalizing(true);
       const { txHash, depositRefId } = await execute(quote, fromWithAmount);
-      const resolvedEngine: BridgeEngine =
-        quote.kind === "lifi-tx"
-          ? "lifi"
-          : quote.kind === "hyperfx-intent"
-            ? "hyperfx"
-            : "near";
+      const resolvedEngine = engineFromQuote(quote);
       const initialDbStatus = "pending";
 
       // Injected wallets authenticate saves via the x-injected-token session
@@ -326,12 +323,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
             fee: bridgeFeeInReceivingToken(quote),
             recipient: {
               account_name: "Convert",
-              institution:
-                quote.kind === "lifi-tx"
-                  ? "LI.FI"
-                  : quote.kind === "hyperfx-intent"
-                    ? "HyperFX"
-                    : "NEAR Intents",
+              institution: bridgeInstitutionLabel(quote),
               account_identifier: txHash,
               // network is the source; persist the destination here (no schema change).
               to_network: to.network,

--- a/app/components/bridge/BridgeQuoteCard.tsx
+++ b/app/components/bridge/BridgeQuoteCard.tsx
@@ -8,7 +8,7 @@ interface BridgeQuoteCardProps {
   quote: BridgeQuote | null;
   isLoading: boolean;
   error: Error | null;
-  engine: "near" | "lifi" | "hyperfx" | null;
+  engine: "near" | "lifi" | "textile" | "hyperfx" | null;
   toToken?: string;
   onExpire?: () => void;
 }
@@ -17,7 +17,7 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
   quote,
   isLoading,
   error,
-  engine,
+  engine: _engine,
   toToken,
   onExpire,
 }) => {
@@ -64,11 +64,13 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
   if (!quote) return null;
 
   const engineLabel =
-    engine === "near"
+    quote.kind === "near-deposit"
       ? "NEAR Intents"
-      : engine === "hyperfx"
-        ? "HyperFX"
-        : "LI.FI";
+      : quote.kind === "textile-swap"
+        ? "Textile FX"
+        : quote.kind === "hyperfx-intent"
+          ? "HyperFX"
+          : "LI.FI";
   const routeName =
     quote.kind === "lifi-tx" &&
     quote.raw &&

--- a/app/components/bridge/BridgeQuoteCard.tsx
+++ b/app/components/bridge/BridgeQuoteCard.tsx
@@ -8,7 +8,7 @@ interface BridgeQuoteCardProps {
   quote: BridgeQuote | null;
   isLoading: boolean;
   error: Error | null;
-  engine: "near" | "lifi" | null;
+  engine: "near" | "lifi" | "hyperfx" | null;
   toToken?: string;
   onExpire?: () => void;
 }
@@ -63,7 +63,12 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
 
   if (!quote) return null;
 
-  const engineLabel = engine === "near" ? "NEAR Intents" : "LI.FI";
+  const engineLabel =
+    engine === "near"
+      ? "NEAR Intents"
+      : engine === "hyperfx"
+        ? "HyperFX"
+        : "LI.FI";
   const routeName =
     quote.kind === "lifi-tx" &&
     quote.raw &&
@@ -131,6 +136,13 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
         <Row
           label="Transaction fee"
           value={`${formatTokenAmount(quote.feeReceivingToken)} ${toToken || ""}`}
+        />
+      )}
+
+      {quote.kind === "hyperfx-intent" && Number(quote.fee) > 0 && (
+        <Row
+          label="Transaction fee"
+          value={`${formatTokenAmount(quote.fee)} ${toToken || ""}`}
         />
       )}
     </div>

--- a/app/components/bridge/BridgeRouteSelector.tsx
+++ b/app/components/bridge/BridgeRouteSelector.tsx
@@ -27,7 +27,7 @@ interface BridgeRouteSelectorProps {
   onFromNetworkChange: (name: string) => void;
   onToNetworkChange: (name: string) => void;
   outputAmount?: string;
-  engine?: "near" | "lifi" | "hyperfx" | null;
+  engine?: "near" | "lifi" | "textile" | "hyperfx" | null;
   timeEstimate?: string;
   isQuoteLoading?: boolean;
   /** When true, styles the From amount like swap validation errors. */

--- a/app/components/bridge/BridgeRouteSelector.tsx
+++ b/app/components/bridge/BridgeRouteSelector.tsx
@@ -27,7 +27,7 @@ interface BridgeRouteSelectorProps {
   onFromNetworkChange: (name: string) => void;
   onToNetworkChange: (name: string) => void;
   outputAmount?: string;
-  engine?: "near" | "lifi" | null;
+  engine?: "near" | "lifi" | "hyperfx" | null;
   timeEstimate?: string;
   isQuoteLoading?: boolean;
   /** When true, styles the From amount like swap validation errors. */

--- a/app/components/play/JoinModal.tsx
+++ b/app/components/play/JoinModal.tsx
@@ -4,11 +4,17 @@
  * Join-the-league modal: pick a permanent username (debounced availability
  * check + suggestions), accept the T&Cs, and POST /api/play/join. Handles the
  * 409 username race by surfacing the server's suggestions.
+ *
+ * With an `inviteCode` (arrived via a friend's mini-league link) the modal also
+ * joins that league straight after, so the invite finishes in one pass instead
+ * of dumping the user on /play/team with the code lost.
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { DialogTitle } from "@headlessui/react";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
@@ -19,21 +25,32 @@ import {
 } from "hugeicons-react";
 import { AnimatedModal } from "../AnimatedComponents";
 import { trackEvent } from "@/app/hooks/analytics/client";
-import { PlayApiError } from "./api";
-import { useJoinLeague, useUsernameAvailability } from "./hooks";
+import { PlayApiError, joinMiniLeague } from "./api";
+import { playKeys, useJoinLeague, useUsernameAvailability } from "./hooks";
+import { leagueJoinPath } from "./league-invite";
 import { primaryButtonClasses } from "./ui";
 
 export const JoinModal = ({
   isOpen,
   onClose,
+  inviteCode = null,
 }: {
   isOpen: boolean;
   onClose: () => void;
+  /** Mini-league code from a `?join=` invite link, joined right after signup. */
+  inviteCode?: string | null;
 }) => {
   const router = useRouter();
+  const { getAccessToken } = usePrivy();
+  const queryClient = useQueryClient();
   const [username, setUsername] = useState("");
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  // The invite redemption is awaited *after* onClose, so this component stays
+  // mounted and reopenable while the request is in flight. The ref blocks a
+  // second redemption; the state keeps the submit button disabled meanwhile.
+  const [redeemingInvite, setRedeemingInvite] = useState(false);
+  const redeemingInviteRef = useRef(false);
 
   const { result, checking } = useUsernameAvailability(username);
   const join = useJoinLeague();
@@ -49,7 +66,41 @@ export const JoinModal = ({
     : (result?.suggestions ?? []);
 
   const canSubmit =
-    trimmed.length >= 3 && acceptTerms && available && !join.isPending;
+    trimmed.length >= 3 &&
+    acceptTerms &&
+    available &&
+    !join.isPending &&
+    !redeemingInvite;
+
+  /**
+   * Redeem the invite the user arrived with. A bad or already-used code must not
+   * strand a brand-new manager, so any failure still hands off to Leagues with
+   * the code pre-filled rather than surfacing a dead end.
+   */
+  const joinInvitedLeague = async (code: string) => {
+    if (redeemingInviteRef.current) return;
+    redeemingInviteRef.current = true;
+    setRedeemingInvite(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) throw new PlayApiError("Unauthorized", 401);
+      const { league } = await joinMiniLeague(code, token);
+      await queryClient.invalidateQueries({ queryKey: playKeys.rewards });
+      trackEvent("league_invite_redeemed", { league_id: league.id });
+      toast.success(`Joined "${league.name}"`);
+      router.push("/play/rewards");
+    } catch (error) {
+      toast.error(
+        error instanceof PlayApiError
+          ? error.message
+          : "Couldn't join that league — try the code below.",
+      );
+      router.push(leagueJoinPath(code));
+    } finally {
+      redeemingInviteRef.current = false;
+      setRedeemingInvite(false);
+    }
+  };
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
@@ -71,6 +122,12 @@ export const JoinModal = ({
           : `Welcome to the league, ${data.username}!`,
       );
       onClose();
+
+      if (inviteCode) {
+        await joinInvitedLeague(inviteCode);
+        return;
+      }
+
       router.push("/play/team");
     } catch (error) {
       if (error instanceof PlayApiError) {
@@ -116,7 +173,7 @@ export const JoinModal = ({
               maxLength={20}
               autoComplete="off"
               autoFocus
-              disabled={join.isPending}
+              disabled={join.isPending || redeemingInvite}
               className="w-full border-0 bg-transparent pt-1 text-base font-medium text-text-body placeholder:text-text-placeholder focus:outline-none focus:ring-0 dark:text-white dark:placeholder:text-white/30"
             />
             {trimmed.length >= 3 &&
@@ -185,7 +242,11 @@ export const JoinModal = ({
           disabled={!canSubmit}
           className={`w-full ${primaryButtonClasses}`}
         >
-          {join.isPending ? "Joining..." : "Join the league"}
+          {redeemingInvite
+            ? "Joining your league..."
+            : join.isPending
+              ? "Joining..."
+              : "Join the league"}
         </button>
       </motion.div>
     </AnimatedModal>

--- a/app/components/play/LeaderboardTable.tsx
+++ b/app/components/play/LeaderboardTable.tsx
@@ -9,6 +9,9 @@ import Link from "next/link";
 import { ArrowDown01Icon, ArrowUp01Icon } from "hugeicons-react";
 import type { LeaderboardRowData } from "./types";
 
+/** DOM id of the signed-in user's row — the Find me scroll target. */
+export const SELF_ROW_ID = "leaderboard-self-row";
+
 const managerHref = (username: string) =>
   `/play/manager/${encodeURIComponent(username)}`;
 
@@ -49,9 +52,12 @@ const Movement = ({ value }: { value: number }) => {
 export const LeaderboardTable = ({
   rows,
   compact = false,
+  highlightSelf = false,
 }: {
   rows: LeaderboardRowData[];
   compact?: boolean;
+  /** Flash the "You" row after a Find me jump so it is obvious where you landed. */
+  highlightSelf?: boolean;
 }) => {
   const router = useRouter();
 
@@ -70,17 +76,26 @@ export const LeaderboardTable = ({
           {rows.map((row) => (
             <tr
               key={`${row.rank}-${row.username ?? "anon"}`}
-              id={row.is_me ? "leaderboard-self-row" : undefined}
+              id={row.is_me ? SELF_ROW_ID : undefined}
+              tabIndex={row.is_me ? -1 : undefined}
+              aria-current={row.is_me ? "true" : undefined}
               onClick={
                 row.username
                   ? () => router.push(managerHref(row.username!))
                   : undefined
               }
-              className={`border-b border-border-light last:border-0 dark:border-white/5 ${
+              className={`border-b border-border-light last:border-0 transition-colors duration-500 dark:border-white/5 ${
                 row.username ? "cursor-pointer" : ""
               } ${
                 row.is_me
-                  ? "bg-lavender-50 dark:bg-lavender-500/10"
+                  ? // The Find me flash deepens the row's own wash rather than
+                    // ringing it: a ring is a square rectangle, and on the last
+                    // row the wrapper's rounded-2xl clips its bottom corners, so
+                    // the outline visibly breaks against the curve. Backgrounds
+                    // follow that clip cleanly.
+                    highlightSelf
+                    ? "bg-lavender-200 dark:bg-lavender-500/40"
+                    : "bg-lavender-50 dark:bg-lavender-500/10"
                   : compact
                     ? ""
                     : "hover:bg-background-neutral dark:hover:bg-white/[.03]"

--- a/app/components/play/PlayShell.tsx
+++ b/app/components/play/PlayShell.tsx
@@ -16,6 +16,7 @@
 
 import { ReactNode } from "react";
 import Link from "next/link";
+import { Home01Icon } from "hugeicons-react";
 import { NoblocksLogo, NoblocksLogoIcon } from "../ImageAssets";
 import { PlayTabs } from "./PlayTabs";
 import { CountdownChip } from "./CountdownChip";
@@ -34,7 +35,20 @@ export const PlayHeader = ({ right }: { right?: ReactNode }) => (
         <NoblocksLogoIcon className="size-[18px] sm:hidden" />
         <NoblocksLogo className="max-sm:hidden" />
       </Link>
-      <div className="flex items-center gap-2">{right}</div>
+      <div className="flex items-center gap-2">
+        {/* The wordmark goes to /play (the game's own home), so leaving the
+            game needed the browser back button until this existed. */}
+        <Link
+          href="/"
+          aria-label="Noblocks home"
+          title="Noblocks home"
+          className="inline-flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-accent-gray hover:text-text-body dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
+        >
+          <Home01Icon className="size-[18px] shrink-0" />
+          <span className="max-sm:sr-only">Home</span>
+        </Link>
+        {right}
+      </div>
     </div>
   </header>
 );

--- a/app/components/play/hooks.ts
+++ b/app/components/play/hooks.ts
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
+  keepPreviousData,
   useMutation,
   useQuery,
   useQueryClient,
@@ -102,6 +103,10 @@ export function useLeaderboard(page: number, findMe = false) {
     // findMe only makes sense once signed in — skip the request entirely
     // for anonymous visits instead of issuing a tokenless findMe lookup.
     enabled: ready && (!findMe || authenticated),
+    // Page changes are their own query key, so without this the table would
+    // unmount into skeletons on every Prev/Next. Hold the previous page's rows
+    // until the new ones arrive; callers dim the table via isFetching instead.
+    placeholderData: keepPreviousData,
     staleTime: 60_000,
     refetchInterval: false,
   });

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -15,7 +15,7 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, NGN_NUBAN_LENGTH } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, isSameSavedRecipient, NGN_NUBAN_LENGTH } from "@/app/utils";
 import type { KesMpesaChannel } from "@/app/types";
 import {
   RecipientDetails,
@@ -167,8 +167,7 @@ export const RecipientDetailsForm = ({
           recipientToDeleteParam.type === "wallet"
             ? r.type === "wallet" && r.walletAddress === recipientToDeleteParam.walletAddress
             : r.type !== "wallet" &&
-            r.accountIdentifier === recipientToDeleteParam.accountIdentifier &&
-            r.institutionCode === recipientToDeleteParam.institutionCode,
+            isSameSavedRecipient(r, recipientToDeleteParam),
       );
 
       if (!recipientWithId) {
@@ -201,8 +200,7 @@ export const RecipientDetailsForm = ({
             recipientToDeleteParam.type === "wallet"
               ? selectedRecipient.type === "wallet" && selectedRecipient.walletAddress === recipientToDeleteParam.walletAddress
               : selectedRecipient.type !== "wallet" &&
-              selectedRecipient.accountIdentifier === recipientToDeleteParam.accountIdentifier &&
-              selectedRecipient.institutionCode === recipientToDeleteParam.institutionCode
+              isSameSavedRecipient(selectedRecipient, recipientToDeleteParam)
           ) {
             setSelectedRecipient(null);
           }

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -15,7 +15,8 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, NGN_NUBAN_LENGTH } from "@/app/utils";
+import type { KesMpesaChannel } from "@/app/types";
 import {
   RecipientDetails,
   RecipientDetailsFormProps,
@@ -61,6 +62,8 @@ export const RecipientDetailsForm = ({
   const accountIdentifier = watch("accountIdentifier");
   const recipientName = watch("recipientName");
   const walletAddress = watch("walletAddress");
+  const kesChannel = watch("kesChannel");
+  const businessNumber = watch("businessNumber");
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -102,10 +105,15 @@ export const RecipientDetailsForm = ({
   const prevCurrencyRef = useRef(currency);
   const isDark = useActualTheme();
 
-  const filteredInstitutions = useMemo(
-    () => filterAndSortInstitutions(institutions, bankSearchTerm),
-    [institutions, bankSearchTerm],
-  );
+  const filteredInstitutions = useMemo(() => {
+    const expanded = expandKesMpesaInstitutions(institutions, currency);
+    return filterAndSortInstitutions(expanded, bankSearchTerm);
+  }, [institutions, bankSearchTerm, currency]);
+
+  const isKesMpesa =
+    currency === "KES" && institution === KES_MPESA_INSTITUTION_CODE;
+  const isKesPaybill = isKesMpesa && kesChannel === "Paybill";
+  const isKesTill = isKesMpesa && kesChannel === "Till";
 
   const selectSavedRecipient = (recipient: RecipientDetails) => {
     setSelectedRecipient(recipient);
@@ -118,16 +126,27 @@ export const RecipientDetailsForm = ({
       });
     } else {
       // Handle bank/mobile money selection for offramp
+      const channel = recipient.channel;
       setSelectedInstitution({
-        name: recipient.institution,
+        name:
+          recipient.institutionCode === KES_MPESA_INSTITUTION_CODE && channel
+            ? getKesMpesaInstitutionLabel(channel)
+            : recipient.institution,
         code: recipient.institutionCode,
         type: recipient.type,
+        ...(channel
+          ? { channel, uiKey: kesMpesaUiKey(channel) }
+          : {}),
       });
       setValue("institution", recipient.institutionCode, { shouldDirty: true });
       setValue("accountIdentifier", recipient.accountIdentifier, {
         shouldDirty: true,
       });
       setValue("accountType", recipient.type, { shouldDirty: true });
+      setValue("kesChannel", channel ?? "", { shouldDirty: true });
+      setValue("businessNumber", recipient.businessNumber ?? "", {
+        shouldDirty: true,
+      });
 
       // Remove extra spaces from recipient name
       recipient.name = recipient.name.replace(/\s+/g, " ").trim();
@@ -265,6 +284,7 @@ export const RecipientDetailsForm = ({
       if (isManualEntry) {
         setValue("recipientName", "");
         setValue("accountIdentifier", "");
+        setValue("businessNumber", "");
         setRecipientNameError("");
       }
     }
@@ -285,6 +305,24 @@ export const RecipientDetailsForm = ({
         return;
       }
 
+      if (isKesPaybill && !(businessNumber ?? "").trim()) {
+        setRecipientNameError("");
+        return;
+      }
+
+      if (isKesTill) {
+        if (digits.length < 5 || digits.length > 7) {
+          if (digits.length > 0) {
+            setRecipientNameError(
+              "Please enter a valid till number (5–7 digits).",
+            );
+          } else {
+            setRecipientNameError("");
+          }
+          return;
+        }
+      }
+
       if (isNGN && digits.length !== NGN_NUBAN_LENGTH) {
         if (digits.length > 0) {
           setRecipientNameError(
@@ -301,9 +339,23 @@ export const RecipientDetailsForm = ({
       setValue("recipientName", "");
 
       try {
+        const channel = (kesChannel || undefined) as
+          | KesMpesaChannel
+          | undefined;
+        const metadata =
+          isKesMpesa && channel
+            ? {
+                channel,
+                ...(channel === "Paybill" && (businessNumber ?? "").trim()
+                  ? { businessNumber: String(businessNumber).trim() }
+                  : {}),
+              }
+            : undefined;
+
         const accountName = await fetchAccountName({
           institution: institution.toString(),
           accountIdentifier: accountIdentifier.toString(),
+          ...(metadata ? { metadata } : {}),
         });
         setValue("recipientName", accountName);
         setIsFetchingRecipientName(false);
@@ -330,24 +382,48 @@ export const RecipientDetailsForm = ({
     isManualEntry,
     selectedInstitution?.code,
     currency,
+    kesChannel,
+    businessNumber,
+    isKesMpesa,
+    isKesPaybill,
+    isKesTill,
   ]);
 
   useEffect(() => {
-    // Initialize selected institution if form has values
+    // Initialize selected institution if form has values (match channel for virtual KES split)
     if (institution && !selectedInstitution) {
-      const foundInstitution = [...(institutions || [])].find(
-        (inst) => inst.code === institution,
-      );
+      const expanded = expandKesMpesaInstitutions(institutions, currency);
+      const foundInstitution =
+        expanded.find((inst) => {
+          if (inst.code !== institution) return false;
+          if (inst.channel) {
+            return inst.channel === kesChannel;
+          }
+          return true;
+        }) ?? expanded.find((inst) => inst.code === institution);
       if (foundInstitution) {
         setSelectedInstitution(foundInstitution);
         setValue("accountType", foundInstitution.type, { shouldValidate: true });
+        if (foundInstitution.channel && !kesChannel) {
+          setValue("kesChannel", foundInstitution.channel, {
+            shouldValidate: true,
+          });
+        }
         // Only set manual entry to false if we have recipient name
         if (recipientName) {
           setIsManualEntry(false);
         }
       }
     }
-  }, [institution, institutions, selectedInstitution, recipientName, setValue]);
+  }, [
+    institution,
+    institutions,
+    selectedInstitution,
+    recipientName,
+    setValue,
+    currency,
+    kesChannel,
+  ]);
 
   // Simplified recipient details management
   const clearRecipientDetails = () => {
@@ -356,6 +432,8 @@ export const RecipientDetailsForm = ({
     setValue("institution", "");
     setValue("recipientName", "");
     setValue("accountIdentifier", "");
+    setValue("kesChannel", "");
+    setValue("businessNumber", "");
     setRecipientNameError("");
     setIsManualEntry(true);
   };
@@ -414,13 +492,34 @@ export const RecipientDetailsForm = ({
   const accountIdentifierRegister = register("accountIdentifier", {
     required: {
       value: true,
-      message: "Account number is required",
+      message: isKesTill
+        ? "Till number is required"
+        : isKesPaybill
+          ? "Account / reference is required"
+          : "Account number is required",
     },
     validate: (value) => {
+      if (isKesTill) {
+        const digits = String(value ?? "").replace(/\D/g, "");
+        if (digits.length < 5 || digits.length > 7) {
+          return "Please enter a valid till number (5–7 digits).";
+        }
+        return true;
+      }
       if (currency !== "NGN") return true;
       const digits = String(value ?? "").replace(/\D/g, "");
       if (digits.length !== NGN_NUBAN_LENGTH) {
         return "Please enter a valid 10-digit account number.";
+      }
+      return true;
+    },
+  });
+
+  const businessNumberRegister = register("businessNumber", {
+    validate: (value) => {
+      if (!isKesPaybill) return true;
+      if (!(value ?? "").toString().trim()) {
+        return "Business number is required";
       }
       return true;
     },
@@ -562,17 +661,18 @@ export const RecipientDetailsForm = ({
                 </button>
               </div>
 
-              {/* Account number - NGN NUBAN is 10 digits */}
+              {/* Account / phone / till / paybill reference (NGN NUBAN is 10 digits) */}
               <div className="w-full flex-1 flex-shrink-0 sm:w-1/2">
                 <input
                   type="text"
-                  inputMode="numeric"
+                  inputMode={isKesPaybill ? "text" : "numeric"}
                   autoComplete="off"
                   placeholder={getOfframpAccountIdentifierPlaceholder(
                     currency,
                     selectedInstitution?.type,
+                    kesChannel,
                   )}
-                  maxLength={ngnAccountMaxDigits ?? undefined}
+                  maxLength={ngnAccountMaxDigits ?? (isKesTill ? 7 : undefined)}
                   {...accountIdentifierRegister}
                   onChange={(e) => {
                     setIsManualEntry(true);
@@ -580,6 +680,13 @@ export const RecipientDetailsForm = ({
                       const next = e.target.value
                         .replace(/\D/g, "")
                         .slice(0, ngnAccountMaxDigits);
+                      if (next !== e.target.value) {
+                        e.target.value = next;
+                      }
+                    } else if (isKesTill) {
+                      const next = e.target.value
+                        .replace(/\D/g, "")
+                        .slice(0, 7);
                       if (next !== e.target.value) {
                         e.target.value = next;
                       }
@@ -595,6 +702,37 @@ export const RecipientDetailsForm = ({
                 />
               </div>
             </div>
+
+            {isKesPaybill && (
+              <div className="w-full">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  placeholder="Business number"
+                  {...businessNumberRegister}
+                  onChange={(e) => {
+                    setIsManualEntry(true);
+                    const next = e.target.value.replace(/\D/g, "");
+                    if (next !== e.target.value) {
+                      e.target.value = next;
+                    }
+                    void businessNumberRegister.onChange(e);
+                  }}
+                  className={classNames(
+                    "w-full rounded-xl border bg-transparent px-4 py-2.5 text-base outline-none transition-all duration-300 placeholder:text-text-placeholder focus:outline-none dark:text-white/80 dark:placeholder:text-white/30 sm:text-sm",
+                    errors.businessNumber
+                      ? "border-input-destructive focus:border-gray-400 dark:border-input-destructive"
+                      : "border-border-input dark:border-white/20 dark:focus:border-white/40 dark:focus:ring-offset-neutral-900",
+                  )}
+                />
+                {errors.businessNumber && (
+                  <div className="mt-2">
+                    <InputError message={errors.businessNumber.message} />
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Account details feedback */}
             <AnimatePresence mode="wait">

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -15,7 +15,7 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
 import {
   RecipientDetails,
   RecipientDetailsFormProps,
@@ -93,11 +93,11 @@ export const RecipientDetailsForm = ({
   const [isManualEntry, setIsManualEntry] = useState(true);
   const [isReturningFromPreview, setIsReturningFromPreview] = useState(false);
 
-  /** NGN NUBAN: cap at 10 digits (6 for SAFAKEPC). Other currencies: no digit cap. */
-  const ngnAccountMaxDigits = useMemo(() => {
-    if (currency !== "NGN") return null;
-    return selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
-  }, [currency, selectedInstitution?.code]);
+  /** NGN NUBAN: cap at 10 digits. Other currencies: no digit cap. */
+  const ngnAccountMaxDigits = useMemo(
+    () => (currency === "NGN" ? NGN_NUBAN_LENGTH : null),
+    [currency],
+  );
 
   const prevCurrencyRef = useRef(currency);
   const isDark = useActualTheme();
@@ -279,19 +279,16 @@ export const RecipientDetailsForm = ({
 
       const isNGN = currency === "NGN";
       const digits = String(accountIdentifier ?? "").replace(/\D/g, "");
-      const requiredLen = selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
 
       if (!institution || !accountIdentifier) {
         setRecipientNameError("");
         return;
       }
 
-      if (isNGN && digits.length !== requiredLen) {
+      if (isNGN && digits.length !== NGN_NUBAN_LENGTH) {
         if (digits.length > 0) {
           setRecipientNameError(
-            requiredLen === 10
-              ? "Please enter a valid 10-digit account number."
-              : "Invalid account number. Please enter a 6-digit account number.",
+            "Please enter a valid 10-digit account number.",
           );
         } else {
           setRecipientNameError("");
@@ -422,12 +419,8 @@ export const RecipientDetailsForm = ({
     validate: (value) => {
       if (currency !== "NGN") return true;
       const digits = String(value ?? "").replace(/\D/g, "");
-      // SAFAKEPC is the sandbox NGN institution (6-digit accounts, not 10-digit NUBAN).
-      const requiredLen = selectedInstitution?.code === "SAFAKEPC" ? 6 : 10;
-      if (digits.length !== requiredLen) {
-        return requiredLen === 10
-          ? "Please enter a valid 10-digit account number."
-          : "Invalid account number. Please enter a 6-digit account number.";
+      if (digits.length !== NGN_NUBAN_LENGTH) {
+        return "Please enter a valid 10-digit account number.";
       }
       return true;
     },
@@ -569,8 +562,7 @@ export const RecipientDetailsForm = ({
                 </button>
               </div>
 
-              {/* Account number */}
-              {/* Account number - NUBAN is 10 digits; SAFAKEPC uses 6 digits (NGN only) */}
+              {/* Account number - NGN NUBAN is 10 digits */}
               <div className="w-full flex-1 flex-shrink-0 sm:w-1/2">
                 <input
                   type="text"
@@ -580,13 +572,7 @@ export const RecipientDetailsForm = ({
                     currency,
                     selectedInstitution?.type,
                   )}
-                  maxLength={
-                    currency === "NGN"
-                      ? selectedInstitution?.code === "SAFAKEPC"
-                        ? 6
-                        : 10
-                      : undefined
-                  }
+                  maxLength={ngnAccountMaxDigits ?? undefined}
                   {...accountIdentifierRegister}
                   onChange={(e) => {
                     setIsManualEntry(true);

--- a/app/components/recipient/SavedBeneficiariesModal.tsx
+++ b/app/components/recipient/SavedBeneficiariesModal.tsx
@@ -9,7 +9,7 @@ import { AnimatedModal } from "../AnimatedComponents";
 import { RecipientListItem } from "./RecipientListItem";
 import { SearchInput } from "./SearchInput";
 import { SavedBeneficiariesModalProps } from "./types";
-import { isBankOrMobileMoneyRecipient } from "@/app/utils";
+import { isBankOrMobileMoneyRecipient, isSameSavedRecipient } from "@/app/utils";
 
 export const SavedBeneficiariesModal = ({
   isOpen,
@@ -60,12 +60,7 @@ export const SavedBeneficiariesModal = ({
 
     const uniqueRecipients = bankRecipientsOnly.filter(
       (recipient, index, self) =>
-        index ===
-        self.findIndex(
-          (r) =>
-            r.accountIdentifier === recipient.accountIdentifier &&
-            r.institutionCode === recipient.institutionCode,
-        ),
+        index === self.findIndex((r) => isSameSavedRecipient(r, recipient)),
     );
 
     const currentBankCodes = institutions.map(

--- a/app/components/recipient/SelectBankModal.tsx
+++ b/app/components/recipient/SelectBankModal.tsx
@@ -5,6 +5,7 @@ import { Cancel01Icon, InformationSquareIcon } from "hugeicons-react";
 import { AnimatedModal } from "@/app/components/AnimatedComponents";
 import { SearchInput } from "@/app/components/recipient/SearchInput";
 import { SelectBankModalProps } from "@/app/components/recipient/types";
+import { KES_MPESA_INSTITUTION_CODE } from "@/app/utils";
 
 export const SelectBankModal = ({
   isOpen,
@@ -19,6 +20,9 @@ export const SelectBankModal = ({
   setBankSearchTerm,
   isFetchingInstitutions,
 }: SelectBankModalProps) => {
+  const selectedKey =
+    selectedInstitution?.uiKey ?? selectedInstitution?.code ?? "";
+
   return (
     <AnimatedModal isOpen={isOpen} onClose={onClose} maxWidth="28.5rem">
       <div className="flex items-center justify-between">
@@ -68,30 +72,46 @@ export const SelectBankModal = ({
           >
             {currency ? (
               filteredInstitutions && filteredInstitutions.length > 0 ? (
-                filteredInstitutions.map((inst) => (
-                  <motion.li
-                    key={inst.code}
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.2 }}
-                    onClick={() => {
-                      setSelectedInstitution(inst);
-                      onClose();
-                      setValue("institution", inst.code, {
-                        shouldValidate: true,
-                      });
-                      setValue("accountType", inst.type, { shouldValidate: true });
-                      setIsManualEntry(true);
-                    }}
-                    className={`cursor-pointer rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-gray-100 dark:hover:bg-white/5 ${
-                      selectedInstitution?.code === inst.code
-                        ? "bg-gray-100 dark:bg-white/5"
-                        : ""
-                    }`}
-                  >
-                    {inst.name}
-                  </motion.li>
-                ))
+                filteredInstitutions.map((inst) => {
+                  const key = inst.uiKey ?? inst.code;
+                  return (
+                    <motion.li
+                      key={key}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.2 }}
+                      onClick={() => {
+                        setSelectedInstitution(inst);
+                        onClose();
+                        // Always submit the real institution code (SAFAKEPC for all M-Pesa rails).
+                        setValue("institution", inst.code, {
+                          shouldValidate: true,
+                        });
+                        setValue("accountType", inst.type, {
+                          shouldValidate: true,
+                        });
+                        if (inst.code === KES_MPESA_INSTITUTION_CODE && inst.channel) {
+                          setValue("kesChannel", inst.channel, {
+                            shouldValidate: true,
+                          });
+                        } else {
+                          setValue("kesChannel", "", { shouldValidate: true });
+                        }
+                        setValue("businessNumber", "", {
+                          shouldValidate: true,
+                        });
+                        setIsManualEntry(true);
+                      }}
+                      className={`cursor-pointer rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-gray-100 dark:hover:bg-white/5 ${
+                        selectedKey === key
+                          ? "bg-gray-100 dark:bg-white/5"
+                          : ""
+                      }`}
+                    >
+                      {inst.name}
+                    </motion.li>
+                  );
+                })
               ) : (
                 <motion.li
                   initial={{ opacity: 0 }}

--- a/app/components/transaction/TransactionDetails.tsx
+++ b/app/components/transaction/TransactionDetails.tsx
@@ -830,7 +830,9 @@ export function TransactionDetails({ transaction }: TransactionDetailsProps) {
             label="Account"
             value={
               <span className="text-text-accent-gray dark:text-white/80">
-                {transaction.recipient.account_identifier}
+                {transaction.recipient.business_number
+                  ? `${transaction.recipient.business_number} / ${transaction.recipient.account_identifier}`
+                  : transaction.recipient.account_identifier}
               </span>
             }
           />

--- a/app/hooks/bridge.ts
+++ b/app/hooks/bridge.ts
@@ -7,6 +7,7 @@ import {
   selectEngine,
   NearIntentsClient,
   LifiClient,
+  TextileClient,
   HyperfxClient,
   toLifiChainId,
   resolveNearAssetId,
@@ -16,6 +17,7 @@ import {
   authHeaders,
 } from "@/app/lib/bridge";
 import type { BridgeLeg, BridgeQuote, BridgeStatusResult, BridgeEngine, NearIntentsToken, BridgeAuth } from "@/app/lib/bridge";
+import { textileChainId } from "@/app/lib/textileNetworks";
 import { getRpcUrl } from "@/app/utils";
 import { appendAttributionSuffix } from "@/app/lib/baseBuilderCode";
 import type { BatchCall } from "@/app/lib/providerBatch";
@@ -26,6 +28,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const nearClient = new NearIntentsClient();
 const lifiClient = new LifiClient();
+const textileClient = new TextileClient();
 const hyperfxClient = new HyperfxClient();
 
 // ============================================================================
@@ -70,6 +73,33 @@ async function fetchLifiQuote(
     toAddress: evmAddress,
     slippage: lifiSlippage,
   }, auth);
+}
+
+async function fetchTextileQuote(
+  from: BridgeLeg,
+  to: BridgeLeg,
+  rawAmount: string,
+  _evmAddress: string,
+  _slippageBps: number,
+  auth: BridgeAuth,
+): Promise<BridgeQuote | null> {
+  const chainId = textileChainId(from.network);
+  if (!chainId) return null;
+
+  const sellToken = from.tokenAddress;
+  const buyToken = to.tokenAddress;
+  if (!sellToken || !buyToken) return null;
+
+  return textileClient.getQuote(
+    {
+      chainId,
+      sellToken,
+      buyToken,
+      sellAmount: rawAmount,
+      toDecimals: to.decimals,
+    },
+    auth,
+  );
 }
 
 async function fetchHyperfxQuote(
@@ -185,6 +215,19 @@ export function useBridgeQuote({
       }, auth, { origin: from.decimals, destination: to.decimals });
     }
 
+    if (engine === "textile") {
+      const textileQuote = await fetchTextileQuote(
+        from,
+        to,
+        rawAmount,
+        evmAddress,
+        slippageBps,
+        auth,
+      );
+      if (textileQuote) return textileQuote;
+      return fetchLifiQuote(from, to, rawAmount, evmAddress, slippageBps, auth);
+    }
+
     return fetchLifiQuote(from, to, rawAmount, evmAddress, slippageBps, auth);
   }, [from, to, amount, evmAddress, starknetAddress, slippageBps, getAccessToken, getInjectedToken]);
 
@@ -208,9 +251,9 @@ export function useBridgeQuote({
     refetchInterval: (q) => {
       const data = q?.state?.data as BridgeQuote | undefined;
       if (!data) return false;
-      // LI.FI quotes embed a slippage/validity window but no explicit deadline — refresh on a
-      // fixed interval so a stale transactionRequest is never executed (it would revert on-chain).
-      if (data.kind === "lifi-tx") return 30_000;
+      // LI.FI / Textile quotes embed a slippage/validity window — refresh on a fixed
+      // interval so stale transaction data is never executed.
+      if (data.kind === "lifi-tx" || data.kind === "textile-swap") return 30_000;
       if (data.kind === "hyperfx-intent") {
         const msLeft = data.expiresAt - Date.now();
         return msLeft > 30_000 ? 30_000 : msLeft > 0 ? msLeft : false;
@@ -271,8 +314,10 @@ export function useBridgeStatus({ engine, refId, enabled, getAccessToken, getInj
         const status =
           engine === "near"
             ? await nearClient.getStatus(refId, auth)
-            : engine === "hyperfx"
-              ? await hyperfxClient.getStatus(refId, auth)
+            : engine === "textile"
+              ? await textileClient.getStatus(refId, auth)
+              : engine === "hyperfx"
+                ? await hyperfxClient.getStatus(refId, auth)
               : await lifiClient.getStatus(refId, auth);
 
         setResult(status);
@@ -362,6 +407,7 @@ export function useBridgeExecute({
   // without needing it as a useCallback dependency (avoids stale closure).
   const selectedNetworkRef = useRef(selectedNetwork);
   useEffect(() => { selectedNetworkRef.current = selectedNetwork; }, [selectedNetwork]);
+
 
   // Use a ref for embedCode to avoid stale closure issues
   const embedCodeRef = useRef(embedCode);
@@ -618,6 +664,124 @@ export function useBridgeExecute({
           onSuccess?.(evmHash);
           // LI.FI: poll status by txHash, not a separate deposit address
           return { txHash: evmHash, depositRefId: evmHash };
+        } else if (quote.kind === "textile-swap") {
+          const textileQuote = quote;
+          const chain = selectedNetworkRef.current?.chain;
+          if (!chain) {
+            throw new Error("Selected network not found");
+          }
+
+          const injectedToken = isInjectedWallet
+            ? ((await getInjectedToken?.()) ?? null)
+            : null;
+          const proxyAuth: BridgeAuth = injectedToken
+            ? { injectedToken }
+            : { token: (await getAccessToken?.()) ?? null };
+
+          const taker = (isInjectedWallet ? injectedAddress : embeddedWallet?.address) as
+            | string
+            | undefined;
+          if (!taker) throw new Error("Wallet not connected");
+
+          const built = await textileClient.requestQuote(
+            {
+              chainId: textileQuote.chainId,
+              sellToken: textileQuote.sellToken,
+              buyToken: textileQuote.buyToken,
+              sellAmount: textileQuote.sellAmount,
+              taker,
+            },
+            proxyAuth,
+          );
+          if (!built) {
+            throw new Error("Textile swap unavailable. Please try again.");
+          }
+
+          if (built.expiresAt) {
+            const expiresMs = Date.parse(built.expiresAt);
+            if (!Number.isNaN(expiresMs) && Date.now() >= expiresMs) {
+              throw new Error("Textile quote expired. Please refresh and try again.");
+            }
+          }
+
+          const calls: BatchCall[] = [];
+          const allowance = BigInt(built.takerPays || "0");
+          if (allowance > BigInt(0)) {
+            if (built.approval?.data && built.approval.data !== "0x") {
+              calls.push({
+                to: built.approval.to as `0x${string}`,
+                value: BigInt(built.approval.value || "0"),
+                data: built.approval.data as `0x${string}`,
+              });
+            } else if (built.reactor && built.reactor !== ZERO_ADDRESS) {
+              calls.push({
+                to: from.tokenAddress as `0x${string}`,
+                value: BigInt(0),
+                data: encodeFunctionData({
+                  abi: erc20Abi,
+                  functionName: "approve",
+                  args: [built.reactor, allowance],
+                }),
+              });
+            } else {
+              throw new Error("Textile approval details unavailable. Please try again.");
+            }
+          }
+          calls.push({
+            to: built.swap.to as `0x${string}`,
+            value: BigInt(built.swap.value || "0"),
+            data: built.swap.data as `0x${string}`,
+          });
+
+          if (built.expiresAt) {
+            const expiresMs = Date.parse(built.expiresAt);
+            if (!Number.isNaN(expiresMs) && Date.now() >= expiresMs) {
+              throw new Error("Textile quote expired before broadcast. Please refresh and try again.");
+            }
+          }
+
+          let evmHash: string;
+          if (isInjectedWallet) {
+            evmHash = await executeInjectedCalls(
+              Number(from.chainId),
+              calls.map((c) => ({ to: c.to, value: c.value, data: c.data })),
+            );
+          } else {
+            if (!embeddedWallet || !signDelegationAuthorization || !getAccessToken) {
+              throw new Error("EVM wallet not configured for Textile execution");
+            }
+            evmHash = await executeBatchCalls({
+              chain: chain as any,
+              calls,
+              getAccessToken,
+              embeddedWallet,
+              signDelegationAuthorization,
+              gasLimit: 600_000,
+              embedCode: embedCodeRef.current,
+            });
+          }
+
+          try {
+            await textileClient.submitSwap(
+              built.rfqId,
+              evmHash,
+              proxyAuth,
+              built.claimToken,
+            );
+          } catch (submitErr) {
+            const detail =
+              submitErr instanceof Error
+                ? submitErr.message
+                : "Textile submit failed";
+            throw new Error(
+              `On-chain swap sent (${evmHash}) but Textile registration failed: ${detail}`,
+            );
+          }
+
+          setTxHash(evmHash);
+          setIsSuccess(true);
+          onSuccess?.(evmHash);
+          return { txHash: evmHash, depositRefId: built.rfqId };
         } else if (quote.kind === "hyperfx-intent") {
           const walletAddr = (isInjectedWallet ? injectedAddress : embeddedWallet?.address) as
             | `0x${string}`

--- a/app/hooks/bridge.ts
+++ b/app/hooks/bridge.ts
@@ -7,6 +7,7 @@ import {
   selectEngine,
   NearIntentsClient,
   LifiClient,
+  HyperfxClient,
   toLifiChainId,
   resolveNearAssetId,
   toRawAmount,
@@ -25,6 +26,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const nearClient = new NearIntentsClient();
 const lifiClient = new LifiClient();
+const hyperfxClient = new HyperfxClient();
 
 // ============================================================================
 // useBridgeQuote
@@ -70,6 +72,27 @@ async function fetchLifiQuote(
   }, auth);
 }
 
+async function fetchHyperfxQuote(
+  from: BridgeLeg,
+  to: BridgeLeg,
+  amount: string,
+  evmAddress: string,
+  auth: BridgeAuth,
+): Promise<BridgeQuote | null> {
+  return hyperfxClient.getQuote(
+    {
+      network: from.network,
+      chainId: Number(from.chainId),
+      fromToken: from.token,
+      toToken: to.token,
+      fromAmount: amount,
+      fromDecimals: from.decimals,
+      fromAddress: evmAddress,
+    },
+    auth,
+  );
+}
+
 interface UseBridgeQuoteParams {
   from: BridgeLeg | null;
   to: BridgeLeg | null;
@@ -110,6 +133,22 @@ export function useBridgeQuote({
       : { token: (await getAccessToken?.()) ?? null };
     const engine = selectEngine(from, to);
     const rawAmount = toRawAmount(amount, from.decimals);
+
+    if (engine === "hyperfx") {
+      try {
+        const hyperfxQuote = await fetchHyperfxQuote(
+          from,
+          to,
+          amount,
+          evmAddress,
+          auth,
+        );
+        if (hyperfxQuote) return hyperfxQuote;
+      } catch {
+        // Fall through to LI.FI when HyperFX is unavailable.
+      }
+      return fetchLifiQuote(from, to, rawAmount, evmAddress, slippageBps, auth);
+    }
 
     if (engine === "near") {
       const tokensRes = await fetch("/api/bridge/near-intents/tokens", {
@@ -172,6 +211,10 @@ export function useBridgeQuote({
       // LI.FI quotes embed a slippage/validity window but no explicit deadline — refresh on a
       // fixed interval so a stale transactionRequest is never executed (it would revert on-chain).
       if (data.kind === "lifi-tx") return 30_000;
+      if (data.kind === "hyperfx-intent") {
+        const msLeft = data.expiresAt - Date.now();
+        return msLeft > 30_000 ? 30_000 : msLeft > 0 ? msLeft : false;
+      }
       // NEAR deposit quotes: stop refetching once the deposit deadline has nearly passed.
       return data.deadline - Date.now() > 30_000 ? 30_000 : false;
     },
@@ -228,7 +271,9 @@ export function useBridgeStatus({ engine, refId, enabled, getAccessToken, getInj
         const status =
           engine === "near"
             ? await nearClient.getStatus(refId, auth)
-            : await lifiClient.getStatus(refId, auth);
+            : engine === "hyperfx"
+              ? await hyperfxClient.getStatus(refId, auth)
+              : await lifiClient.getStatus(refId, auth);
 
         setResult(status);
         if (status.status === "SUCCESS" || status.status === "REFUNDED" || status.status === "FAILED") {
@@ -573,6 +618,112 @@ export function useBridgeExecute({
           onSuccess?.(evmHash);
           // LI.FI: poll status by txHash, not a separate deposit address
           return { txHash: evmHash, depositRefId: evmHash };
+        } else if (quote.kind === "hyperfx-intent") {
+          const walletAddr = (isInjectedWallet ? injectedAddress : embeddedWallet?.address) as
+            | `0x${string}`
+            | undefined;
+          if (!walletAddr) {
+            throw new Error("EVM wallet not connected");
+          }
+
+          const { runHyperfxSwap } = await import("@/app/lib/hyperfx");
+          type Hex = `0x${string}`;
+
+          const signTransaction = async (tx: {
+            to: Hex;
+            data: Hex;
+            value: bigint;
+          }): Promise<Hex> => {
+            const valueHex =
+              tx.value > BigInt(0) ? (`0x${tx.value.toString(16)}` as Hex) : ("0x0" as Hex);
+
+            if (isInjectedWallet && injectedProvider && injectedAddress) {
+              await injectedProvider.request({
+                method: "wallet_switchEthereumChain",
+                params: [{ chainId: `0x${quote.chainId.toString(16)}` }],
+              });
+              return (await injectedProvider.request({
+                method: "eth_sendTransaction",
+                params: [
+                  {
+                    from: injectedAddress,
+                    to: tx.to,
+                    data: tx.data,
+                    value: valueHex,
+                  },
+                ],
+              })) as Hex;
+            }
+
+            if (!embeddedWallet) {
+              throw new Error("EVM wallet not configured for HyperFX");
+            }
+            await embeddedWallet.switchChain(quote.chainId);
+            const provider = await embeddedWallet.getEthereumProvider();
+            return (await provider.request({
+              method: "eth_sendTransaction",
+              params: [
+                {
+                  from: embeddedWallet.address,
+                  to: tx.to,
+                  data: tx.data,
+                  value: valueHex,
+                },
+              ],
+            })) as Hex;
+          };
+
+          const executeSponsoredBatch =
+            !isInjectedWallet && embeddedWallet && signDelegationAuthorization && getAccessToken
+              ? async (calls: BatchCall[], gasLimit?: number): Promise<Hex> => {
+                  const chain = selectedNetworkRef.current?.chain;
+                  if (!chain) {
+                    throw new Error("Selected network not found");
+                  }
+                  await embeddedWallet!.switchChain(quote.chainId);
+                  const hash = await executeBatchCalls({
+                    chain: chain as any,
+                    calls,
+                    getAccessToken: getAccessToken!,
+                    embeddedWallet: embeddedWallet!,
+                    signDelegationAuthorization: signDelegationAuthorization!,
+                    gasLimit: gasLimit ?? 1_500_000,
+                  });
+                  return hash as Hex;
+                }
+              : undefined;
+
+          const executeSponsoredCall = executeSponsoredBatch
+            ? async (call: BatchCall, gasLimit?: number): Promise<Hex> =>
+                executeSponsoredBatch([call], gasLimit)
+            : undefined;
+
+          const switchChain = async (chainId: number) => {
+            if (isInjectedWallet && injectedProvider) {
+              await injectedProvider.request({
+                method: "wallet_switchEthereumChain",
+                params: [{ chainId: `0x${chainId.toString(16)}` }],
+              });
+              return;
+            }
+            if (embeddedWallet) {
+              await embeddedWallet.switchChain(chainId);
+            }
+          };
+
+          const { placementTxHash } = await runHyperfxSwap(quote, {
+            address: walletAddr,
+            chainId: quote.chainId,
+            signTransaction,
+            executeSponsoredCall,
+            executeSponsoredBatch,
+            switchChain,
+          });
+
+          setTxHash(placementTxHash);
+          setIsSuccess(true);
+          onSuccess?.(placementTxHash);
+          return { txHash: placementTxHash, depositRefId: placementTxHash };
         }
         throw new Error("Unsupported quote type");
       } catch (err) {

--- a/app/hooks/useBridgeStatusTracker.ts
+++ b/app/hooks/useBridgeStatusTracker.ts
@@ -5,11 +5,17 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useWalletAddress } from "@/app/hooks/useWalletAddress";
 import { useInjectedWallet } from "@/app/context";
 import { updateBridgeTransactionStatus } from "@/app/api/aggregator";
-import { NearIntentsClient, LifiClient, HyperfxClient } from "@/app/lib/bridge";
+import {
+  NearIntentsClient,
+  LifiClient,
+  TextileClient,
+  HyperfxClient,
+} from "@/app/lib/bridge";
 import type { BridgeEngine, BridgeAuth } from "@/app/lib/bridge";
 
 const nearClient = new NearIntentsClient();
 const lifiClient = new LifiClient();
+const textileClient = new TextileClient();
 const hyperfxClient = new HyperfxClient();
 
 export interface BridgeSubmitInfo {
@@ -96,9 +102,11 @@ export function useBridgeStatusTracker() {
           const status =
             bridge.engine === "near"
               ? await nearClient.getStatus(bridge.depositRefId, auth)
-              : bridge.engine === "hyperfx"
-                ? await hyperfxClient.getStatus(bridge.depositRefId, auth)
-                : await lifiClient.getStatus(bridge.depositRefId, auth);
+              : bridge.engine === "textile"
+                ? await textileClient.getStatus(bridge.depositRefId, auth)
+                : bridge.engine === "hyperfx"
+                  ? await hyperfxClient.getStatus(bridge.depositRefId, auth)
+                  : await lifiClient.getStatus(bridge.depositRefId, auth);
 
           if (status.status === "SUCCESS") {
             await updateBridgeTransactionStatus(

--- a/app/hooks/useBridgeStatusTracker.ts
+++ b/app/hooks/useBridgeStatusTracker.ts
@@ -5,11 +5,12 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useWalletAddress } from "@/app/hooks/useWalletAddress";
 import { useInjectedWallet } from "@/app/context";
 import { updateBridgeTransactionStatus } from "@/app/api/aggregator";
-import { NearIntentsClient, LifiClient } from "@/app/lib/bridge";
+import { NearIntentsClient, LifiClient, HyperfxClient } from "@/app/lib/bridge";
 import type { BridgeEngine, BridgeAuth } from "@/app/lib/bridge";
 
 const nearClient = new NearIntentsClient();
 const lifiClient = new LifiClient();
+const hyperfxClient = new HyperfxClient();
 
 export interface BridgeSubmitInfo {
   savedTxId: string;
@@ -95,7 +96,9 @@ export function useBridgeStatusTracker() {
           const status =
             bridge.engine === "near"
               ? await nearClient.getStatus(bridge.depositRefId, auth)
-              : await lifiClient.getStatus(bridge.depositRefId, auth);
+              : bridge.engine === "hyperfx"
+                ? await hyperfxClient.getStatus(bridge.depositRefId, auth)
+                : await lifiClient.getStatus(bridge.depositRefId, auth);
 
           if (status.status === "SUCCESS") {
             await updateBridgeTransactionStatus(

--- a/app/hooks/useEvmWalletDisplayTotal.ts
+++ b/app/hooks/useEvmWalletDisplayTotal.ts
@@ -9,8 +9,8 @@ import { isEvmEarnFlow } from "../lib/earnFeature";
 import { useEarnSourcePosition } from "./useEarnSourcePosition";
 
 /**
- * Selected-chain wallet total for Phase 2 EVM earn: liquid on-chain + Vesu
- * position sourced from that chain (localStorage).
+ * Cross-chain wallet total for Phase 2 EVM earn: liquid on all chains + Vesu
+ * position sourced from the selected chain (localStorage).
  */
 export function useEvmWalletDisplayTotal(params: {
   chainName: string;

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -13,10 +13,15 @@ import { buildBatchDigest, encodeExecuteBatch, readBatchNonce } from "./provider
 import { getRpcUrl } from "@/app/utils";
 import { getDelegationContractAddress } from "./config";
 import { get7702AuthorizedImplementationForAddress } from "../hooks/useEIP7702Account";
+import { isTextileRoute } from "./bridgeFeature";
 import {
   HYPERFX_SUPPORTED_NETWORKS,
   isHyperfxSwapEnabled,
 } from "./bridgeFeature";
+import {
+  getTextileRfqClaim,
+  storeTextileRfqClaim,
+} from "./textileServer";
 
 // ============================================================================
 // TYPES
@@ -73,7 +78,32 @@ export interface LifiTxQuote {
   raw: unknown;
 }
 
-export type BridgeQuote = NearDepositQuote | LifiTxQuote | HyperfxIntentQuote;
+/** Textile FX v2 RFQ preview — firm quote + txs fetched on confirm via POST /v2/rfq/request. */
+export interface TextileSwapQuote {
+  kind: "textile-swap";
+  amountOut: string;
+  /** Protocol fee in receiving token (0 when not surfaced at preview time). */
+  feeReceivingToken: string;
+  chainId: number;
+  sellToken: string;
+  buyToken: string;
+  /** Exact-input sell cap in atomic units — pass to POST /v2/rfq/request. */
+  sellAmount: string;
+  toDecimals: number;
+  raw: unknown;
+}
+
+/** Built Textile v2 RFQ with unsigned approval + swap txs (short-lived). */
+export interface TextileBuiltSwap {
+  rfqId: string;
+  claimToken: string;
+  /** Gross sell-token debit including protocol fee — approve this to reactor. */
+  takerPays: string;
+  reactor: `0x${string}`;
+  expiresAt: string;
+  approval?: { to: string; data: string; value: string; chainId: number };
+  swap: { to: string; data: string; value: string; chainId: number };
+}
 
 /** Hyperbridge IntentGateway quote for same-chain USDC/USDT↔cNGN (HyperFX). */
 export interface HyperfxIntentQuote {
@@ -95,6 +125,14 @@ export interface HyperfxIntentQuote {
   bundlerUrl?: string;
 }
 
+export { storeTextileRfqClaim, getTextileRfqClaim };
+
+export type BridgeQuote =
+  | NearDepositQuote
+  | LifiTxQuote
+  | TextileSwapQuote
+  | HyperfxIntentQuote;
+
 export type BridgeStatus =
   | "PENDING_DEPOSIT"
   | "KNOWN_DEPOSIT_TX"
@@ -109,7 +147,7 @@ export interface BridgeStatusResult {
   destinationTxHash?: string;
 }
 
-export type BridgeEngine = "near" | "lifi" | "hyperfx";
+export type BridgeEngine = "near" | "lifi" | "textile" | "hyperfx";
 
 export { HYPERFX_SUPPORTED_NETWORKS };
 
@@ -145,10 +183,12 @@ export function isHyperfxRoute(from: BridgeLeg, to: BridgeLeg): boolean {
 // ============================================================================
 
 /**
- * Routes HyperFX for same-chain USDC/USDT↔cNGN on supported networks; LI.FI for other
- * cNGN legs or Starknet; NEAR Intents otherwise (EVM↔EVM stablecoins).
+ * Routes Textile for same-chain USDT↔cNGN on BSC/Celo; HyperFX for same-chain
+ * USDC/USDT↔cNGN on supported networks; LI.FI for other cNGN legs or Starknet;
+ * NEAR Intents otherwise (EVM↔EVM stablecoins).
  */
 export function selectEngine(from: BridgeLeg, to: BridgeLeg): BridgeEngine {
+  if (isTextileRoute(from, to)) return "textile";
   if (isHyperfxRoute(from, to)) return "hyperfx";
 
   const cngn = "cngn";
@@ -156,6 +196,35 @@ export function selectEngine(from: BridgeLeg, to: BridgeLeg): BridgeEngine {
   if (from.token.toLowerCase() === cngn || to.token.toLowerCase() === cngn) return "lifi";
   if (isStarknet(from.network) || isStarknet(to.network)) return "lifi";
   return "near";
+}
+
+/** Resolve the status-polling engine from a concrete quote (source of truth after fetch). */
+export function engineFromQuote(quote: BridgeQuote): BridgeEngine {
+  switch (quote.kind) {
+    case "lifi-tx":
+      return "lifi";
+    case "hyperfx-intent":
+      return "hyperfx";
+    case "textile-swap":
+      return "textile";
+    case "near-deposit":
+    default:
+      return "near";
+  }
+}
+
+/** Institution label persisted on bridge transactions and shown in history. */
+export function bridgeInstitutionLabel(quote: BridgeQuote): string {
+  switch (quote.kind) {
+    case "near-deposit":
+      return "NEAR Intents";
+    case "textile-swap":
+      return "Textile FX";
+    case "hyperfx-intent":
+      return "HyperFX";
+    case "lifi-tx":
+      return "LI.FI";
+  }
 }
 
 /**
@@ -279,6 +348,9 @@ export function bridgeFeeInReceivingToken(quote: BridgeQuote): number {
     return parseFloat(quote.fee) || 0;
   }
   if (quote.kind === "lifi-tx") {
+    return parseFloat(quote.feeReceivingToken) || 0;
+  }
+  if (quote.kind === "textile-swap") {
     return parseFloat(quote.feeReceivingToken) || 0;
   }
   return parseFloat(quote.fee) || 0;
@@ -516,6 +588,239 @@ export class LifiClient {
       status: mapLifiStatus(data.status, data.substatus),
       txHash: data.txHash,
       destinationTxHash: data.receiving?.txHash,
+    };
+  }
+}
+
+
+export function mapTextileStatus(status?: string): BridgeStatus {
+  switch ((status ?? "").toLowerCase()) {
+    case "filled":
+      return "SUCCESS";
+    case "failed":
+    case "expired":
+    case "no_quote":
+      return "FAILED";
+    case "quoted":
+    case "submitted":
+    case "soliciting":
+    default:
+      return "PROCESSING";
+  }
+}
+
+/**
+ * Accept Textile v2 RFQ previews with status `preview`.
+ * Falls back to LI.FI on `no_quote` or missing liquidity.
+ */
+export function normalizeTextileQuote(
+  data: unknown,
+  params: {
+    chainId: number;
+    sellToken: string;
+    buyToken: string;
+    sellAmount: string;
+    toDecimals: number;
+  },
+): TextileSwapQuote | null {
+  const preview = (data as { data?: Record<string, unknown> })?.data;
+  if (!preview || preview.status !== "preview") return null;
+
+  const buyAmount = String(preview.buyAmount ?? "0");
+  let amountOut = "0";
+  try {
+    if (BigInt(buyAmount) > BigInt(0)) {
+      amountOut = formatUnits(BigInt(buyAmount), params.toDecimals);
+    }
+  } catch {
+    return null;
+  }
+  if (parseFloat(amountOut) <= 0) return null;
+
+  return {
+    kind: "textile-swap",
+    amountOut,
+    feeReceivingToken: "0",
+    chainId: params.chainId,
+    sellToken: params.sellToken,
+    buyToken: params.buyToken,
+    sellAmount: params.sellAmount,
+    toDecimals: params.toDecimals,
+    raw: data,
+  };
+}
+
+export class TextileClient {
+  async getQuote(
+    params: {
+      chainId: number;
+      sellToken: string;
+      buyToken: string;
+      sellAmount: string;
+      toDecimals: number;
+    },
+    auth?: BridgeAuth | string | null,
+  ): Promise<BridgeQuote | null> {
+    const { data, status } = await axios.post(
+      "/api/bridge/textile/quote",
+      {
+        chainId: params.chainId,
+        sellToken: params.sellToken,
+        buyToken: params.buyToken,
+        sellAmount: params.sellAmount,
+      },
+      {
+        headers: authHeaders(auth),
+        validateStatus: () => true,
+      },
+    );
+
+    if (status === 404) return null;
+    if (status === 401 || status === 403) {
+      throw new Error("Authentication required for bridge quote");
+    }
+    if (status === 429) {
+      throw new Error("Textile quote rate-limited. Please retry shortly.");
+    }
+    if (status >= 400 && status < 500) return null;
+    if (status >= 500) {
+      throw new Error(data?.message || `Textile service error (${status})`);
+    }
+
+    return normalizeTextileQuote(data, {
+      chainId: params.chainId,
+      sellToken: params.sellToken,
+      buyToken: params.buyToken,
+      sellAmount: params.sellAmount,
+      toDecimals: params.toDecimals,
+    });
+  }
+
+  async requestQuote(
+    params: {
+      chainId: number;
+      sellToken: string;
+      buyToken: string;
+      sellAmount: string;
+      taker: string;
+    },
+    auth?: BridgeAuth | string | null,
+  ): Promise<TextileBuiltSwap | null> {
+    const { data, status } = await axios.post(
+      "/api/bridge/textile/swap",
+      {
+        chainId: params.chainId,
+        sellToken: params.sellToken,
+        buyToken: params.buyToken,
+        sellAmount: params.sellAmount,
+        taker: params.taker,
+      },
+      {
+        headers: authHeaders(auth),
+        validateStatus: () => true,
+      },
+    );
+
+    if (status === 401 || status === 403) {
+      throw new Error("Authentication required for bridge swap");
+    }
+    if (status >= 500) {
+      throw new Error(data?.message || `Textile service error (${status})`);
+    }
+    if (status >= 400) return null;
+
+    const rfq = data?.data;
+    if (rfq?.status !== "quoted" || !rfq.transactions?.swap) return null;
+
+    const firm = rfq.quote as Record<string, unknown> | undefined;
+    const reactor = firm?.reactor as string | undefined;
+    if (!rfq.rfqId || !rfq.claimToken || !reactor || !firm?.takerPays) return null;
+
+    storeTextileRfqClaim(String(rfq.rfqId), String(rfq.claimToken));
+
+    return {
+      rfqId: String(rfq.rfqId),
+      claimToken: String(rfq.claimToken),
+      takerPays: String(firm.takerPays),
+      reactor: reactor as `0x${string}`,
+      expiresAt: String(firm.expiresAt ?? ""),
+      approval: rfq.transactions.approval,
+      swap: rfq.transactions.swap,
+    };
+  }
+
+  /** @deprecated use requestQuote — kept as alias for call sites */
+  async buildSwap(
+    params: {
+      chainId: number;
+      sellToken: string;
+      buyToken: string;
+      sellAmount: string;
+      taker: string;
+    },
+    auth?: BridgeAuth | string | null,
+  ): Promise<TextileBuiltSwap | null> {
+    return this.requestQuote(params, auth);
+  }
+
+  async submitSwap(
+    rfqId: string,
+    txHash: string,
+    auth?: BridgeAuth | string | null,
+    claimToken?: string | null,
+  ): Promise<void> {
+    const claim = claimToken ?? getTextileRfqClaim(rfqId);
+    const maxAttempts = 3;
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const { data, status } = await axios.post(
+          `/api/bridge/textile/submit`,
+          { rfqId, txHash, claimToken: claim ?? undefined },
+          {
+            headers: authHeaders(auth),
+            validateStatus: () => true,
+          },
+        );
+        if (status >= 200 && status < 300) return;
+
+        const message =
+          (data as { error?: { message?: string }; message?: string })?.error
+            ?.message ||
+          (data as { message?: string })?.message ||
+          `Textile submit failed (${status})`;
+        lastError = new Error(message);
+      } catch (err) {
+        lastError =
+          err instanceof Error ? err : new Error("Textile submit request failed");
+      }
+
+      if (attempt < maxAttempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+      }
+    }
+
+    throw lastError ?? new Error("Textile submit failed");
+  }
+
+  async getStatus(
+    rfqId: string,
+    auth?: BridgeAuth | string | null,
+    claimToken?: string | null,
+  ): Promise<BridgeStatusResult> {
+    const claim = claimToken ?? getTextileRfqClaim(rfqId);
+    const { data } = await axios.get("/api/bridge/textile/status", {
+      params: {
+        rfqId,
+        ...(claim ? { claimToken: claim } : {}),
+      },
+      headers: authHeaders(auth),
+    });
+    const rfq = data?.data;
+    return {
+      status: mapTextileStatus(rfq?.status),
+      txHash: rfq?.txHash,
     };
   }
 }

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -13,6 +13,10 @@ import { buildBatchDigest, encodeExecuteBatch, readBatchNonce } from "./provider
 import { getRpcUrl } from "@/app/utils";
 import { getDelegationContractAddress } from "./config";
 import { get7702AuthorizedImplementationForAddress } from "../hooks/useEIP7702Account";
+import {
+  HYPERFX_SUPPORTED_NETWORKS,
+  isHyperfxSwapEnabled,
+} from "./bridgeFeature";
 
 // ============================================================================
 // TYPES
@@ -69,7 +73,27 @@ export interface LifiTxQuote {
   raw: unknown;
 }
 
-export type BridgeQuote = NearDepositQuote | LifiTxQuote;
+export type BridgeQuote = NearDepositQuote | LifiTxQuote | HyperfxIntentQuote;
+
+/** Hyperbridge IntentGateway quote for same-chain USDC/USDT↔cNGN (HyperFX). */
+export interface HyperfxIntentQuote {
+  kind: "hyperfx-intent";
+  amountOut: string;
+  /** Protocol fee deducted from input, expressed in the receiving token. */
+  fee: string;
+  amountIn: string;
+  rawAmountIn: string;
+  rawAmountOut: string;
+  tokenIn: string;
+  tokenOut: string;
+  network: string;
+  chainId: number;
+  protocolFeeBps: number;
+  /** Quote validity window (ms since epoch). */
+  expiresAt: number;
+  /** ERC-4337 bundler URL from the authenticated quote response. */
+  bundlerUrl?: string;
+}
 
 export type BridgeStatus =
   | "PENDING_DEPOSIT"
@@ -85,18 +109,48 @@ export interface BridgeStatusResult {
   destinationTxHash?: string;
 }
 
-export type BridgeEngine = "near" | "lifi";
+export type BridgeEngine = "near" | "lifi" | "hyperfx";
+
+export { HYPERFX_SUPPORTED_NETWORKS };
+
+export function isHyperfxEnabled(): boolean {
+  return isHyperfxSwapEnabled();
+}
+
+const HYPERFX_STABLES = new Set(["usdc", "usdt"]);
+
+function isHyperfxStableCngnPair(fromSym: string, toSym: string): boolean {
+  return (
+    (HYPERFX_STABLES.has(fromSym) && toSym === "cngn") ||
+    (fromSym === "cngn" && HYPERFX_STABLES.has(toSym))
+  );
+}
+
+/**
+ * True when this leg pair should route through HyperFX (same-chain USDC/USDT↔cNGN).
+ */
+export function isHyperfxRoute(from: BridgeLeg, to: BridgeLeg): boolean {
+  if (!isHyperfxEnabled()) return false;
+  if (from.network !== to.network) return false;
+  if (!HYPERFX_SUPPORTED_NETWORKS.has(from.network)) return false;
+
+  return isHyperfxStableCngnPair(
+    from.token.toLowerCase(),
+    to.token.toLowerCase(),
+  );
+}
 
 // ============================================================================
 // ROUTING
 // ============================================================================
 
 /**
- * Routes to LI.FI for cNGN legs or any Starknet leg; NEAR Intents otherwise (EVM↔EVM stablecoins).
- * Starknet uses LI.FI because NEAR Intents' token list only includes STRK/ZEC/XRP on Starknet —
- * no USDC/stablecoins — so stablecoin routes via NEAR always fail asset resolution.
+ * Routes HyperFX for same-chain USDC/USDT↔cNGN on supported networks; LI.FI for other
+ * cNGN legs or Starknet; NEAR Intents otherwise (EVM↔EVM stablecoins).
  */
 export function selectEngine(from: BridgeLeg, to: BridgeLeg): BridgeEngine {
+  if (isHyperfxRoute(from, to)) return "hyperfx";
+
   const cngn = "cngn";
   const isStarknet = (n: string) => n.toLowerCase() === "starknet";
   if (from.token.toLowerCase() === cngn || to.token.toLowerCase() === cngn) return "lifi";
@@ -221,6 +275,9 @@ export function toRawAmount(amount: string, decimals: number): string {
  * comment there for how the origin-denominated `refundFee` fallback is converted.
  */
 export function bridgeFeeInReceivingToken(quote: BridgeQuote): number {
+  if (quote.kind === "hyperfx-intent") {
+    return parseFloat(quote.fee) || 0;
+  }
   if (quote.kind === "lifi-tx") {
     return parseFloat(quote.feeReceivingToken) || 0;
   }
@@ -460,6 +517,104 @@ export class LifiClient {
       txHash: data.txHash,
       destinationTxHash: data.receiving?.txHash,
     };
+  }
+}
+
+type HyperfxQuoteParams = {
+  network: string;
+  chainId: number;
+  fromToken: string;
+  toToken: string;
+  fromAmount: string;
+  fromDecimals: number;
+  fromAddress: string;
+};
+
+export class HyperfxClient {
+  async getQuote(
+    params: HyperfxQuoteParams,
+    auth?: BridgeAuth | string | null,
+  ): Promise<HyperfxIntentQuote | null> {
+    const { data, status } = await axios.get("/api/bridge/hyperfx/quote", {
+      params: {
+        network: params.network,
+        chainId: params.chainId,
+        fromToken: params.fromToken,
+        toToken: params.toToken,
+        fromAmount: params.fromAmount,
+        fromDecimals: params.fromDecimals,
+        fromAddress: params.fromAddress,
+      },
+      headers: authHeaders(auth),
+      validateStatus: () => true,
+    });
+
+    if (status === 404 || status === 422) return null;
+    if (status >= 400) {
+      throw new Error(data?.error || data?.message || `HyperFX quote failed (${status})`);
+    }
+    if (!data?.quote) return null;
+    return data.quote as HyperfxIntentQuote;
+  }
+
+  /**
+   * HyperFX status via server-side on-chain reads (same pattern as LI.FI status API).
+   */
+  async getStatus(
+    txHash: string,
+    auth?: BridgeAuth | string | null,
+    opts?: { settled?: boolean; fillTxHash?: string },
+  ): Promise<BridgeStatusResult> {
+    if (opts?.settled) {
+      return {
+        status: "SUCCESS",
+        txHash,
+        destinationTxHash: opts.fillTxHash ?? txHash,
+      };
+    }
+    if (typeof window !== "undefined") {
+      try {
+        const fillTxHash = sessionStorage.getItem(`hyperfx-settled-${txHash}`);
+        if (fillTxHash) {
+          return {
+            status: "SUCCESS",
+            txHash,
+            destinationTxHash: fillTxHash,
+          };
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    try {
+      const { data } = await axios.get<BridgeStatusResult>(
+        "/api/bridge/hyperfx/status",
+        {
+          params: { txHash, network: "Base" },
+          headers: authHeaders(auth),
+        },
+      );
+      if (typeof window !== "undefined") {
+        if (data.status === "SUCCESS") {
+          sessionStorage.setItem(
+            `hyperfx-settled-${txHash}`,
+            data.destinationTxHash ?? txHash,
+          );
+          sessionStorage.removeItem(`hyperfx-failed-${txHash}`);
+        } else if (data.status === "FAILED" || data.status === "REFUNDED") {
+          sessionStorage.setItem(
+            `hyperfx-failed-${txHash}`,
+            data.status === "REFUNDED" ? "refunded" : "expired",
+          );
+        }
+      }
+      return data;
+    } catch (err) {
+      console.warn("[HyperFX] Status check failed:", err);
+    }
+
+    return { status: "PROCESSING", txHash };
   }
 }
 

--- a/app/lib/bridgeFeature.ts
+++ b/app/lib/bridgeFeature.ts
@@ -1,5 +1,12 @@
 import config from "./config";
+import { HYPERFX_SUPPORTED_NETWORKS } from "./hyperfxNetworks";
+
+export { HYPERFX_SUPPORTED_NETWORKS };
 
 export function isBridgeUiVisible(): boolean {
   return config.bridgeEnabled;
+}
+
+export function isHyperfxSwapEnabled(): boolean {
+  return config.bridgeEnabled && config.hyperfxEnabled;
 }

--- a/app/lib/bridgeFeature.ts
+++ b/app/lib/bridgeFeature.ts
@@ -1,4 +1,6 @@
 import config from "./config";
+import type { BridgeLeg } from "./bridge";
+import { TEXTILE_SUPPORTED_NETWORKS } from "./textileNetworks";
 import { HYPERFX_SUPPORTED_NETWORKS } from "./hyperfxNetworks";
 
 export { HYPERFX_SUPPORTED_NETWORKS };
@@ -7,6 +9,26 @@ export function isBridgeUiVisible(): boolean {
   return config.bridgeEnabled;
 }
 
+export function isTextileSwapEnabled(): boolean {
+  return config.bridgeEnabled && config.textileEnabled;
+}
+
 export function isHyperfxSwapEnabled(): boolean {
   return config.bridgeEnabled && config.hyperfxEnabled;
+}
+
+/**
+ * Same-chain USDT ↔ cNGN on BSC or Celo when Textile is enabled.
+ */
+export function isTextileRoute(from: BridgeLeg, to: BridgeLeg): boolean {
+  if (!isTextileSwapEnabled()) return false;
+  if (from.network !== to.network) return false;
+  if (!TEXTILE_SUPPORTED_NETWORKS.has(from.network)) return false;
+
+  const fromSym = from.token.toLowerCase();
+  const toSym = to.token.toLowerCase();
+  return (
+    (fromSym === "usdt" && toSym === "cngn") ||
+    (fromSym === "cngn" && toSym === "usdt")
+  );
 }

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -73,6 +73,7 @@ const config: Config = {
   tronEnabled: process.env.NEXT_PUBLIC_TRON_ENABLED === "true",
   referralEnabled: (process.env.NEXT_PUBLIC_REFERRAL_ENABLED || "").trim().toLowerCase() !== "false",
   bridgeEnabled: process.env.NEXT_PUBLIC_BRIDGE_ENABLED === "true",
+  textileEnabled: process.env.NEXT_PUBLIC_TEXTILE_ENABLED === "true",
   hyperfxEnabled: process.env.NEXT_PUBLIC_HYPERFX_ENABLED === "true",
   onrampChainedForwardingEnabled:
     process.env.NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED === "true",

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -56,8 +56,6 @@ const config: Config = {
     );
     return Number.isFinite(parsed) ? parsed : 0;
   })(),
-  /** Sender API key UUID (aggregator dashboard). Used by server proxy and client (on-chain messageHash metadata). */
-  aggregatorSenderApiKey: (process.env.NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID || "").trim(),
   moralisWebhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
   activepiecesWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
   activepiecesSignupVerifyWebhookUrl:

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -73,6 +73,7 @@ const config: Config = {
   tronEnabled: process.env.NEXT_PUBLIC_TRON_ENABLED === "true",
   referralEnabled: (process.env.NEXT_PUBLIC_REFERRAL_ENABLED || "").trim().toLowerCase() !== "false",
   bridgeEnabled: process.env.NEXT_PUBLIC_BRIDGE_ENABLED === "true",
+  hyperfxEnabled: process.env.NEXT_PUBLIC_HYPERFX_ENABLED === "true",
   onrampChainedForwardingEnabled:
     process.env.NEXT_PUBLIC_ONRAMP_CHAINED_FORWARDING_ENABLED === "true",
   kesOnrampEnabled: process.env.NEXT_PUBLIC_KES_ONRAMP_ENABLED !== "false",

--- a/app/lib/evmEarnWalletTotal.ts
+++ b/app/lib/evmEarnWalletTotal.ts
@@ -13,6 +13,16 @@ export function selectedChainLiquidUsd(
   return typeof total === "number" && Number.isFinite(total) ? total : 0;
 }
 
+/** Sum liquid USD across all cross-chain balance entries. */
+export function sumAllChainLiquidUsd(
+  crossChainBalances: CrossChainBalanceEntry[],
+): number {
+  return crossChainBalances.reduce((sum, entry) => {
+    const total = entry.balances.total;
+    return sum + (typeof total === "number" && Number.isFinite(total) ? total : 0);
+  }, 0);
+}
+
 export function parseEarnDepositedUsd(
   suppliedFormatted?: string | null,
 ): number {
@@ -35,10 +45,7 @@ export function resolveEvmEarnWalletDisplayTotal(params: {
   earnDepositedUsd: number;
 }): { liquidUsd: number; displayTotalUsd: number; includesEarn: boolean } {
   const includesEarn = isEvmEarnFlow(params.chainName);
-  const liquidUsd = selectedChainLiquidUsd(
-    params.crossChainBalances,
-    params.chainName,
-  );
+  const liquidUsd = sumAllChainLiquidUsd(params.crossChainBalances);
   const displayTotalUsd = includesEarn
     ? evmWalletDisplayTotalUsd(liquidUsd, params.earnDepositedUsd)
     : liquidUsd;

--- a/app/lib/hyperfx.ts
+++ b/app/lib/hyperfx.ts
@@ -1,0 +1,612 @@
+/**
+ * Client-side HyperFX (Hyperbridge IntentGateway) swap execution.
+ * Loaded dynamically from useBridgeExecute to keep the SDK out of unrelated bundles.
+ */
+
+import {
+  EvmChain,
+  IntentGateway,
+  IntentGatewayABI,
+  IntentsCoprocessor,
+  IntentOrderStatus,
+  createQueryClient,
+  orderCommitment,
+  type DecodedOrderPlacedLog,
+  type Order,
+} from "@hyperbridge/sdk";
+import {
+  createPublicClient,
+  encodeFunctionData,
+  erc20Abi,
+  http,
+  padHex,
+  parseEventLogs,
+  stringToHex,
+  zeroAddress,
+  zeroHash,
+  type Hex,
+} from "viem";
+import { appendBaseBuilderCode } from "@/app/lib/baseBuilderCode";
+import type { BatchCall } from "@/app/lib/providerBatch";
+import { getRpcUrl, resolveHyperfxBundlerUrl } from "@/app/utils";
+import {
+  HYPERFX_CHAIN_ID_BY_NETWORK,
+  HYPERFX_VIEM_CHAIN_BY_NETWORK,
+} from "@/app/lib/hyperfxNetworks";
+import {
+  HYPERFX_GATEWAY_BY_NETWORK,
+  orderFromOrderPlacedLog,
+  resolveHyperfxOrderStatus,
+} from "@/app/lib/hyperfxStatus";
+import type { HyperfxIntentQuote } from "./bridge";
+
+const WS_URL =
+  process.env.NEXT_PUBLIC_HYPERBRIDGE_WS_URL ||
+  process.env.HYPERBRIDGE_WS_URL ||
+  "wss://nexus.rpc.polytope.technology";
+const INDEXER_URL =
+  process.env.NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL ||
+  process.env.HYPERBRIDGE_INDEXER_URL ||
+  "https://nexus.indexer.polytope.technology";
+
+const NOBLOCKS_GRAFFITI = padHex(stringToHex("noblocks.xyz"), {
+  size: 32,
+  dir: "right",
+});
+
+export type HyperfxWallet = {
+  address: `0x${string}`;
+  chainId: number;
+  /** Injected wallets: direct eth_sendTransaction (with Base builder code applied). */
+  signTransaction?: (tx: {
+    to: Hex;
+    data: Hex;
+    value: bigint;
+  }) => Promise<Hex>;
+  /**
+   * Privy embedded wallets: sponsored EIP-7702 batch for a single call.
+   * Raw eth_sendTransaction corrupts ERC-20 approve calldata via Privy dataSuffix.
+   */
+  executeSponsoredCall?: (
+    call: BatchCall,
+    gasLimit?: number,
+  ) => Promise<Hex>;
+  /** Privy embedded: sponsored batch with multiple calls (approve + placeOrder). */
+  executeSponsoredBatch?: (
+    calls: BatchCall[],
+    gasLimit?: number,
+  ) => Promise<Hex>;
+  switchChain?: (chainId: number) => Promise<void>;
+};
+
+async function sendOnChainCall(
+  wallet: HyperfxWallet,
+  tx: { to: Hex; data: Hex; value: bigint },
+  options: { gasLimit?: number; routing: "sponsored" | "direct" },
+): Promise<Hex> {
+  if (options.routing === "sponsored" && wallet.executeSponsoredCall) {
+    return wallet.executeSponsoredCall(
+      { to: tx.to, value: tx.value, data: tx.data },
+      options.gasLimit,
+    );
+  }
+  if (!wallet.signTransaction) {
+    throw new Error("Wallet not configured for HyperFX execution");
+  }
+  // Injected wallets append builder code manually; Privy adds dataSuffix via plugin.
+  const data = wallet.executeSponsoredBatch || wallet.executeSponsoredCall
+    ? tx.data
+    : appendBaseBuilderCode(wallet.chainId, tx.data);
+  return wallet.signTransaction({ to: tx.to, data, value: tx.value });
+}
+
+export type HyperfxSwapResult = {
+  placementTxHash: string;
+  /** Same as placement until fill is detected via on-chain status polling. */
+  fillTxHash: string;
+};
+
+export type HyperfxBridgeStatus = "SUCCESS" | "PROCESSING" | "REFUNDED" | "FAILED";
+
+export type HyperfxStatusResult = {
+  status: HyperfxBridgeStatus;
+  txHash: string;
+  destinationTxHash?: string;
+};
+
+const hyperfxOrderKey = (txHash: string) => `hyperfx-order-${txHash}`;
+
+const INTENT_GATEWAY_ABI =
+  (IntentGatewayABI as { ABI?: typeof IntentGatewayABI }).ABI ??
+  IntentGatewayABI;
+
+/** SDK `getOrderPlacedFromTx` uses a stale ABI and misses V2 OrderPlaced logs. */
+function parseOrderPlacedFromReceipt(
+  logs: Awaited<
+    ReturnType<ReturnType<typeof createPublicClient>["getTransactionReceipt"]>
+  >["logs"],
+  gatewayAddress: string,
+): DecodedOrderPlacedLog | undefined {
+  const gateway = gatewayAddress.toLowerCase();
+  const events = parseEventLogs({
+    abi: INTENT_GATEWAY_ABI,
+    logs: logs.filter((log) => log.address.toLowerCase() === gateway),
+  });
+  return events.find((event) => event.eventName === "OrderPlaced") as
+    | DecodedOrderPlacedLog
+    | undefined;
+}
+
+const HYPERFX_GATEWAY = HYPERFX_GATEWAY_BY_NETWORK;
+
+function createNetworkPublicClient(network: string) {
+  const rpcUrl = getRpcUrl(network);
+  const chain = HYPERFX_VIEM_CHAIN_BY_NETWORK[network];
+  if (!rpcUrl || !chain) return null;
+  return createPublicClient({ chain, transport: http(rpcUrl) });
+}
+
+function markHyperfxTerminal(
+  placementTxHash: string,
+  outcome: "settled" | "expired" | "refunded" | "failed",
+  fillTxHash?: string,
+): void {
+  if (typeof window === "undefined") return;
+  if (outcome === "settled") {
+    sessionStorage.setItem(
+      `hyperfx-settled-${placementTxHash}`,
+      fillTxHash ?? placementTxHash,
+    );
+    sessionStorage.removeItem(`hyperfx-failed-${placementTxHash}`);
+    return;
+  }
+  const reason =
+    outcome === "refunded" ? "refunded" : outcome === "expired" ? "expired" : "failed";
+  sessionStorage.setItem(`hyperfx-failed-${placementTxHash}`, reason);
+}
+
+function orderToStoredJson(order: Order): unknown {
+  return JSON.parse(
+    JSON.stringify(order, (_, value) =>
+      typeof value === "bigint" ? { __bigint: value.toString() } : value,
+    ),
+  );
+}
+
+function orderFromStoredJson(value: unknown): Order {
+  const order = JSON.parse(JSON.stringify(value), (_, v) =>
+    v && typeof v === "object" && v !== null && "__bigint" in v
+      ? BigInt(v.__bigint as string)
+      : v,
+  ) as Order;
+  return { ...order, id: order.id ?? orderCommitment(order) };
+}
+
+function suppressBidManagerConsoleLogs(): () => void {
+  const prev = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  const filter =
+    (fn: (...args: unknown[]) => void) =>
+    (...args: unknown[]) => {
+      if (String(args[0] ?? "").includes("[BidManager]")) return;
+      fn(...args);
+    };
+  console.log = filter(prev.log);
+  console.warn = filter(prev.warn);
+  console.error = filter(prev.error);
+  return () => {
+    console.log = prev.log;
+    console.warn = prev.warn;
+    console.error = prev.error;
+  };
+}
+
+async function trackHyperfxFillInBackground(
+  run: AsyncIterableIterator<{ status: string; transactionHash?: string; error?: string }>,
+  placementTxHash: Hex,
+): Promise<void> {
+  const restoreConsole = suppressBidManagerConsoleLogs();
+
+  try {
+    while (true) {
+      const update = await run.next();
+      if (update.done) break;
+      const { status, transactionHash, error } = update.value as {
+        status: string;
+        transactionHash?: string;
+        error?: string;
+      };
+      if (status === IntentOrderStatus.BID_SELECTED) {
+        markHyperfxTerminal(
+          placementTxHash,
+          "settled",
+          transactionHash ?? placementTxHash,
+        );
+        // Same-chain: fill may complete without a separate FILLED yield.
+        continue;
+      }
+      if (status === IntentOrderStatus.FILLED) {
+        markHyperfxTerminal(
+          placementTxHash,
+          "settled",
+          transactionHash ?? placementTxHash,
+        );
+        return;
+      }
+      if (status === IntentOrderStatus.EXPIRED) {
+        markHyperfxTerminal(placementTxHash, "expired");
+        return;
+      }
+      if (status === IntentOrderStatus.FAILED) {
+        // Doc: retryable — SDK keeps polling until FILLED or EXPIRED.
+        console.warn("[HyperFX] Retryable fill failure:", error);
+        continue;
+      }
+    }
+  } catch (err) {
+    console.warn("[HyperFX] Fill tracking stopped:", err);
+    markHyperfxTerminal(
+      placementTxHash,
+      "failed",
+    );
+  } finally {
+    restoreConsole();
+  }
+}
+
+export function saveHyperfxPlacedOrder(
+  placementTxHash: string,
+  network: string,
+  chainId: number,
+  order: Order,
+  placementBlockNumber?: bigint,
+): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(
+    hyperfxOrderKey(placementTxHash),
+    JSON.stringify({
+      network,
+      chainId,
+      order: orderToStoredJson(order),
+      ...(placementBlockNumber !== undefined
+        ? { placementBlockNumber: placementBlockNumber.toString() }
+        : {}),
+    }),
+  );
+}
+
+async function loadHyperfxOrderContext(
+  placementTxHash: Hex,
+  network: string,
+  chainId: number,
+): Promise<{ order: Order; placementBlockNumber: bigint } | null> {
+  if (typeof window !== "undefined") {
+    try {
+      const raw = sessionStorage.getItem(hyperfxOrderKey(placementTxHash));
+      if (raw) {
+        const parsed = JSON.parse(raw) as {
+          order?: unknown;
+          placementBlockNumber?: string;
+        };
+        if (parsed.order) {
+          const order = orderFromStoredJson(parsed.order);
+          const placementBlockNumber = parsed.placementBlockNumber
+            ? BigInt(parsed.placementBlockNumber)
+            : undefined;
+          if (placementBlockNumber !== undefined) {
+            return { order, placementBlockNumber };
+          }
+          return { order, placementBlockNumber: await resolvePlacementBlockNumber(
+            placementTxHash,
+            network,
+          ) };
+        }
+      }
+    } catch {
+      // fall through to receipt decode
+    }
+  }
+
+  const gateway = HYPERFX_GATEWAY[network];
+  const publicClient = createNetworkPublicClient(network);
+  if (!gateway || !publicClient) return null;
+
+  const receipt = await publicClient.getTransactionReceipt({
+    hash: placementTxHash,
+  });
+  const placedLog = parseOrderPlacedFromReceipt(receipt.logs, gateway);
+  if (!placedLog) return null;
+
+  const order = orderFromOrderPlacedLog(placedLog.args);
+  saveHyperfxPlacedOrder(
+    placementTxHash,
+    network,
+    chainId,
+    order,
+    receipt.blockNumber,
+  );
+  return { order, placementBlockNumber: receipt.blockNumber };
+}
+
+async function resolvePlacementBlockNumber(
+  placementTxHash: Hex,
+  network: string,
+): Promise<bigint> {
+  const publicClient = createNetworkPublicClient(network);
+  if (!publicClient) return BigInt(0);
+  const receipt = await publicClient.getTransactionReceipt({ hash: placementTxHash });
+  return receipt.blockNumber;
+}
+
+/**
+ * Resolves HyperFX swap status from on-chain IntentGateway state.
+ * Used by status polling when sessionStorage has no terminal result yet.
+ */
+export async function resolveHyperfxOnChainStatus(
+  placementTxHash: string,
+): Promise<HyperfxStatusResult> {
+  const txHash = placementTxHash;
+  let network = "Base";
+  let chainId = HYPERFX_CHAIN_ID_BY_NETWORK.Base ?? 8453;
+
+  if (typeof window !== "undefined") {
+    try {
+      const raw = sessionStorage.getItem(hyperfxOrderKey(placementTxHash));
+      if (raw) {
+        const parsed = JSON.parse(raw) as { network?: string; chainId?: number };
+        if (parsed.network) network = parsed.network;
+        if (parsed.chainId) chainId = parsed.chainId;
+      }
+    } catch {
+      // use defaults
+    }
+  }
+
+  const gateway = HYPERFX_GATEWAY[network];
+  const client = createNetworkPublicClient(network);
+  if (!gateway || !client) {
+    return { status: "PROCESSING", txHash };
+  }
+
+  const ctx = await loadHyperfxOrderContext(
+    placementTxHash as Hex,
+    network,
+    chainId,
+  );
+  if (!ctx) {
+    return { status: "PROCESSING", txHash };
+  }
+
+  const resolved = await resolveHyperfxOrderStatus(
+    client as import("viem").PublicClient,
+    gateway,
+    ctx.order,
+    ctx.placementBlockNumber,
+  );
+
+  if (resolved.status === "SUCCESS") {
+    const fillTx = resolved.fillTxHash ?? placementTxHash;
+    markHyperfxTerminal(placementTxHash, "settled", fillTx);
+    return {
+      status: "SUCCESS",
+      txHash,
+      destinationTxHash: fillTx,
+    };
+  }
+
+  if (resolved.status === "REFUNDED") {
+    markHyperfxTerminal(placementTxHash, "refunded");
+    return { status: "REFUNDED", txHash };
+  }
+
+  if (resolved.status === "FAILED") {
+    markHyperfxTerminal(placementTxHash, "expired");
+    return { status: "FAILED", txHash };
+  }
+
+  return { status: "PROCESSING", txHash };
+}
+
+async function createEvmChain(network: string, bundlerUrl: string) {
+  const rpcUrl = getRpcUrl(network);
+  if (!rpcUrl) {
+    throw new Error(`RPC URL not configured for ${network}`);
+  }
+  return EvmChain.create(rpcUrl, bundlerUrl);
+}
+
+async function createExecutionGateway(
+  network: string,
+  chainId: number,
+  bundlerUrl: string,
+) {
+  const chain = await createEvmChain(network, bundlerUrl);
+  const coprocessor = await IntentsCoprocessor.connect(WS_URL);
+  const queryClient = createQueryClient({ url: INDEXER_URL });
+  const gateway = (
+    await IntentGateway.create(chain, chain, coprocessor)
+  ).withQueryClient(queryClient);
+
+  return { gateway, chain, chainId };
+}
+
+/**
+ * Executes a HyperFX intent swap through IntentGateway `executeBest`.
+ * Resolves when the order is filled or throws on expiry / hard failure.
+ */
+export async function runHyperfxSwap(
+  quote: HyperfxIntentQuote,
+  wallet: HyperfxWallet,
+): Promise<HyperfxSwapResult> {
+  if (Date.now() > quote.expiresAt) {
+    throw new Error("Quote expired. Refresh and try again.");
+  }
+
+  if (wallet.switchChain) {
+    await wallet.switchChain(quote.chainId);
+  }
+
+  const bundlerUrl =
+    quote.bundlerUrl?.trim() || (await resolveHyperfxBundlerUrl(quote.network));
+
+  const { gateway, chain } = await createExecutionGateway(
+    quote.network,
+    quote.chainId,
+    bundlerUrl,
+  );
+  const sourceId = chain.config.stateMachineId;
+  const destId = sourceId;
+  const sourceGateway = chain.configService.getIntentGatewayAddress(sourceId);
+
+  const order: Order = {
+    user: zeroHash,
+    source: sourceId,
+    destination: destId,
+    deadline: (await chain.client.getBlockNumber()) + BigInt(200),
+    nonce: BigInt(0),
+    fees: BigInt(0),
+    session: zeroAddress,
+    predispatch: { assets: [], call: "0x" },
+    inputs: [
+      {
+        token: quote.tokenIn as Hex,
+        amount: BigInt(quote.rawAmountIn),
+      },
+    ],
+    output: {
+      beneficiary: wallet.address,
+      assets: [
+        {
+          token: quote.tokenOut as Hex,
+          amount: BigInt(quote.rawAmountOut),
+        },
+      ],
+      call: "0x",
+    },
+  };
+
+  const { fees } = await gateway.quoteOrderFees(order);
+  order.fees = fees;
+
+  const { address: feeTokenAddress } = await chain.getFeeTokenWithDecimals();
+  const inputIsFeeToken =
+    feeTokenAddress.toLowerCase() === (quote.tokenIn as string).toLowerCase();
+  const approvalAmount = inputIsFeeToken
+    ? BigInt(quote.rawAmountIn) + fees
+    : BigInt(quote.rawAmountIn);
+
+  const publicClient = createNetworkPublicClient(quote.network);
+  if (!publicClient) {
+    throw new Error(`RPC URL not configured for ${quote.network}`);
+  }
+
+  const inputApprovalCall: BatchCall = {
+    to: quote.tokenIn as Hex,
+    value: BigInt(0),
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [sourceGateway as Hex, approvalAmount],
+    }),
+  };
+
+  const feeApprovalCall: BatchCall | null = inputIsFeeToken
+    ? null
+    : {
+        to: feeTokenAddress as Hex,
+        value: BigInt(0),
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: "approve",
+          args: [sourceGateway as Hex, fees],
+        }),
+      };
+
+  const run = gateway.executeBest(order, NOBLOCKS_GRAFFITI, {
+    auctionTimeMs: 15_000,
+    pollIntervalMs: 5_000,
+  });
+
+  const first = await run.next();
+  if (first.done || first.value.status !== IntentOrderStatus.AWAITING_PLACE_ORDER) {
+    throw new Error("HyperFX placement transaction unavailable");
+  }
+
+  // Fee-token orders (e.g. USDC→cNGN): fee is pulled via ERC-20 allowance in calldata —
+  // msg.value is only native-token inputs (`value`). Do not add nativeFee or the batch
+  // reverts when the wallet lacks ETH (see SDK AWAITING_PLACE_ORDER docs).
+  const placementValue =
+    first.value.feeTokenAmount > BigInt(0) &&
+    first.value.feeTokenAddress.toLowerCase() !== zeroAddress
+      ? first.value.value
+      : first.value.value + first.value.nativeFee;
+
+  const placementCall: BatchCall = {
+    to: first.value.to as Hex,
+    value: placementValue,
+    data: first.value.data as Hex,
+  };
+
+  const prePlacementCalls = feeApprovalCall
+    ? [inputApprovalCall, feeApprovalCall]
+    : [inputApprovalCall];
+
+  let placementTxHash: Hex;
+
+  if (wallet.executeSponsoredBatch) {
+    // Doc: batched [input approve, fee approve?, placeOrder] in one sponsored EIP-7702 tx.
+    placementTxHash = await wallet.executeSponsoredBatch(
+      [...prePlacementCalls, placementCall],
+      1_500_000,
+    );
+  } else if (wallet.signTransaction) {
+    for (const call of prePlacementCalls) {
+      const approvalHash = await sendOnChainCall(wallet, call, {
+        gasLimit: 600_000,
+        routing: "direct",
+      });
+      await publicClient.waitForTransactionReceipt({ hash: approvalHash });
+    }
+    placementTxHash = await sendOnChainCall(wallet, placementCall, {
+      gasLimit: 1_000_000,
+      routing: "direct",
+    });
+  } else if (wallet.executeSponsoredCall) {
+    for (const call of prePlacementCalls) {
+      const approvalHash = await wallet.executeSponsoredCall(call, 600_000);
+      await publicClient.waitForTransactionReceipt({ hash: approvalHash });
+    }
+    placementTxHash = await wallet.executeSponsoredCall(placementCall, 1_000_000);
+  } else {
+    throw new Error("Wallet not configured for HyperFX execution");
+  }
+
+  const placed = await run.next(placementTxHash);
+  if (placed.done || placed.value.status !== IntentOrderStatus.ORDER_PLACED) {
+    throw new Error("HyperFX order was not placed");
+  }
+
+  const placedOrder = (placed.value as { order?: Order }).order;
+  const placementReceipt = await publicClient.waitForTransactionReceipt({
+    hash: placementTxHash,
+  });
+  if (placedOrder) {
+    saveHyperfxPlacedOrder(
+      placementTxHash,
+      quote.network,
+      quote.chainId,
+      placedOrder,
+      placementReceipt.blockNumber,
+    );
+  }
+
+  // Must keep consuming executeBest after placement — it drives the solver auction
+  // (autoSelect on BIDS_RECEIVED). Without this, USDC is escrowed but cNGN is never delivered.
+  // Known limitation: if the tab closes before fill completes, rely on on-chain status polling.
+  void trackHyperfxFillInBackground(run, placementTxHash);
+
+  return { placementTxHash, fillTxHash: placementTxHash };
+}

--- a/app/lib/hyperfxNetworks.ts
+++ b/app/lib/hyperfxNetworks.ts
@@ -1,0 +1,85 @@
+/**
+ * HyperFX network config: Noblocks chains with cNGN that IntentGateway supports.
+ * Lisk has cNGN in Noblocks but is not on Hyperbridge — stays on LI.FI.
+ */
+
+import { base, bsc, mainnet, polygon, type Chain } from "viem/chains";
+
+const INTENT_GATEWAY_PROXY =
+  "0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716" as const;
+
+export const HYPERFX_NETWORK_CONFIG = {
+  Base: {
+    chainId: 8453,
+    chain: base,
+    gateway: INTENT_GATEWAY_PROXY,
+    alchemyHost: "base-mainnet",
+  },
+  Polygon: {
+    chainId: 137,
+    chain: polygon,
+    gateway: INTENT_GATEWAY_PROXY,
+    alchemyHost: "polygon-mainnet",
+  },
+  "BNB Smart Chain": {
+    chainId: 56,
+    chain: bsc,
+    gateway: INTENT_GATEWAY_PROXY,
+    alchemyHost: "bnb-mainnet",
+  },
+  Ethereum: {
+    chainId: 1,
+    chain: mainnet,
+    gateway: INTENT_GATEWAY_PROXY,
+    alchemyHost: "eth-mainnet",
+  },
+} satisfies Record<
+  string,
+  {
+    chainId: number;
+    chain: Chain;
+    gateway: typeof INTENT_GATEWAY_PROXY;
+    alchemyHost: string;
+  }
+>;
+
+export type HyperfxNetwork = keyof typeof HYPERFX_NETWORK_CONFIG;
+
+export const HYPERFX_SUPPORTED_NETWORKS = new Set<string>(
+  Object.keys(HYPERFX_NETWORK_CONFIG),
+);
+
+export function isHyperfxSupportedNetwork(
+  network: string,
+): network is HyperfxNetwork {
+  return Object.prototype.hasOwnProperty.call(HYPERFX_NETWORK_CONFIG, network);
+}
+
+export function getHyperfxNetworkConfig(network: string) {
+  if (!isHyperfxSupportedNetwork(network)) return undefined;
+  return HYPERFX_NETWORK_CONFIG[network];
+}
+
+export const HYPERFX_GATEWAY_BY_NETWORK: Record<string, `0x${string}`> =
+  Object.fromEntries(
+    Object.entries(HYPERFX_NETWORK_CONFIG).map(([name, cfg]) => [
+      name,
+      cfg.gateway,
+    ]),
+  ) as Record<string, `0x${string}`>;
+
+export const HYPERFX_VIEM_CHAIN_BY_NETWORK: Record<string, Chain> =
+  Object.fromEntries(
+    Object.entries(HYPERFX_NETWORK_CONFIG).map(([name, cfg]) => [
+      name,
+      cfg.chain,
+    ]),
+  );
+
+export const HYPERFX_CHAIN_ID_BY_NETWORK: Record<string, number> =
+  Object.fromEntries(
+    Object.entries(HYPERFX_NETWORK_CONFIG).map(([name, cfg]) => [
+      name,
+      cfg.chainId,
+    ]),
+  );

--- a/app/lib/hyperfxStatus.ts
+++ b/app/lib/hyperfxStatus.ts
@@ -1,0 +1,199 @@
+/**
+ * Shared HyperFX on-chain order status resolution (client + status API).
+ */
+
+import { IntentGatewayABI, orderCommitment, type Order } from "@hyperbridge/sdk";
+import type { Hex, PublicClient } from "viem";
+import { parseEventLogs } from "viem";
+import { HYPERFX_GATEWAY_BY_NETWORK } from "@/app/lib/hyperfxNetworks";
+
+export { HYPERFX_GATEWAY_BY_NETWORK };
+
+const INTENT_GATEWAY_ABI =
+  (IntentGatewayABI as { ABI?: typeof IntentGatewayABI }).ABI ??
+  IntentGatewayABI;
+
+export { INTENT_GATEWAY_ABI as HYPERFX_INTENT_GATEWAY_ABI };
+
+const ORDER_FILLED_EVENT = INTENT_GATEWAY_ABI.find(
+  (item): item is Extract<(typeof INTENT_GATEWAY_ABI)[number], { type: "event"; name: "OrderFilled" }> =>
+    item.type === "event" && item.name === "OrderFilled",
+);
+
+export type HyperfxTerminalStatus = "SUCCESS" | "REFUNDED" | "FAILED" | "PROCESSING";
+
+export type HyperfxOrderStatus = {
+  status: HyperfxTerminalStatus;
+  fillTxHash?: Hex;
+};
+
+function tokenBytes32ToAddress(token: Hex): `0x${string}` {
+  return `0x${token.slice(-40)}` as `0x${string}`;
+}
+
+/** Ensures `order.id` matches the on-chain commitment used by fills/refunds. */
+export function normalizeHyperfxOrder(order: Order): Order {
+  const id = order.id ?? orderCommitment(order);
+  return { ...order, id };
+}
+
+type OrderPlacedEventArgs = {
+  user: `0x${string}`;
+  source: string;
+  destination: string;
+  deadline: bigint;
+  nonce: bigint;
+  fees: bigint;
+  session: `0x${string}`;
+  beneficiary: `0x${string}`;
+  predispatch: ReadonlyArray<{ token: `0x${string}`; amount: bigint }>;
+  inputs: ReadonlyArray<{ token: `0x${string}`; amount: bigint }>;
+  outputs: ReadonlyArray<{ token: `0x${string}`; amount: bigint }>;
+  predispatchCall?: `0x${string}`;
+  outputCall?: `0x${string}`;
+};
+
+/** Builds a mutable SDK `Order` from an `OrderPlaced` log (viem args are readonly). */
+export function orderFromOrderPlacedLog(args: OrderPlacedEventArgs): Order {
+  const order: Order = {
+    user: args.user,
+    source: args.source,
+    destination: args.destination,
+    deadline: args.deadline,
+    nonce: args.nonce,
+    fees: args.fees,
+    session: args.session,
+    predispatch: {
+      assets: args.predispatch.map((asset) => ({ ...asset })),
+      call: args.predispatchCall ?? "0x",
+    },
+    inputs: args.inputs.map((asset) => ({ ...asset })),
+    output: {
+      beneficiary: args.beneficiary,
+      assets: args.outputs.map((asset) => ({ ...asset })),
+      call: args.outputCall ?? "0x",
+    },
+  };
+  return normalizeHyperfxOrder(order);
+}
+
+export async function isOrderFilledByStorage(
+  client: PublicClient,
+  gateway: `0x${string}`,
+  commitment: Hex,
+): Promise<boolean> {
+  const filledSlot = await client.readContract({
+    abi: INTENT_GATEWAY_ABI,
+    address: gateway,
+    functionName: "calculateCommitmentSlotHash",
+    args: [commitment],
+  });
+  const filledStatus = await client.getStorageAt({
+    address: gateway,
+    slot: filledSlot,
+  });
+  return (
+    filledStatus !==
+    "0x0000000000000000000000000000000000000000000000000000000000000000"
+  );
+}
+
+/** Scans gateway logs for OrderFilled — fallback when storage slot lags or differs. */
+export async function findOrderFilledTxHash(
+  client: PublicClient,
+  gateway: `0x${string}`,
+  commitment: Hex,
+  fromBlock: bigint,
+): Promise<Hex | null> {
+  if (!ORDER_FILLED_EVENT) {
+    return null;
+  }
+
+  const logs = await client.getLogs({
+    address: gateway,
+    event: ORDER_FILLED_EVENT,
+    args: { commitment },
+    fromBlock,
+    toBlock: "latest",
+  });
+  const events = parseEventLogs({
+    abi: INTENT_GATEWAY_ABI,
+    logs,
+    eventName: "OrderFilled",
+  });
+  const match = events.find(
+    (event) =>
+      event.args.commitment?.toLowerCase() === commitment.toLowerCase(),
+  );
+  return match?.transactionHash ?? null;
+}
+
+export async function isOrderEscrowEmpty(
+  client: PublicClient,
+  gateway: `0x${string}`,
+  order: Order,
+): Promise<boolean> {
+  if (!order.inputs?.length) return false;
+  const commitment = (order.id ?? orderCommitment(order)) as Hex;
+  for (const input of order.inputs) {
+    const escrowed = await client.readContract({
+      abi: INTENT_GATEWAY_ABI,
+      address: gateway,
+      functionName: "_orders",
+      args: [commitment, tokenBytes32ToAddress(input.token as Hex)],
+    });
+    if (escrowed !== BigInt(0)) return false;
+  }
+  return true;
+}
+
+/**
+ * Resolves terminal HyperFX order status from on-chain state.
+ *
+ * A filled order also clears escrow — never treat "escrow empty" alone as refunded.
+ */
+export async function resolveHyperfxOrderStatus(
+  client: PublicClient,
+  gateway: `0x${string}`,
+  orderInput: Order,
+  placementBlockNumber: bigint,
+): Promise<HyperfxOrderStatus> {
+  const order = normalizeHyperfxOrder(orderInput);
+  const commitment = order.id as Hex;
+
+  if (await isOrderFilledByStorage(client, gateway, commitment)) {
+    const fillTxHash = await findOrderFilledTxHash(
+      client,
+      gateway,
+      commitment,
+      placementBlockNumber,
+    );
+    return fillTxHash
+      ? { status: "SUCCESS", fillTxHash }
+      : { status: "SUCCESS" };
+  }
+
+  const fillTxHash = await findOrderFilledTxHash(
+    client,
+    gateway,
+    commitment,
+    placementBlockNumber,
+  );
+  if (fillTxHash) {
+    return { status: "SUCCESS", fillTxHash };
+  }
+
+  const escrowEmpty = await isOrderEscrowEmpty(client, gateway, order);
+  if (!escrowEmpty) {
+    return { status: "PROCESSING" };
+  }
+
+  const blockNumber = await client.getBlockNumber();
+  if (blockNumber > order.deadline) {
+    // Escrow cleared after deadline without a fill → cancelled / refunded.
+    return { status: "REFUNDED" };
+  }
+
+  // Escrow cleared before deadline but no fill detected yet — still settling.
+  return { status: "PROCESSING" };
+}

--- a/app/lib/kyc-telemetry.ts
+++ b/app/lib/kyc-telemetry.ts
@@ -1,0 +1,331 @@
+/**
+ * Datadog telemetry for the KYC flow (tiers 1–3).
+ *
+ * Until this existed, a failed tier upgrade left no queryable trace. Client
+ * errors went to GlitchTip, Mixpanel only ever heard about submissions and
+ * successes, and the routes themselves reported failures through `console.*` —
+ * unparsed strings with no trace correlation, and in the case of a genuine
+ * Smile ID rejection, nothing at all. "Why did this user's upgrade fail?" was
+ * not answerable from Datadog.
+ *
+ * One structured line per KYC step outcome, flattened into `@kyc.*` facets so
+ * Datadog can turn them into metrics (Logs → Generate Metrics) and monitors,
+ * and so support can search a wallet address and read the provider's own words
+ * for why it failed.
+ *
+ * Emitted through the shared pino logger to stdout, where the agent sidecar
+ * collects it. `logger` stamps dd.trace_id, so each line links back to its
+ * trace; the same facets are mirrored onto the active span so the failures are
+ * filterable from APM too.
+ *
+ * Server-only — `logger` pulls in Node internals.
+ */
+import tracer from "dd-trace";
+
+import logger from "@/app/lib/logger";
+
+type DatadogLogStatus = "info" | "warn" | "error";
+
+/** Stable message string — log-based metrics and monitors filter on this. */
+export const KYC_EVENT_MESSAGE = "kyc step";
+
+/**
+ * The upgrade steps, plus the signup nudge that precedes tier 1 and the
+ * read-only status endpoint (failures only — every KYC surface polls it, so
+ * logging its successes would bury everything else).
+ */
+export type KycStep =
+  | "signup_email"
+  | "phone_otp_send"
+  | "phone_otp_verify"
+  | "id_verification"
+  | "id_callback"
+  | "address_verification"
+  | "status";
+
+/**
+ * `rejected` is a legitimate user-facing outcome (wrong OTP, Smile ID said no,
+ * attempts exhausted); `error` is our fault or a provider's. Separating them is
+ * what keeps an outage monitor from being drowned by users mistyping an OTP.
+ *
+ * `noop` is for work that correctly did nothing — chiefly the async Smile ID
+ * callback arriving after the synchronous path already promoted the profile.
+ * It logs at info so callback delivery stays observable without a stream of
+ * warnings about the normal case.
+ */
+export type KycOutcome = "success" | "rejected" | "error" | "noop";
+
+export type KycProvider =
+  | "smile_id"
+  | "dojah"
+  | "kudisms"
+  | "twilio"
+  | "supabase";
+
+/**
+ * Bounds on the payload. Provider and Postgres messages are built from the data
+ * that caused them, so an unbounded `detail` is both a payload-size and an
+ * accidental-disclosure risk.
+ */
+const MAX_DETAIL_LENGTH = 500;
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+const MAX_ERROR_STACK_LENGTH = 2_000;
+
+/**
+ * Provider rejection messages quote the input that failed — Smile ID and Dojah
+ * both echo the submitted ID number back in `ResultText`. Mask long digit runs
+ * (NIN and BVN are 11, passport and licence numbers are shorter but still
+ * caught) and anything email-shaped before the line ships. Result codes
+ * (4 digits) and tier numbers stay readable.
+ */
+const DIGIT_RUN = /\d{6,}/g;
+const EMAIL_LIKE = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function maskSensitive(value: string): string {
+  return value.replace(EMAIL_LIKE, "[email]").replace(DIGIT_RUN, "[digits]");
+}
+
+/** Exported for the test suite — masking is the guard that keeps PII out. */
+export function sanitizeDetail(value: string): string {
+  return truncate(maskSensitive(value), MAX_DETAIL_LENGTH);
+}
+
+/** Facets are only useful when absent means absent — drop empty keys. */
+function compact(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined || value === null || value === "") continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Everything a step can report beyond its identity and outcome. */
+export interface KycEventDetails {
+  /** Lower-cased before it ships, so a search matches whatever casing support pastes. */
+  walletAddress?: string | null;
+  /** Where in the route it happened: `profile_fetch`, `provider_submit`, … */
+  stage?: string;
+  /** Stable machine-readable cause: `attempts_exhausted`, `provider_rejected`, … */
+  reason?: string;
+  /** The provider's or Postgres' own message. Masked and truncated. */
+  detail?: string | null;
+  /** `classifySmileIdFailure` output, for the ID step. */
+  failureCategory?: string | null;
+  provider?: KycProvider;
+  /** Smile ID ResultCode, Postgres SQLSTATE, Dojah status. */
+  providerCode?: string | number | null;
+  jobId?: string | null;
+  jobType?: number | null;
+  idCountry?: string | null;
+  idType?: string | null;
+  tierFrom?: number | null;
+  tierTo?: number | null;
+  /** The tier this step is trying to reach, even when it never gets there. */
+  targetTier?: number | null;
+  attempt?: number | null;
+  attemptsRemaining?: number | null;
+  durationMs?: number;
+  statusCode?: number;
+  /** Attached as `error.*` so Datadog Error Tracking groups it. */
+  error?: unknown;
+}
+
+export interface KycEvent extends KycEventDetails {
+  step: KycStep;
+  outcome: KycOutcome;
+}
+
+export interface KycLog {
+  message: string;
+  status: DatadogLogStatus;
+  attributes: Record<string, unknown>;
+}
+
+const STATUS_BY_OUTCOME: Record<KycOutcome, DatadogLogStatus> = {
+  success: "info",
+  noop: "info",
+  rejected: "warn",
+  error: "error",
+};
+
+/**
+ * Flattens one step outcome. `@kyc.ok` is the boolean twin of `outcome` so a
+ * single "upgrades in the last hour" query can count failures without an
+ * outcome-by-outcome filter.
+ */
+export function buildKycLog(event: KycEvent): KycLog {
+  const {
+    step,
+    outcome,
+    walletAddress,
+    stage,
+    reason,
+    detail,
+    failureCategory,
+    provider,
+    providerCode,
+    jobId,
+    jobType,
+    idCountry,
+    idType,
+    tierFrom,
+    tierTo,
+    targetTier,
+    attempt,
+    attemptsRemaining,
+    durationMs,
+    statusCode,
+    error,
+  } = event;
+
+  const attributes: Record<string, unknown> = {
+    feature: "kyc",
+    kyc: compact({
+      step,
+      outcome,
+      ok: outcome === "success",
+      wallet_address: walletAddress ? walletAddress.toLowerCase() : undefined,
+      stage,
+      reason,
+      detail: detail ? sanitizeDetail(detail) : undefined,
+      failure_category: failureCategory,
+      provider,
+      provider_code:
+        providerCode === undefined || providerCode === null
+          ? undefined
+          : String(providerCode),
+      job_id: jobId,
+      job_type: jobType,
+      id_country: idCountry,
+      id_type: idType,
+      tier_from: tierFrom,
+      tier_to: tierTo,
+      target_tier: targetTier,
+      // Boolean twin so a promotion is countable without a null-vs-0 filter.
+      promoted:
+        typeof tierFrom === "number" && typeof tierTo === "number"
+          ? tierTo > tierFrom
+          : undefined,
+      attempt,
+      attempts_remaining: attemptsRemaining,
+      duration_ms: durationMs,
+      status_code: statusCode,
+    }),
+  };
+
+  if (error !== undefined) {
+    const normalized =
+      error instanceof Error ? error : new Error(String(error));
+    attributes.error = compact({
+      kind: normalized.name,
+      message: sanitizeDetail(
+        truncate(normalized.message, MAX_ERROR_MESSAGE_LENGTH),
+      ),
+      // Our own frames, and the main reason to ship an error line at all.
+      // Masked on its own budget: the first line of a stack repeats the
+      // message, so skipping it here would undo the masking above.
+      stack: normalized.stack
+        ? truncate(maskSensitive(normalized.stack), MAX_ERROR_STACK_LENGTH)
+        : undefined,
+    });
+  }
+
+  return {
+    message: KYC_EVENT_MESSAGE,
+    status: STATUS_BY_OUTCOME[outcome],
+    attributes,
+  };
+}
+
+/**
+ * Mirrors the identifying facets onto the active APM span so the same failure
+ * is findable from the trace view, not only from Logs.
+ *
+ * Deliberately does not set the span's error flag: dd-trace already marks 5xx
+ * responses, and flagging a `rejected` outcome (a user mistyping an OTP) would
+ * inflate the service's APM error rate with normal product behaviour.
+ */
+function tagActiveSpan(event: KycEvent): void {
+  try {
+    const span = tracer.scope().active();
+    if (!span) return;
+    span.addTags(
+      compact({
+        "kyc.step": event.step,
+        "kyc.outcome": event.outcome,
+        "kyc.reason": event.reason,
+        "kyc.stage": event.stage,
+        "kyc.target_tier": event.targetTier,
+      }),
+    );
+  } catch {
+    // APM disabled or unavailable — the log line still stands on its own.
+  }
+}
+
+/**
+ * Writes a step outcome to stdout for the agent to collect.
+ *
+ * Synchronous and non-throwing by contract: pino writes to a stream rather than
+ * making a network call, so there is nothing to await and no in-flight request
+ * for the runtime to drop. Telemetry must never be the reason a verification
+ * fails, so the whole body is guarded.
+ */
+export function emitKycEvent(event: KycEvent): void {
+  try {
+    tagActiveSpan(event);
+    const log = buildKycLog(event);
+    logger[log.status](log.attributes, log.message);
+  } catch {
+    // Never let reporting break the flow it is reporting on.
+  }
+}
+
+export interface KycReporter {
+  /** The step completed and the user is now at `tierTo`. */
+  success(details?: KycEventDetails): void;
+  /** A legitimate user-facing refusal — the flow worked, the answer was no. */
+  rejected(details: KycEventDetails): void;
+  /** Our fault, the database's, or the provider's. */
+  failed(details: KycEventDetails): void;
+  /** Correctly did nothing — already verified, superseded, not applicable. */
+  noop(details: KycEventDetails): void;
+}
+
+/**
+ * Binds the facets a route already knows (step, wallet, target tier, provider)
+ * and stamps `duration_ms` from construction, so each exit path is one call
+ * naming only what is new about it.
+ *
+ * Construct it as early as the wallet address is known; later calls can still
+ * override any base field — the async Smile ID callback, for one, only learns
+ * the wallet from the request body.
+ */
+export function createKycReporter(
+  base: KycEventDetails & { step: KycStep },
+): KycReporter {
+  const startedAt = Date.now();
+
+  const emit = (outcome: KycOutcome, details: KycEventDetails = {}) =>
+    emitKycEvent({
+      ...base,
+      ...details,
+      step: base.step,
+      outcome,
+      durationMs: details.durationMs ?? Date.now() - startedAt,
+    });
+
+  return {
+    success: (details) => emit("success", details),
+    rejected: (details) => emit("rejected", details),
+    failed: (details) => emit("error", details),
+    noop: (details) => emit("noop", details),
+  };
+}

--- a/app/lib/payment-order-message-hash.ts
+++ b/app/lib/payment-order-message-hash.ts
@@ -1,0 +1,394 @@
+import "server-only";
+import type { NextRequest } from "next/server";
+import {
+  constants,
+  createPublicKey,
+  publicEncrypt,
+  randomBytes,
+  type KeyObject,
+} from "crypto";
+import config from "./config";
+import { getAggregatorSenderApiKey } from "./server-config";
+import {
+  trackApiRequest,
+  trackApiResponse,
+  trackApiError,
+} from "./server-analytics";
+import { KES_MPESA_INSTITUTION_CODE } from "../utils";
+import { fetchAggregatorPublicKey } from "../api/aggregator";
+import type { KesMpesaChannel } from "../types";
+
+/**
+ * Server-side construction of the encrypted offramp recipient payload.
+ *
+ * Offramp orders are created on-chain by the user's wallet, and the aggregator
+ * learns which sender profile owns the order only from `metadata.apiKey`
+ * inside the RSA-encrypted recipient blob passed as `messageHash`. Building
+ * that blob here — rather than in the browser — is what keeps the sender API
+ * key out of the client bundle. The payload shape is unchanged from the
+ * previous client-side implementation, so the aggregator needs no change.
+ *
+ * Handler follows app/lib/refund-account-api.ts: a minimal request surface in,
+ * `{ status, body }` out, so it is unit-testable without NextRequest.
+ */
+
+export const MESSAGE_HASH_ENDPOINT = "/api/v1/payment-orders/message-hash";
+
+const KES_CHANNELS: readonly string[] = ["Mobile", "Till", "Paybill"];
+const MAX_ACCOUNT_IDENTIFIER = 32;
+const MAX_ACCOUNT_NAME = 100;
+/** Mirrors the memo input's maxLength in TransactionForm. */
+const MAX_MEMO = 25;
+/** Comes straight from the `?provider=` query string — bounded, not trusted. */
+const MAX_PROVIDER_ID = 64;
+const INSTITUTION_RE = /^[A-Za-z0-9_.-]{2,32}$/;
+const PROVIDER_ID_RE = /^[\w-]+$/;
+const BUSINESS_NUMBER_RE = /^\d{1,12}$/;
+/** PKCS#1 v1.5 EME: 0x00 0x02, at least 8 non-zero padding bytes, 0x00. */
+const PKCS1_V15_OVERHEAD_BYTES = 11;
+
+export type MessageHashInput = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo?: string;
+  providerId?: string;
+  kesChannel?: KesMpesaChannel;
+  businessNumber?: string;
+};
+
+/** Exactly the shape the aggregator indexer decrypts (OrderEVM.CreateOrder). */
+export type OfframpRecipient = {
+  accountIdentifier: string;
+  accountName: string;
+  institution: string;
+  memo: string;
+  providerId?: string;
+  nonce: string;
+  metadata: { apiKey: string; channel?: string; businessNumber?: string };
+};
+
+/** Minimal request surface used by the handler (avoids NextRequest in tests). */
+export type MessageHashRequest = {
+  headers: { get(name: string): string | null };
+  json?: () => Promise<unknown>;
+};
+
+export type MessageHashApiResult = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+export type ParseMessageHashResult =
+  | { ok: true; input: MessageHashInput }
+  | { ok: false; error: string };
+
+export class RecipientTooLongError extends Error {
+  constructor(message = "Recipient details are too long to encrypt") {
+    super(message);
+    this.name = "RecipientTooLongError";
+  }
+}
+
+/**
+ * Allowlist parser. Only the seven recipient fields the client legitimately
+ * knows are read; `metadata`, `apiKey`, `nonce` or anything else in the body
+ * is ignored by construction.
+ */
+export function parseMessageHashBody(raw: unknown): ParseMessageHashResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, error: "Request body must be a JSON object" };
+  }
+  const body = raw as Record<string, unknown>;
+
+  const accountIdentifier = requiredString(body, "accountIdentifier", MAX_ACCOUNT_IDENTIFIER);
+  if ("error" in accountIdentifier) return { ok: false, error: accountIdentifier.error };
+  const accountName = requiredString(body, "accountName", MAX_ACCOUNT_NAME);
+  if ("error" in accountName) return { ok: false, error: accountName.error };
+  const institution = requiredString(body, "institution", 32);
+  if ("error" in institution) return { ok: false, error: institution.error };
+  if (!INSTITUTION_RE.test(institution.value)) {
+    return { ok: false, error: "institution is not a valid institution code" };
+  }
+
+  const memo = optionalString(body, "memo", MAX_MEMO);
+  if ("error" in memo) return { ok: false, error: memo.error };
+  const providerId = optionalString(body, "providerId", MAX_PROVIDER_ID);
+  if ("error" in providerId) return { ok: false, error: providerId.error };
+  if (providerId.value && !PROVIDER_ID_RE.test(providerId.value)) {
+    return { ok: false, error: "providerId contains invalid characters" };
+  }
+  const kesChannel = optionalString(body, "kesChannel", 16);
+  if ("error" in kesChannel) return { ok: false, error: kesChannel.error };
+  if (kesChannel.value && !KES_CHANNELS.includes(kesChannel.value)) {
+    return { ok: false, error: "kesChannel must be one of Mobile, Till, Paybill" };
+  }
+  const businessNumber = optionalString(body, "businessNumber", 12);
+  if ("error" in businessNumber) return { ok: false, error: businessNumber.error };
+  if (businessNumber.value && !BUSINESS_NUMBER_RE.test(businessNumber.value)) {
+    return { ok: false, error: "businessNumber must be 1–12 digits" };
+  }
+
+  return {
+    ok: true,
+    input: {
+      accountIdentifier: accountIdentifier.value,
+      accountName: accountName.value,
+      institution: institution.value,
+      ...(memo.value !== undefined && { memo: memo.value }),
+      ...(providerId.value !== undefined && { providerId: providerId.value }),
+      ...(kesChannel.value !== undefined && {
+        kesChannel: kesChannel.value as KesMpesaChannel,
+      }),
+      ...(businessNumber.value !== undefined && {
+        businessNumber: businessNumber.value,
+      }),
+    },
+  };
+}
+
+function requiredString(
+  body: Record<string, unknown>,
+  key: string,
+  max: number,
+): { value: string } | { error: string } {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) {
+    return { error: `${key} is required` };
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > max) {
+    return { error: `${key} must be at most ${max} characters` };
+  }
+  return { value: trimmed };
+}
+
+function optionalString(
+  body: Record<string, unknown>,
+  key: string,
+  max: number,
+): { value: string | undefined } | { error: string } {
+  const value = body[key];
+  if (value === undefined || value === null || value === "") {
+    return { value: undefined };
+  }
+  if (typeof value !== "string") {
+    return { error: `${key} must be a string` };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return { value: undefined };
+  if (trimmed.length > max) {
+    return { error: `${key} must be at most ${max} characters` };
+  }
+  return { value: trimmed };
+}
+
+/**
+ * 12 URL-safe chars (72 bits) from a CSPRNG. The aggregator never reads the
+ * nonce; it only makes ciphertexts unique. Kept at or below the old client
+ * nonce length (13 chars) so the payload never grows against the 245-byte
+ * PKCS#1 v1.5 budget.
+ */
+export function generateRecipientNonce(): string {
+  return randomBytes(9).toString("base64url");
+}
+
+/**
+ * Builds the recipient exactly as the client used to, with the KES M-Pesa
+ * rules from TransactionPreview: `channel` is included for Till/Paybill (never
+ * "Mobile", the default), `businessNumber` only for Paybill, and both only when
+ * the institution is M-Pesa. `memo` is always present (possibly "") to keep the
+ * on-chain payload byte-compatible with the previous client build.
+ */
+export function buildOfframpRecipient(
+  input: MessageHashInput,
+  apiKey: string,
+  nonce: string = generateRecipientNonce(),
+): OfframpRecipient {
+  const metadata: OfframpRecipient["metadata"] = { apiKey };
+  if (input.institution === KES_MPESA_INSTITUTION_CODE && input.kesChannel) {
+    if (input.kesChannel !== "Mobile") {
+      metadata.channel = input.kesChannel;
+    }
+    if (input.kesChannel === "Paybill" && input.businessNumber) {
+      metadata.businessNumber = input.businessNumber;
+    }
+  }
+
+  return {
+    accountIdentifier: input.accountIdentifier,
+    accountName: input.accountName,
+    institution: input.institution,
+    memo: input.memo ?? "",
+    ...(input.providerId ? { providerId: input.providerId } : {}),
+    nonce,
+    metadata,
+  };
+}
+
+/**
+ * Parses the aggregator's `/pubkey` PEM by its DER body, not its label. The
+ * aggregator's own reference config ships a key labelled `RSA PUBLIC KEY`
+ * whose body is SPKI; Go and jsencrypt accept it, Node's PEM parser does not.
+ */
+export function parseAggregatorPublicKey(pem: string): KeyObject {
+  const base64 = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  if (!base64) {
+    throw new Error("Aggregator public key is empty");
+  }
+  const der = Buffer.from(base64, "base64");
+  let key: KeyObject;
+  try {
+    key = createPublicKey({ key: der, format: "der", type: "spki" });
+  } catch {
+    key = createPublicKey({ key: der, format: "der", type: "pkcs1" });
+  }
+  if (key.asymmetricKeyType !== "rsa") {
+    throw new Error(
+      `Aggregator public key is ${key.asymmetricKeyType ?? "unknown"}, expected rsa`,
+    );
+  }
+  return key;
+}
+
+/** Largest plaintext PKCS#1 v1.5 can carry for this key (245 bytes for the production 2047-bit key). */
+export function maxPkcs1v15PlaintextBytes(key: KeyObject): number {
+  const modulusBits = key.asymmetricKeyDetails?.modulusLength;
+  if (!modulusBits) {
+    throw new Error("Cannot determine RSA modulus length");
+  }
+  return Math.ceil(modulusBits / 8) - PKCS1_V15_OVERHEAD_BYTES;
+}
+
+/**
+ * RSA PKCS#1 v1.5 via Node crypto (CSPRNG padding). Byte-identical output
+ * format to the jsencrypt call this replaces, and what the aggregator's
+ * `rsa.DecryptPKCS1v15` expects. Never use jsencrypt server-side: without
+ * `window.crypto` it seeds its padding RNG from Math.random().
+ */
+export function encryptRecipient(recipient: unknown, key: KeyObject): string {
+  const plaintext = Buffer.from(JSON.stringify(recipient), "utf8");
+  if (plaintext.length > maxPkcs1v15PlaintextBytes(key)) {
+    throw new RecipientTooLongError();
+  }
+  try {
+    return publicEncrypt(
+      { key, padding: constants.RSA_PKCS1_PADDING },
+      plaintext,
+    ).toString("base64");
+  } catch (error) {
+    if (/too large/i.test(error instanceof Error ? error.message : "")) {
+      throw new RecipientTooLongError();
+    }
+    throw error;
+  }
+}
+
+function errorBody(message: string): Record<string, unknown> {
+  return { status: "error", message };
+}
+
+export async function handleCreateMessageHash(
+  request: MessageHashRequest,
+): Promise<MessageHashApiResult> {
+  const startTime = Date.now();
+  const req = request as unknown as NextRequest;
+  const walletAddress = request.headers.get("x-wallet-address")?.toLowerCase();
+
+  if (!walletAddress) {
+    trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error("Unauthorized"), 401);
+    return { status: 401, body: errorBody("Unauthorized") };
+  }
+
+  trackApiRequest(req, MESSAGE_HASH_ENDPOINT, "POST", { wallet_address: walletAddress });
+
+  try {
+    const apiKey = getAggregatorSenderApiKey();
+    if (!apiKey || !config.aggregatorUrl) {
+      // Env names stay server-side; the client only sees a generic 503.
+      const cause = !apiKey
+        ? "AGGREGATOR_SENDER_API_KEY_ID is not configured"
+        : "NEXT_PUBLIC_AGGREGATOR_URL is not configured";
+      console.error(`[message-hash] ${cause}`);
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error(cause), 503);
+      return { status: 503, body: errorBody("Order service temporarily unavailable") };
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json?.();
+    } catch {
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error("Invalid JSON body"), 400);
+      return { status: 400, body: errorBody("Invalid JSON body") };
+    }
+    const parsed = parseMessageHashBody(raw);
+    if (!parsed.ok) {
+      trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", new Error(parsed.error), 400);
+      return { status: 400, body: errorBody(parsed.error) };
+    }
+
+    let publicKey: KeyObject;
+    try {
+      const response = await fetchAggregatorPublicKey();
+      if (response?.status !== "success" || typeof response.data !== "string") {
+        throw new Error(`Unexpected /pubkey response: ${String(response?.status)}`);
+      }
+      publicKey = parseAggregatorPublicKey(response.data);
+    } catch (error) {
+      trackApiError(
+        req,
+        MESSAGE_HASH_ENDPOINT,
+        "POST",
+        error instanceof Error ? error : new Error(String(error)),
+        502,
+      );
+      return {
+        status: 502,
+        body: errorBody("Could not reach the aggregator. Please try again."),
+      };
+    }
+
+    // No pubkey cache on purpose: an aggregator key rotation would otherwise
+    // fail silently for the cache lifetime. One GET per order is negligible.
+    const recipient = buildOfframpRecipient(parsed.input, apiKey);
+
+    let messageHash: string;
+    try {
+      messageHash = encryptRecipient(recipient, publicKey);
+    } catch (error) {
+      if (error instanceof RecipientTooLongError) {
+        trackApiError(req, MESSAGE_HASH_ENDPOINT, "POST", error, 422);
+        return {
+          status: 422,
+          body: errorBody(
+            "Recipient details are too long to encrypt. Shorten the memo and try again.",
+          ),
+        };
+      }
+      throw error;
+    }
+
+    trackApiResponse(MESSAGE_HASH_ENDPOINT, "POST", 200, Date.now() - startTime, {
+      wallet_address: walletAddress,
+      institution: parsed.input.institution,
+    });
+    return {
+      status: 200,
+      body: { status: "success", message: "OK", data: { messageHash } },
+    };
+  } catch (error) {
+    console.error("[message-hash] unexpected error:", error);
+    trackApiError(
+      req,
+      MESSAGE_HASH_ENDPOINT,
+      "POST",
+      error instanceof Error ? error : new Error(String(error)),
+      500,
+      { response_time_ms: Date.now() - startTime },
+    );
+    return { status: 500, body: errorBody("Internal server error") };
+  }
+}

--- a/app/lib/sentry.client.ts
+++ b/app/lib/sentry.client.ts
@@ -2,6 +2,8 @@
 
 import * as Sentry from "@sentry/react";
 
+import { datadogRum, isDatadogRumInitialized } from "./datadog.client";
+
 const INIT_KEY = "__noblocks_sentry_init__" as const;
 
 function scrubEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
@@ -104,9 +106,16 @@ export function ensureSentryClientInitialized(): void {
 }
 
 /**
- * Report a handled error to GlitchTip. The **primary event** is `error` itself
- * (original message, stack, etc.); `context` / `extra` is only supplemental
- * (e.g. `userFacingMessage` for the copy shown in the UI).
+ * Report a handled error to GlitchTip **and** Datadog RUM. The **primary
+ * event** is `error` itself (original message, stack, etc.); `context` /
+ * `extra` is only supplemental (e.g. `userFacingMessage` for the copy shown in
+ * the UI).
+ *
+ * RUM matters for the failures that never reach our API — a dropped network
+ * request, a camera permission refusal, a wallet rejection — which no
+ * server-side log can see. It is consent-gated and initialised separately, so
+ * this is strictly additive: server logs remain the complete record, and a
+ * user who declined analytics cookies still reports to GlitchTip.
  */
 export function reportClientError(
   error: unknown,
@@ -117,6 +126,15 @@ export function reportClientError(
   Sentry.captureException(error, {
     extra: context,
   });
+
+  // Calling addError before init is a no-op that logs a warning, so guard it.
+  if (!isDatadogRumInitialized()) return;
+  try {
+    // RUM's own beforeSend scrubs this context (see datadog.client.ts).
+    datadogRum.addError(error, context);
+  } catch {
+    // Reporting must never be the reason a handler throws.
+  }
 }
 
 export { Sentry };

--- a/app/lib/server-config.ts
+++ b/app/lib/server-config.ts
@@ -60,3 +60,18 @@ export function getServerMixpanelToken(): string {
     false, // Optional - analytics can fail gracefully
   );
 }
+
+/**
+ * Aggregator sender API key (UUID from the aggregator dashboard).
+ *
+ * SERVER-ONLY. Sent as the `API-Key` header by the /api/v1/payment-orders*
+ * routes and injected into the encrypted offramp messageHash by
+ * app/lib/payment-order-message-hash.ts. Never NEXT_PUBLIC_ — the value must
+ * not reach the browser. Read lazily per call so a missing variable degrades
+ * to a 503 at request time instead of breaking `next build` (CI builds with it
+ * unset).
+ */
+export function getAggregatorSenderApiKey(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.AGGREGATOR_SENDER_API_KEY_ID || "").trim();
+}

--- a/app/lib/smileIdIdValidation.ts
+++ b/app/lib/smileIdIdValidation.ts
@@ -23,7 +23,7 @@ export class SmileIdValidationError extends Error {
 
 export function getJobTypeForIdType(idType: string): number {
   const normalized = idType?.toString().trim().toUpperCase();
-  if (["BVN", "NIN", "NIN_SLIP", "V_NIN", "NIN_V2"].includes(normalized)) return 5;
+  if (["BVN", "NIN", "NIN_SLIP", "NIN_V2"].includes(normalized)) return 5;
   if (normalized === "DRIVERS_LICENSE") return 6;
   return 1;
 }
@@ -32,7 +32,6 @@ const SMILE_ELEVEN_DIGIT_ID_TYPES = new Set([
   "BVN",
   "NIN",
   "NIN_SLIP",
-  "V_NIN",
   "NIN_V2",
 ]);
 
@@ -124,7 +123,6 @@ function elevenDigitNinFamilyMessage(idType: string): string {
   const ninFamily =
     idType === "NIN" ||
     idType === "NIN_SLIP" ||
-    idType === "V_NIN" ||
     idType === "NIN_V2";
   return ninFamily
     ? "Enter a valid 11-digit NIN."

--- a/app/lib/textileNetworks.ts
+++ b/app/lib/textileNetworks.ts
@@ -1,0 +1,54 @@
+/**
+ * Textile FX network config: same-chain USDT ↔ cNGN on BSC and Celo.
+ * @see https://docs.textilecredit.com/address-book.html
+ */
+
+export const TEXTILE_NETWORK_CONFIG = {
+  "BNB Smart Chain": { chainId: 56 },
+  Celo: { chainId: 42220 },
+} as const;
+
+export type TextileNetworkName = keyof typeof TEXTILE_NETWORK_CONFIG;
+
+export const TEXTILE_SUPPORTED_NETWORKS = new Set<string>(
+  Object.keys(TEXTILE_NETWORK_CONFIG),
+);
+
+export const TEXTILE_SUPPORTED_CHAIN_IDS = new Set<number>([56, 42220]);
+
+/** Live Textile USDT↔cNGN token addresses per chain. */
+export const TEXTILE_CORRIDOR_TOKENS: Record<
+  number,
+  { usdt: `0x${string}`; cngn: `0x${string}` }
+> = {
+  56: {
+    usdt: "0x55d398326f99059ff775485246999027b3197955",
+    cngn: "0xa8aea66b361a8d53e8865c62d142167af28af058",
+  },
+  42220: {
+    usdt: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+    cngn: "0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f",
+  },
+};
+
+export function isTextileCorridorPair(
+  chainId: number,
+  sellToken: string,
+  buyToken: string,
+): boolean {
+  const tokens = TEXTILE_CORRIDOR_TOKENS[chainId];
+  if (!tokens) return false;
+
+  const sell = sellToken.toLowerCase();
+  const buy = buyToken.toLowerCase();
+  const usdt = tokens.usdt.toLowerCase();
+  const cngn = tokens.cngn.toLowerCase();
+
+  return (sell === usdt && buy === cngn) || (sell === cngn && buy === usdt);
+}
+
+export function textileChainId(networkName: string): number | null {
+  const cfg =
+    TEXTILE_NETWORK_CONFIG[networkName as TextileNetworkName];
+  return cfg?.chainId ?? null;
+}

--- a/app/lib/textileServer.ts
+++ b/app/lib/textileServer.ts
@@ -1,0 +1,176 @@
+/** Shared Textile FX upstream helpers for server proxy routes. */
+
+import {
+  isTextileCorridorPair,
+  TEXTILE_SUPPORTED_CHAIN_IDS,
+} from "./textileNetworks";
+
+export const TEXTILE_API_V2_BASE = "https://api.textilecredit.com/v2";
+export const TEXTILE_PREVIEW_TIMEOUT_MS = 15_000;
+/** RFQ request blocks while makers reply (~750 ms default); allow headroom for network. */
+export const TEXTILE_RFQ_REQUEST_TIMEOUT_MS = 20_000;
+export const TEXTILE_UPSTREAM_TIMEOUT_MS = 15_000;
+
+export function textileAuthHeaders(): Record<string, string> {
+  const key = process.env.TEXTILE_API_KEY || "";
+  const headers: Record<string, string> = {};
+  if (key) headers.Authorization = `Bearer ${key}`;
+  return headers;
+}
+
+/** Optional claim token for RFQ cancel/submit/status when not using the requesting API key. */
+export function textileRfqClaimHeaders(
+  claimToken?: string | null,
+): Record<string, string> {
+  if (!claimToken?.trim()) return {};
+  return { "X-Rfq-Claim": claimToken.trim() };
+}
+
+/** True when a RAY-scaled rate string is a positive integer. */
+export function isPositiveRayRate(value: unknown): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) return false;
+  try {
+    return BigInt(value) > BigInt(0);
+  } catch {
+    return false;
+  }
+}
+
+/** Parse request JSON body; rejects null, arrays, and non-objects with 400. */
+export function parseJsonObjectBody(
+  value: unknown,
+): { ok: true; body: Record<string, unknown> } | { ok: false; error: string } {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "Request body must be a JSON object" };
+  }
+  return { ok: true, body: value as Record<string, unknown> };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isEvmAddress(value: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+function parseChainId(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isPositiveAtomicAmount(value: unknown): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) return false;
+  try {
+    return BigInt(value) > BigInt(0);
+  } catch {
+    return false;
+  }
+}
+
+function validateTextileCorridorBody(
+  body: Record<string, unknown>,
+  requireTaker: boolean,
+): { ok: true } | { ok: false; error: string } {
+  const missing = [
+    body.chainId === undefined || body.chainId === null ? "chainId" : null,
+    !isNonEmptyString(body.sellToken) ? "sellToken" : null,
+    !isNonEmptyString(body.buyToken) ? "buyToken" : null,
+    !isNonEmptyString(body.sellAmount) ? "sellAmount" : null,
+    requireTaker && !isNonEmptyString(body.taker) ? "taker" : null,
+  ].filter(Boolean);
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Missing required fields: ${missing.join(", ")}`,
+    };
+  }
+
+  const chainId = parseChainId(body.chainId);
+  if (chainId === null || !TEXTILE_SUPPORTED_CHAIN_IDS.has(chainId)) {
+    return {
+      ok: false,
+      error: "chainId must be a supported Textile corridor (56 or 42220)",
+    };
+  }
+
+  const sellToken = body.sellToken as string;
+  const buyToken = body.buyToken as string;
+
+  if (!isEvmAddress(sellToken) || !isEvmAddress(buyToken)) {
+    return { ok: false, error: "sellToken and buyToken must be valid EVM addresses" };
+  }
+
+  if (requireTaker) {
+    const taker = body.taker as string;
+    if (!isEvmAddress(taker)) {
+      return { ok: false, error: "taker must be a valid EVM address" };
+    }
+  }
+
+  if (sellToken.toLowerCase() === buyToken.toLowerCase()) {
+    return { ok: false, error: "sellToken and buyToken must differ" };
+  }
+
+  if (!isTextileCorridorPair(chainId, sellToken, buyToken)) {
+    return {
+      ok: false,
+      error: "Token pair is not a supported Textile USDT↔cNGN corridor on this chain",
+    };
+  }
+
+  if (!isPositiveAtomicAmount(body.sellAmount)) {
+    return { ok: false, error: "sellAmount must be a positive atomic amount string" };
+  }
+
+  return { ok: true };
+}
+
+/** POST /v2/rfq/preview — same body as request minus taker. */
+export function validateTextilePreviewBody(
+  body: Record<string, unknown>,
+): { ok: true } | { ok: false; error: string } {
+  return validateTextileCorridorBody(body, false);
+}
+
+/** POST /v2/rfq/request — firm quote with taker wallet. */
+export function validateTextileRequestBody(
+  body: Record<string, unknown>,
+): { ok: true } | { ok: false; error: string } {
+  return validateTextileCorridorBody(body, true);
+}
+
+/** @deprecated v1 name — use validateTextileRequestBody */
+export const validateTextileSwapBody = validateTextileRequestBody;
+
+export function validateTextileSubmitBody(
+  body: Record<string, unknown>,
+): { ok: true; rfqId: string } | { ok: false; error: string } {
+  const rfqId =
+    (isNonEmptyString(body.rfqId) && body.rfqId) ||
+    (isNonEmptyString(body.swapId) && body.swapId) ||
+    null;
+
+  if (!rfqId || !isNonEmptyString(body.txHash)) {
+    return { ok: false, error: "rfqId and txHash are required" };
+  }
+  return { ok: true, rfqId };
+}
+
+const TEXTILE_RFQ_CLAIM_PREFIX = "textile-rfq-claim:";
+
+/** Persist RFQ claim token for status polling (browser only). */
+export function storeTextileRfqClaim(rfqId: string, claimToken: string): void {
+  if (typeof sessionStorage === "undefined") return;
+  sessionStorage.setItem(`${TEXTILE_RFQ_CLAIM_PREFIX}${rfqId}`, claimToken);
+}
+
+export function getTextileRfqClaim(rfqId: string): string | null {
+  if (typeof sessionStorage === "undefined") return null;
+  return sessionStorage.getItem(`${TEXTILE_RFQ_CLAIM_PREFIX}${rfqId}`);
+}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -43,6 +43,9 @@ import {
   swapModeFromSideParam,
   RATE_DECIMALS,
   formatRateForDisplay,
+  getQuoteDecimals,
+  quoteTokenAmountForFiat,
+  ONRAMP_FIAT_DECIMALS,
 } from "../utils";
 import { ArrowUpDownIcon, NoteEditIcon, Wallet01Icon } from "hugeicons-react";
 import { useSwapButton } from "../hooks/useSwapButton";
@@ -414,6 +417,19 @@ export const TransactionForm = ({
 
   const fetchedTokens: Token[] = allTokens[selectedNetwork.chain.name] || [];
 
+  // Precision the token leg is quoted and validated at. Derived from the
+  // selected token so the amount that goes on-chain is not rounded below what
+  // the recipient was quoted — see quoteTokenAmountForFiat.
+  const quoteDecimals = getQuoteDecimals(
+    fetchedTokens.find((t) => t.symbol.toUpperCase() === token?.toUpperCase())
+      ?.decimals,
+  );
+
+  // `amountSent` is the token leg on offramp but the fiat leg on onramp, where
+  // the token's precision means nothing. Only the token leg follows the token;
+  // onramp fiat keeps the four places it has always allowed.
+  const amountSentDecimals = isSwapped ? ONRAMP_FIAT_DECIMALS : quoteDecimals;
+
   const { handleFundWallet } = useFundWalletHandler("Transaction form");
 
   const handleFundWalletClick = async (
@@ -731,8 +747,14 @@ export const TransactionForm = ({
           } else {
             // Not swapped: Receive = Currency, so calculate Send (Token)
             // Send = Receive / Rate (1400 NGN / 1400 = 1 USDC)
-            const calculatedAmount = Number(
-              (Number(amountReceived) / rate).toFixed(4),
+            //
+            // This amount is deposited on-chain verbatim and multiplied back by
+            // the rate to pay the recipient, so it rounds up at the token's own
+            // precision rather than to a fixed 4 places.
+            const calculatedAmount = quoteTokenAmountForFiat(
+              Number(amountReceived),
+              rate,
+              quoteDecimals,
             );
             setValue("amountSent", calculatedAmount, {
               shouldDirty: true,
@@ -758,7 +780,7 @@ export const TransactionForm = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [amountSent, amountReceived, rate, isSwapped],
+    [amountSent, amountReceived, rate, isSwapped, quoteDecimals],
   );
 
   // Derive swap eligibility from tier + spend limits. Always set explicitly so we
@@ -859,8 +881,8 @@ export const TransactionForm = ({
               const decimals = value.toString().split(".")[1];
               return (
                 !decimals ||
-                decimals.length <= 4 ||
-                "Maximum 4 decimal places allowed"
+                decimals.length <= amountSentDecimals ||
+                `Maximum ${amountSentDecimals} decimal places allowed`
               );
             },
             onrampFiatMin: (value: number) => {
@@ -1350,7 +1372,7 @@ export const TransactionForm = ({
     // Only limit decimal places, allow any whole number
     if (cleanedValue.includes(".")) {
       const decimals: string | undefined = cleanedValue.split(".")[1];
-      if (decimals?.length > 4) return;
+      if (decimals?.length > amountSentDecimals) return;
     } // Update the form value
     setValue("amountSent", value, {
       shouldValidate: true,

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -19,7 +19,6 @@ import {
   getNetworkImageUrl,
   getRpcUrl,
   normalizeNetworkName,
-  publicKeyEncrypt,
   shortenAddress,
 } from "../utils";
 import { tokensEqual, toAggregatorToken } from "../lib/token-symbol";
@@ -68,7 +67,7 @@ import {
 import { useApiAuth } from "../hooks/useApiAuth";
 
 import {
-  fetchAggregatorPublicKey,
+  createOfframpMessageHash,
   fetchTokens,
   saveTransaction,
   precheckSwapTransaction,
@@ -375,57 +374,31 @@ export const TransactionPreview = ({
       network: selectedNetwork.chain.name,
     };
 
-  const prepareCreateOrderParams = async () => {
-    const senderApiKeyId = config.aggregatorSenderApiKey?.trim();
-    if (!senderApiKeyId) {
-      throw new Error(
-        "Sender API key is not configured (set NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID)",
-      );
-    }
-    const metadata: Record<string, string> = { apiKey: senderApiKeyId };
-    if (
-      !isOnramp &&
-      formValues.institution === KES_MPESA_INSTITUTION_CODE &&
-      formValues.kesChannel
-    ) {
-      // Omit Mobile channel (default phone M-Pesa); include Till/Paybill for aggregator.
-      if (formValues.kesChannel !== "Mobile") {
-        metadata.channel = formValues.kesChannel;
-      }
-      if (
-        formValues.kesChannel === "Paybill" &&
-        formValues.businessNumber?.trim()
-      ) {
-        metadata.businessNumber = formValues.businessNumber.trim();
-      }
-    }
+  type OrderAuth = { accessToken: string | null; injectedToken: string | null };
 
+  // Offramp only (onramp never reaches createOrder). The server builds the
+  // encrypted recipient — nonce and sender API key are added there, so the key
+  // never reaches the browser. Raw KES fields are sent; the server applies the
+  // channel/businessNumber rules authoritatively.
+  const prepareCreateOrderParams = async (auth: OrderAuth) => {
     const providerId =
       searchParams.get("provider") || searchParams.get("PROVIDER");
 
-    // Prepare recipient data (metadata.apiKey matches aggregator OrderEVM.CreateOrder + indexer)
-    const recipient = isOnramp
-      ? {
-        accountIdentifier: walletAddress || "",
-        accountName: recipientName || walletAddress || "",
-        institution: "Wallet",
-        ...(providerId && { providerId }),
-        nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
-        metadata,
-      }
-      : {
+    const messageHash = await createOfframpMessageHash(
+      {
         accountIdentifier: formValues.accountIdentifier,
         accountName: recipientName,
         institution: formValues.institution,
         memo: formValues.memo,
         ...(providerId && { providerId }),
-        nonce: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`,
-        metadata,
-      };
-
-    // Fetch aggregator public key
-    const publicKey = await fetchAggregatorPublicKey();
-    const encryptedRecipient = publicKeyEncrypt(recipient, publicKey.data);
+        ...(formValues.kesChannel && { kesChannel: formValues.kesChannel }),
+        ...(formValues.businessNumber?.trim() && {
+          businessNumber: formValues.businessNumber.trim(),
+        }),
+      },
+      auth.accessToken,
+      auth.injectedToken,
+    );
 
     // Prepare transaction parameters
     const params = {
@@ -435,7 +408,7 @@ export const TransactionPreview = ({
       senderFeeRecipient: zeroAddress,
       senderFee: BigInt(0),
       refundAddress: activeWallet?.address as `0x${string}`,
-      messageHash: encryptedRecipient,
+      messageHash,
     };
 
     return params;
@@ -453,14 +426,14 @@ export const TransactionPreview = ({
     }
   };
 
-  const createOrder = async () => {
+  const createOrder = async (auth: OrderAuth) => {
     try {
       if (isStarknetSelected) {
         if (!starknetWalletId || !starknetPublicKey || !starknetWalletAddress) {
           throw new Error("Starknet wallet not ready");
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const accessToken = await getAccessToken();
@@ -526,7 +499,7 @@ export const TransactionPreview = ({
           throw new Error("Injected wallet not ready");
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const requiredSpend = params.amount + params.senderFee;
@@ -665,7 +638,7 @@ export const TransactionPreview = ({
           authorization = await signDelegationAuthorization(chainId);
         }
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
         const requiredSpend = params.amount + params.senderFee;
 
@@ -785,7 +758,7 @@ export const TransactionPreview = ({
           id: selectedNetwork.chain.id,
         });
 
-        const params = await prepareCreateOrderParams();
+        const params = await prepareCreateOrderParams(auth);
         setCreatedAt(new Date().toISOString());
 
         const requiredSpend = params.amount + params.senderFee;
@@ -1101,7 +1074,7 @@ export const TransactionPreview = ({
         injectedToken,
       );
 
-      await createOrder();
+      await createOrder({ accessToken, injectedToken });
     } catch (e) {
       const msg =
         e instanceof Error ? e.message : "Unable to start this transaction.";

--- a/app/pages/TransactionPreview.tsx
+++ b/app/pages/TransactionPreview.tsx
@@ -13,6 +13,9 @@ import {
   getCurrencySymbol,
   getGatewayContractAddress,
   getInstitutionNameByCode,
+  formatRecipientInstitutionDisplay,
+  getKesMpesaInstitutionLabel,
+  KES_MPESA_INSTITUTION_CODE,
   getNetworkImageUrl,
   getRpcUrl,
   normalizeNetworkName,
@@ -145,6 +148,8 @@ export const TransactionPreview = ({
     accountIdentifier,
     memo,
     walletAddress,
+    kesChannel,
+    businessNumber,
   } = formValues;
 
   // Derive the flow from the form's own mode, never from `!!walletAddress` — a Buy that somehow
@@ -356,7 +361,16 @@ export const TransactionPreview = ({
         .split(" ")
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(" "),
-      account: `${accountIdentifier} • ${getInstitutionNameByCode(institution, supportedInstitutions) ?? institution ?? ""}`,
+      account: formatRecipientInstitutionDisplay(
+        institution,
+        supportedInstitutions,
+        {
+          currency,
+          channel: kesChannel,
+          accountIdentifier,
+          businessNumber,
+        },
+      ),
       ...(memo && { description: memo }),
       network: selectedNetwork.chain.name,
     };
@@ -368,7 +382,23 @@ export const TransactionPreview = ({
         "Sender API key is not configured (set NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID)",
       );
     }
-    const metadata = { apiKey: senderApiKeyId };
+    const metadata: Record<string, string> = { apiKey: senderApiKeyId };
+    if (
+      !isOnramp &&
+      formValues.institution === KES_MPESA_INSTITUTION_CODE &&
+      formValues.kesChannel
+    ) {
+      // Omit Mobile channel (default phone M-Pesa); include Till/Paybill for aggregator.
+      if (formValues.kesChannel !== "Mobile") {
+        metadata.channel = formValues.kesChannel;
+      }
+      if (
+        formValues.kesChannel === "Paybill" &&
+        formValues.businessNumber?.trim()
+      ) {
+        metadata.businessNumber = formValues.businessNumber.trim();
+      }
+    }
 
     const providerId =
       searchParams.get("provider") || searchParams.get("PROVIDER");
@@ -1052,12 +1082,19 @@ export const TransactionPreview = ({
           fee: Number(rate),
           recipient: {
             account_name: recipientName,
-            institution: getInstitutionNameByCode(
-              institution,
-              supportedInstitutions,
-            ) as string,
+            institution:
+              institution === KES_MPESA_INSTITUTION_CODE && kesChannel
+                ? getKesMpesaInstitutionLabel(kesChannel)
+                : (getInstitutionNameByCode(
+                    institution,
+                    supportedInstitutions,
+                  ) as string),
             account_identifier: accountIdentifier,
             ...(memo && { memo }),
+            ...(kesChannel ? { channel: kesChannel } : {}),
+            ...(businessNumber?.trim()
+              ? { business_number: businessNumber.trim() }
+              : {}),
           },
         },
         accessToken,
@@ -1117,12 +1154,19 @@ export const TransactionPreview = ({
           }
           : {
             account_name: recipientName,
-            institution: getInstitutionNameByCode(
-              institution,
-              supportedInstitutions,
-            ) as string,
+            institution:
+              institution === KES_MPESA_INSTITUTION_CODE && kesChannel
+                ? getKesMpesaInstitutionLabel(kesChannel)
+                : (getInstitutionNameByCode(
+                    institution,
+                    supportedInstitutions,
+                  ) as string),
             account_identifier: accountIdentifier,
             ...(memo && { memo }),
+            ...(kesChannel ? { channel: kesChannel } : {}),
+            ...(businessNumber?.trim()
+              ? { business_number: businessNumber.trim() }
+              : {}),
           },
         status: "pending",
         network: selectedNetwork.chain.name,

--- a/app/pages/TransactionStatus.tsx
+++ b/app/pages/TransactionStatus.tsx
@@ -31,6 +31,10 @@ import {
   formatRecipientNameFirstWordForPill,
   getExplorerLink,
   getInstitutionNameByCode,
+  getKesMpesaInstitutionLabel,
+  KES_MPESA_INSTITUTION_CODE,
+  normalizeSavedRecipientChannel,
+  isSameSavedRecipient,
   getRpcUrl,
   isBlockFestActive,
 } from "../utils";
@@ -50,6 +54,7 @@ import {
   STEPS,
   type OrderDetailsData,
   type TransactionStatusProps,
+  type KesMpesaChannel,
 } from "../types";
 import { toast } from "sonner";
 import { trackEvent } from "../hooks/analytics/client";
@@ -236,6 +241,8 @@ export function TransactionStatus({
   const recipientName = String(watch("recipientName")) || "";
   const accountIdentifier = watch("accountIdentifier") || "";
   const institution = watch("institution") || "";
+  const watchedKesChannel = watch("kesChannel") || "";
+  const watchedBusinessNumber = watch("businessNumber") || "";
   const recipientWalletAddress = String(watch("walletAddress") || "");
   const amountReceivedCrypto = Number(watch("amountReceived")) || 0;
 
@@ -616,8 +623,12 @@ export function TransactionStatus({
         const exists = savedRecipients.some(
           (r) =>
             r.type !== "wallet" &&
-            r.accountIdentifier === accountIdentifier &&
-            r.institutionCode === institution,
+            isSameSavedRecipient(r, {
+              accountIdentifier: String(accountIdentifier),
+              institutionCode: String(institution),
+              channel: String(watchedKesChannel) as KesMpesaChannel | "",
+              businessNumber: String(watchedBusinessNumber),
+            }),
         );
         setIsRecipientInBeneficiaries(exists);
       } catch (error) {
@@ -627,7 +638,13 @@ export function TransactionStatus({
     };
 
     checkRecipientExists();
-  }, [accountIdentifier, institution, getAccessToken]);
+  }, [
+    accountIdentifier,
+    institution,
+    watchedKesChannel,
+    watchedBusinessNumber,
+    getAccessToken,
+  ]);
 
   /**
    * Updates transaction status in the backend
@@ -1184,10 +1201,22 @@ export function TransactionStatus({
       return false;
     }
 
-    const institutionName = getInstitutionNameByCode(
-      String(institutionCode),
-      supportedInstitutions,
-    );
+    const kesChannel = formMethods.watch("kesChannel") as
+      | KesMpesaChannel
+      | ""
+      | undefined;
+    const businessNumber = String(
+      formMethods.watch("businessNumber") || "",
+    ).trim();
+    const savedChannel = normalizeSavedRecipientChannel(kesChannel);
+
+    const institutionName =
+      String(institutionCode) === KES_MPESA_INSTITUTION_CODE && kesChannel
+        ? getKesMpesaInstitutionLabel(kesChannel)
+        : getInstitutionNameByCode(
+            String(institutionCode),
+            supportedInstitutions,
+          );
 
     if (!institutionName) {
       console.error("Institution name not found");
@@ -1203,6 +1232,9 @@ export function TransactionStatus({
       type:
         (formMethods.watch("accountType") as "bank" | "mobile_money") || "bank",
       currency: String(formMethods.watch("currency") || ""),
+      // Send Money normalizes away so it matches pre-channel saved recipients.
+      ...(savedChannel ? { channel: savedChannel } : {}),
+      ...(businessNumber ? { businessNumber } : {}),
     };
 
     const accessToken = await getAccessToken();
@@ -1237,6 +1269,8 @@ export function TransactionStatus({
   const removeRecipient = async () => {
     const accountIdentifier = formMethods.watch("accountIdentifier");
     const institutionCode = formMethods.watch("institution");
+    const channel = formMethods.watch("kesChannel") || "";
+    const businessNumber = formMethods.watch("businessNumber") || "";
 
     if (!accountIdentifier || !institutionCode) {
       console.error("Missing account identifier or institution code");
@@ -1255,8 +1289,12 @@ export function TransactionStatus({
       const recipientToDelete = savedRecipients.find(
         (r) =>
           r.type !== "wallet" &&
-          r.accountIdentifier === accountIdentifier &&
-          r.institutionCode === institutionCode,
+          isSameSavedRecipient(r, {
+            accountIdentifier: String(accountIdentifier),
+            institutionCode: String(institutionCode),
+            channel: String(channel) as KesMpesaChannel | "",
+            businessNumber: String(businessNumber),
+          }),
       );
 
       if (!recipientToDelete) {

--- a/app/play/leaderboard/page.tsx
+++ b/app/play/leaderboard/page.tsx
@@ -5,7 +5,7 @@
  * points, with self-row highlight, "Find me" jump and pagination.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
   ArrowLeft01Icon,
@@ -14,7 +14,10 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { trackEvent } from "@/app/hooks/analytics/client";
-import { LeaderboardTable } from "@/app/components/play/LeaderboardTable";
+import {
+  LeaderboardTable,
+  SELF_ROW_ID,
+} from "@/app/components/play/LeaderboardTable";
 import { useJoinStatus, useLeaderboard } from "@/app/components/play/hooks";
 import {
   EmptyState,
@@ -23,27 +26,77 @@ import {
   secondaryButtonClasses,
 } from "@/app/components/play/ui";
 
+/** How long the "You" row keeps its ring after a Find me jump. */
+const SELF_HIGHLIGHT_MS = 2400;
+
 export default function LeaderboardPage() {
   const [page, setPage] = useState(1);
   const [findMe, setFindMe] = useState(false);
+  const [pendingSelfScroll, setPendingSelfScroll] = useState(false);
+  const [highlightSelf, setHighlightSelf] = useState(false);
+  const tableRef = useRef<HTMLDivElement>(null);
   const { authenticated } = usePrivy();
   const { joined } = useJoinStatus();
 
-  const { data, isPending, isError, refetch } = useLeaderboard(page, findMe);
+  const { data, isPending, isFetching, isPlaceholderData, isError, refetch } =
+    useLeaderboard(page, findMe);
 
   useEffect(() => {
     trackEvent("leaderboard_viewed", { page });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // keepPreviousData hands back the outgoing page's rows the instant findMe
+  // flips the query key, so `data` is non-null before the find request has run.
+  // Acting on that placeholder would set the page back to where we already were
+  // and clear findMe, silently cancelling the jump — wait for the real result.
   useEffect(() => {
-    if (findMe && data) {
+    if (findMe && data && !isPlaceholderData) {
       setPage(data.page);
       setFindMe(false);
     }
-  }, [findMe, data]);
+  }, [findMe, data, isPlaceholderData]);
+
+  // Landing on the right page is not enough — on a full page of 50 the "You"
+  // row is usually below the fold. Once the rows holding it are committed,
+  // bring it to the middle of the viewport and ring it.
+  useEffect(() => {
+    // Placeholder rows belong to the page we are leaving: scrolling to them, or
+    // concluding from them that there is no self row, both break the jump.
+    if (!pendingSelfScroll || !data || isPlaceholderData) return;
+    const hasSelf = data.rows.some((row) => row.is_me);
+    if (!hasSelf) {
+      // Signed in but not ranked yet (no scores computed) — nothing to jump to.
+      if (!findMe) setPendingSelfScroll(false);
+      return;
+    }
+    setPendingSelfScroll(false);
+    setHighlightSelf(true);
+    const row = document.getElementById(SELF_ROW_ID);
+    row?.scrollIntoView({ behavior: "smooth", block: "center" });
+    // preventScroll: scrollIntoView above already owns the movement, and
+    // focus() would otherwise jump instantly and cancel the smooth scroll.
+    row?.focus({ preventScroll: true });
+  }, [pendingSelfScroll, data, findMe, isPlaceholderData]);
+
+  useEffect(() => {
+    if (!highlightSelf) return;
+    const timer = window.setTimeout(
+      () => setHighlightSelf(false),
+      SELF_HIGHLIGHT_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [highlightSelf]);
 
   const totalPages = data ? Math.max(1, Math.ceil(data.total / data.page_size)) : 1;
+
+  const goToPage = (next: number) => {
+    setPage(next);
+    setHighlightSelf(false);
+    // Keep the top of the list in view: without this the browser holds the old
+    // scroll offset and the new page appears to open halfway down.
+    tableRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
     <div className="space-y-4 max-lg:pb-10">
@@ -56,6 +109,7 @@ export default function LeaderboardPage() {
             type="button"
             onClick={() => {
               setFindMe(true);
+              setPendingSelfScroll(true);
             }}
             className={`${secondaryButtonClasses} inline-flex items-center gap-2`}
           >
@@ -84,11 +138,22 @@ export default function LeaderboardPage() {
         />
       ) : (
         <>
-          <LeaderboardTable rows={data.rows} />
+          {/* Rows from the previous page stay mounted while the next one loads
+              (see keepPreviousData in useLeaderboard) — dim them rather than
+              collapsing the table into skeletons on every Prev/Next. */}
+          <div
+            ref={tableRef}
+            aria-busy={isFetching}
+            className={`transition-opacity duration-200 ${
+              isFetching ? "opacity-60" : "opacity-100"
+            }`}
+          >
+            <LeaderboardTable rows={data.rows} highlightSelf={highlightSelf} />
+          </div>
           <div className="flex items-center justify-between">
             <button
               type="button"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              onClick={() => goToPage(Math.max(1, page - 1))}
               disabled={page <= 1}
               className={`${secondaryButtonClasses} inline-flex items-center gap-1`}
             >
@@ -100,7 +165,7 @@ export default function LeaderboardPage() {
             </span>
             <button
               type="button"
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              onClick={() => goToPage(Math.min(totalPages, page + 1))}
               disabled={page >= totalPages}
               className={`${secondaryButtonClasses} inline-flex items-center gap-1`}
             >

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -28,10 +28,19 @@ import {
 const ASSET = (name: string) => `/images/play-promo/${name}`;
 const HERO_PILL_BUTTON =
   "inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-white px-4 py-2 text-sm font-semibold text-text-body transition-transform active:scale-[0.98] dark:bg-white dark:text-text-body";
+// The desktop banner is a fixed-aspect box whose headline, body and gaps are all
+// sized in cqw; these two buttons were its only fixed-px elements. At text-sm
+// with px-6 they needed ~308px side by side but the text column is only 35.34%
+// (~287px at the 812px design width), so the row wrapped to two lines and the
+// second button spilled through the banner's bottom edge — worse the narrower
+// the screen, since the box height shrank while the buttons did not. Sizing them
+// in cqw too keeps the pair on one line at every container width.
+const HERO_DESKTOP_BUTTON_SIZING =
+  "px-[2.1cqw] py-[1.15cqw] text-[1.6cqw]";
 const HERO_DESKTOP_PRIMARY_BUTTON =
-  "inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-text-body px-6 py-2.5 text-sm font-semibold text-lavender-100 transition-transform hover:bg-text-body/90 active:scale-[0.98] dark:bg-black dark:text-lavender-100 dark:hover:bg-black/90";
+  `inline-flex min-h-0 items-center justify-center gap-1 whitespace-nowrap rounded-full bg-text-body ${HERO_DESKTOP_BUTTON_SIZING} font-semibold text-lavender-100 transition-transform hover:bg-text-body/90 active:scale-[0.98] dark:bg-black dark:text-lavender-100 dark:hover:bg-black/90`;
 const HERO_SECONDARY_BUTTON =
-  "inline-flex min-h-0 items-center justify-center whitespace-nowrap rounded-full bg-white/10 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/20";
+  `inline-flex min-h-0 items-center justify-center whitespace-nowrap rounded-full bg-white/10 ${HERO_DESKTOP_BUTTON_SIZING} font-semibold text-white transition-colors hover:bg-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/20`;
 const BOTTOM_CTA_SECTION =
   "relative overflow-hidden rounded-3xl bg-text-body dark:bg-surface-overlay";
 const BOTTOM_CTA_SCRIM = "pointer-events-none absolute inset-0 z-0 bg-text-body/70 dark:bg-surface-overlay/70";
@@ -235,7 +244,11 @@ const JoinCTA = ({
     return (
       <Link
         href="/play/team"
-        className={`${buttonClassName} inline-flex items-center gap-2  px-8 py-3 ${className}`}
+        className={`${buttonClassName} inline-flex items-center gap-2 ${
+          // Callers passing their own look (the hero banners) size their own
+          // padding; only the default button needs this widening.
+          buttonClassName === primaryButtonClasses ? "px-8 py-3" : ""
+        } ${className}`}
       >
         My Team
         <ArrowRight01Icon className="size-4" />

--- a/app/play/rewards/page.tsx
+++ b/app/play/rewards/page.tsx
@@ -15,6 +15,7 @@ import {
   UserGroupIcon,
 } from "hugeicons-react";
 import { toast } from "sonner";
+import { JoinModal } from "@/app/components/play/JoinModal";
 import { LeagueCard } from "@/app/components/play/LeagueCard";
 import { playKeys, useRewards } from "@/app/components/play/hooks";
 import {
@@ -56,10 +57,12 @@ export default function RewardsPage() {
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
   const [joinHighlight, setJoinHighlight] = useState(false);
+  const [playJoinOpen, setPlayJoinOpen] = useState(false);
   const joinInputRef = useRef<HTMLInputElement>(null);
+  const inviteCode = searchParams.get("join")?.trim().toUpperCase() || null;
 
   useEffect(() => {
-    const join = searchParams.get("join")?.trim().toUpperCase();
+    const join = inviteCode;
     if (!join || join.length < 4) return;
     setCode(join);
     setJoinHighlight(true);
@@ -70,7 +73,7 @@ export default function RewardsPage() {
         block: "center",
       });
     }, 300);
-  }, [searchParams]);
+  }, [inviteCode]);
 
   const refresh = async () => {
     await queryClient.invalidateQueries({ queryKey: playKeys.rewards });
@@ -95,7 +98,6 @@ export default function RewardsPage() {
   if (!ready || (authenticated && isLoading)) return <RewardsSkeleton />;
 
   if (!authenticated) {
-    const inviteCode = searchParams.get("join")?.trim().toUpperCase();
     return (
       <EmptyState
         icon={<UserGroupIcon className="size-8 text-lavender-500" />}
@@ -119,17 +121,35 @@ export default function RewardsPage() {
   }
 
   if (error instanceof PlayApiError && error.code === "NOT_JOINED") {
+    // Joining Play used to bounce through /play, which dropped the invite code
+    // and left the user to find Leagues and retype it. Do it here instead: the
+    // modal redeems `inviteCode` as soon as the username is taken.
     return (
-      <EmptyState
-        icon={<UserGroupIcon className="size-8 text-lavender-500" />}
-        title="Join Noblocks Play first"
-        description="Pick a username and enter the league, then come back here to join your friend's mini-league."
-        action={
-          <Link href="/play" className={primaryButtonClasses}>
-            Join the league
-          </Link>
-        }
-      />
+      <>
+        <EmptyState
+          icon={<UserGroupIcon className="size-8 text-lavender-500" />}
+          title="Join Noblocks Play first"
+          description={
+            inviteCode
+              ? `Pick a username to enter the league — we'll add you to the mini-league (${inviteCode}) straight after.`
+              : "Pick a username and enter the league, then come back here to join a friend's mini-league."
+          }
+          action={
+            <button
+              type="button"
+              onClick={() => setPlayJoinOpen(true)}
+              className={primaryButtonClasses}
+            >
+              Join the league
+            </button>
+          }
+        />
+        <JoinModal
+          isOpen={playJoinOpen}
+          onClose={() => setPlayJoinOpen(false)}
+          inviteCode={inviteCode}
+        />
+      </>
     );
   }
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -490,7 +490,6 @@ export type Config = {
   maintenanceSchedule: string; // e.g. "Friday, February 13th, from 7:00 PM to 11:00 PM WAT"
   referralMinQualifyingVolumeUsd: number;
   referralRewardAmountUsd: number;
-  aggregatorSenderApiKey: string;
   moralisWebhookSecret: string;
   activepiecesWebhookUrl: string;
   /**

--- a/app/types.ts
+++ b/app/types.ts
@@ -493,6 +493,8 @@ export type Config = {
   referralEnabled: boolean;
   /** Bridge/Swap feature flag. Controls Convert button visibility + proxy routes. */
   bridgeEnabled: boolean;
+  /** Textile FX for same-chain USDT↔cNGN on BSC and Celo. Requires TEXTILE_API_KEY server-side. */
+  textileEnabled: boolean;
   /** HyperFX (Hyperbridge IntentGateway) USDC↔cNGN same-chain swaps in Convert. */
   hyperfxEnabled: boolean;
   onrampChainedForwardingEnabled: boolean;

--- a/app/types.ts
+++ b/app/types.ts
@@ -24,10 +24,20 @@ import type {
   UseFormReturn,
 } from "react-hook-form";
 
+/** KES M-Pesa payout rail. Till/Paybill share institution SAFAKEPC with channel metadata. */
+export type KesMpesaChannel = "Mobile" | "Till" | "Paybill";
+
 export type InstitutionProps = {
   name: string;
   code: string;
   type: "bank" | "mobile_money";
+  /**
+   * UI-only key for virtual KES M-Pesa splits (e.g. `SAFAKEPC:Till`).
+   * Always submit `code` (SAFAKEPC) to the API.
+   */
+  uiKey?: string;
+  /** Present on virtually expanded KES M-Pesa institution options. */
+  channel?: KesMpesaChannel;
 };
 
 /** Onramp refund bank account (persisted per wallet + fiat currency; v2 order source.refundAccount). */
@@ -59,6 +69,10 @@ export type FormData = {
   isSwapped?: boolean;
   /** True after user picks the Receive row asset (fiat off-ramp, token on-ramp). */
   receiveDestinationExplicitlySelected: boolean;
+  /** KES M-Pesa rail when SAFAKEPC is virtually split in the UI. */
+  kesChannel?: KesMpesaChannel | "";
+  /** Paybill business number (KES Paybill only). */
+  businessNumber?: string;
 };
 
 export const STEPS = {
@@ -106,6 +120,10 @@ export type RecipientDetails =
     institutionCode: string;
     accountIdentifier: string;
     currency?: string;
+    /** KES M-Pesa channel when saved from a virtual institution split. */
+    channel?: KesMpesaChannel;
+    /** Paybill business number when channel is Paybill. */
+    businessNumber?: string;
     walletAddress?: never;
   };
 
@@ -164,6 +182,11 @@ export type SelectFieldProps = {
 export type VerifyAccountPayload = {
   institution: string;
   accountIdentifier: string;
+  /** KES Till/Paybill: skips phone normalization on the aggregator. */
+  metadata?: {
+    channel?: KesMpesaChannel;
+    businessNumber?: string;
+  };
 };
 
 /** Paycrest v2 rates: onramp uses `buy`, offramp uses `sell`. */
@@ -573,6 +596,10 @@ export interface Recipient {
   institution: string;
   account_identifier: string;
   memo?: string;
+  /** KES M-Pesa channel label for history display (e.g. Till, Paybill). */
+  channel?: KesMpesaChannel;
+  /** Paybill business number when applicable. */
+  business_number?: string;
   /** Bridge only: destination network (the transactions.network column holds the source). */
   to_network?: string;
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -493,6 +493,8 @@ export type Config = {
   referralEnabled: boolean;
   /** Bridge/Swap feature flag. Controls Convert button visibility + proxy routes. */
   bridgeEnabled: boolean;
+  /** HyperFX (Hyperbridge IntentGateway) USDC↔cNGN same-chain swaps in Convert. */
+  hyperfxEnabled: boolean;
   onrampChainedForwardingEnabled: boolean;
   /**
    * KES fiat→crypto onramp. Default on (unset env); set

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -173,6 +173,58 @@ export function formatKesMpesaAccountDisplay(
   return `${id} • M-PESA`;
 }
 
+/** Identity of a saved bank/mobile-money recipient, for dedupe and delete matching. */
+type SavedRecipientIdentity = {
+  accountIdentifier: string;
+  institutionCode: string;
+  channel?: KesMpesaChannel | "" | null;
+  businessNumber?: string | null;
+};
+
+/**
+ * Channel value to persist on a *saved recipient*, whose unique key includes it.
+ *
+ * Send Money collapses to `""` so it matches recipients saved before channels
+ * existed — otherwise the same phone number would be stored twice, once as `""`
+ * and once as `"Mobile"`. Only Till and Paybill, which are genuinely different
+ * payout targets, get a distinguishing value.
+ *
+ * Transaction history is not identity and keeps the literal channel, so past
+ * orders still show the rail the user actually picked.
+ *
+ * Unrecognized values also collapse to `""`, so an unexpected channel can never
+ * open a new slot in the recipient unique key.
+ */
+export function normalizeSavedRecipientChannel(
+  channel?: string | null,
+): "" | "Till" | "Paybill" {
+  const value = (channel ?? "").trim();
+  return value === "Till" || value === "Paybill" ? value : "";
+}
+
+/**
+ * True when two saved recipients are the same payout target.
+ *
+ * Mirrors the saved-recipient unique key exactly. Channel matters because Send
+ * Money / Till / Paybill share the `SAFAKEPC` code and may share an identifier;
+ * business number matters because two Paybills can share a reference under
+ * different businesses ("INV-001" billed by 400200 and by 888880). Comparing on
+ * fewer fields than the key hides rows in the beneficiaries list and can delete
+ * the wrong one.
+ */
+export function isSameSavedRecipient(
+  a: SavedRecipientIdentity,
+  b: SavedRecipientIdentity,
+): boolean {
+  return (
+    a.accountIdentifier === b.accountIdentifier &&
+    a.institutionCode === b.institutionCode &&
+    normalizeSavedRecipientChannel(a.channel) ===
+      normalizeSavedRecipientChannel(b.channel) &&
+    (a.businessNumber ?? "").trim() === (b.businessNumber ?? "").trim()
+  );
+}
+
 /**
  * Resolve institution display for preview/history, including KES channel rails.
  * With `accountIdentifier` set, returns the full account line (`id • name`);

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -94,6 +94,9 @@ export function getInstitutionNameByCode(
 /** Safaricom M-Pesa institution code (KES). Till/Paybill use the same code + channel metadata. */
 export const KES_MPESA_INSTITUTION_CODE = "SAFAKEPC";
 
+/** NGN NUBAN account numbers are always 10 digits. */
+export const NGN_NUBAN_LENGTH = 10;
+
 export type { KesMpesaChannel };
 
 const KES_MPESA_VIRTUAL_OPTIONS: {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,5 +1,4 @@
 import { createElement, type ReactElement } from "react";
-import JSEncrypt from "jsencrypt";
 import type {
   InstitutionProps,
   KesMpesaChannel,
@@ -666,24 +665,6 @@ export async function getEmailForMonitoredAddress(
     console.warn("[privy] getUserBySmartWalletAddress", normalized, e);
   }
   return null;
-}
-
-/**
- * Encrypts data using the provided public key.
- * @param data - The data to be encrypted.
- * @param publicKeyPEM - The public key in PEM format.
- * @returns The encrypted data as a base64-encoded string.
- */
-export function publicKeyEncrypt(data: unknown, publicKeyPEM: string): string {
-  const encrypt = new JSEncrypt();
-  encrypt.setPublicKey(publicKeyPEM);
-
-  const encrypted = encrypt.encrypt(JSON.stringify(data));
-  if (encrypted === false) {
-    throw new Error("Failed to encrypt data");
-  }
-
-  return encrypted;
 }
 
 /**

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -23,6 +23,10 @@ import { colors } from "./mocks";
 import { fetchTokens } from "./api/aggregator";
 import { toast } from "sonner";
 import config from "./lib/config";
+import {
+  getHyperfxNetworkConfig,
+  isHyperfxSupportedNetwork,
+} from "./lib/hyperfxNetworks";
 import { logBalanceTelemetry } from "./lib/balanceTelemetry";
 
 /**
@@ -610,6 +614,68 @@ export function getRpcUrl(network: string) {
     default:
       return undefined;
   }
+}
+
+/** ERC-4337 bundler URL for HyperFX IntentGateway fill execution (Alchemy per chain). */
+function buildHyperfxBundlerUrl(network: string, alchemyKey: string): string | undefined {
+  if (!isHyperfxSupportedNetwork(network)) {
+    return undefined;
+  }
+  const cfg = getHyperfxNetworkConfig(network)!;
+  return `https://${cfg.alchemyHost}.g.alchemy.com/v2/${alchemyKey.trim()}`;
+}
+
+/** Server-only: builds bundler URL from ALCHEMY_API_KEY. */
+export function getHyperfxBundlerUrl(network: string): string | undefined {
+  const alchemyKey = process.env.ALCHEMY_API_KEY?.trim();
+  if (!alchemyKey) {
+    return undefined;
+  }
+  return buildHyperfxBundlerUrl(network, alchemyKey);
+}
+
+export function requireHyperfxBundlerUrl(network: string): string {
+  const url = getHyperfxBundlerUrl(network);
+  if (!url) {
+    throw new Error("HyperFX bundler URL not configured");
+  }
+  return url;
+}
+
+const clientBundlerUrlCache = new Map<string, string>();
+
+/** Server: sync from env. Browser: optional fetch (requires auth) — prefer quote.bundlerUrl. */
+export async function resolveHyperfxBundlerUrl(
+  network: string,
+  authToken?: string | null,
+): Promise<string> {
+  if (typeof window === "undefined") {
+    return requireHyperfxBundlerUrl(network);
+  }
+
+  const cached = clientBundlerUrlCache.get(network);
+  if (cached) {
+    return cached;
+  }
+
+  const headers: HeadersInit = {};
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  const res = await fetch(
+    `/api/bridge/hyperfx/bundler?network=${encodeURIComponent(network)}`,
+    { headers },
+  );
+  if (!res.ok) {
+    throw new Error("HyperFX bundler URL not configured");
+  }
+  const data = (await res.json()) as { bundlerUrl?: string };
+  if (!data.bundlerUrl) {
+    throw new Error("HyperFX bundler URL not configured");
+  }
+  clientBundlerUrlCache.set(network, data.bundlerUrl);
+  return data.bundlerUrl;
 }
 
 // Token caching

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -922,6 +922,13 @@ export const FALLBACK_TOKENS: { [key: string]: Token[] } = {
       address: "0x765DE816845861e75A25fCA122bb6898B8B1282a",
       imageUrl: "/logos/cusd-logo.svg",
     },
+    {
+      name: "Compliant Naira",
+      symbol: "cNGN",
+      decimals: 6,
+      address: "0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f",
+      imageUrl: "/logos/cngn-logo.svg",
+    },
   ],
   Lisk: [
     {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -332,6 +332,78 @@ export function roundAmountForCurrency(amount: number): number {
 }
 
 /**
+ * Decimal places a quoted token amount is carried at.
+ *
+ * Capped below the token's own precision so an 18-decimal token does not put
+ * `36.475317147039290123` in the amount field. Six places is finer than one
+ * minor unit of fiat at every corridor rate Noblocks quotes (the highest is
+ * ~3,700 fiat per token, where one subunit is worth ~0.004), so the cap costs
+ * the sender at most a rounding crumb.
+ */
+export const MAX_QUOTE_DECIMALS = 6;
+
+/**
+ * Decimal places the onramp Send field accepts. That leg is fiat, not token, so
+ * it is unaffected by token precision and keeps its long-standing limit.
+ */
+export const ONRAMP_FIAT_DECIMALS = 4;
+
+export function getQuoteDecimals(tokenDecimals: number | undefined): number {
+  const decimals = Math.trunc(Number(tokenDecimals));
+  if (!Number.isFinite(decimals) || decimals <= 0) return MAX_QUOTE_DECIMALS;
+  return Math.min(decimals, MAX_QUOTE_DECIMALS);
+}
+
+/**
+ * Scales by a power of ten through the decimal string, so 36.4753 * 1e6 lands on
+ * 36475300 rather than 36475299.999999996. Values already in exponential form
+ * cannot take a second exponent, so those fall back to plain multiplication.
+ */
+function shiftDecimalPoint(value: number, exponent: number): number {
+  const shifted = Number(`${value}e${exponent}`);
+  return Number.isFinite(shifted) ? shifted : value * 10 ** exponent;
+}
+
+/**
+ * Token amount to send so the recipient is paid `fiatAmount`, rounded **up** to
+ * the last subunit.
+ *
+ * Rounding down here is a real loss. The deposited token amount is what the
+ * aggregator multiplies back by the rate to decide the payout, so an amount
+ * short of `fiatAmount / rate` pays the recipient less than the quote — at 4
+ * decimal places a ₦50,000 order at rate 1370.79 deposited 36.4753 USDC and
+ * paid out ₦49,999.98. Rounding up costs the sender at most one subunit and can
+ * only land the recipient on or above the quote.
+ */
+export function quoteTokenAmountForFiat(
+  fiatAmount: number,
+  rate: number,
+  tokenDecimals: number | undefined,
+): number {
+  if (
+    !Number.isFinite(fiatAmount) ||
+    fiatAmount <= 0 ||
+    !Number.isFinite(rate) ||
+    rate <= 0
+  ) {
+    return 0;
+  }
+
+  const decimals = getQuoteDecimals(tokenDecimals);
+  const subunits = shiftDecimalPoint(fiatAmount / rate, decimals);
+  if (!Number.isFinite(subunits)) return 0;
+
+  // A division that is mathematically exact can still land a hair off in binary
+  // (3 as 3.0000000000000004). Snapping those back keeps the amount field clean
+  // instead of charging a whole extra subunit for float noise.
+  const nearest = Math.round(subunits);
+  const rounded =
+    Math.abs(subunits - nearest) < 1e-6 ? nearest : Math.ceil(subunits);
+
+  return shiftDecimalPoint(rounded, -decimals);
+}
+
+/**
  * List / details: fiat uses symbol prefix (e.g. ₦1,000.5); crypto uses "1.23 USDC".
  */
 export function formatTransactionAmountDisplay(

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -2,6 +2,7 @@ import { createElement, type ReactElement } from "react";
 import JSEncrypt from "jsencrypt";
 import type {
   InstitutionProps,
+  KesMpesaChannel,
   Network,
   Token,
   Currency,
@@ -77,15 +78,137 @@ export function getTokenLogoIdentifier(tokenSymbol: string): string {
 /**
  * Retrieves the institution name based on the provided institution code.
  *
- * @param code - The institution code.
+ * @param code - The institution code (or UI key like `SAFAKEPC:Till`).
  * @returns The institution name associated with the provided code, or undefined if not found.
  */
 export function getInstitutionNameByCode(
   code: string,
   supportedInstitutions: InstitutionProps[],
 ): string | undefined {
-  const institution = supportedInstitutions.find((inst) => inst.code === code);
+  const institution = supportedInstitutions.find(
+    (inst) => inst.code === code || inst.uiKey === code,
+  );
   return institution ? institution.name : undefined;
+}
+
+/** Safaricom M-Pesa institution code (KES). Till/Paybill use the same code + channel metadata. */
+export const KES_MPESA_INSTITUTION_CODE = "SAFAKEPC";
+
+export type { KesMpesaChannel };
+
+const KES_MPESA_VIRTUAL_OPTIONS: {
+  channel: KesMpesaChannel;
+  name: string;
+}[] = [
+  { channel: "Mobile", name: "M-PESA (Send Money)" },
+  { channel: "Till", name: "M-PESA (Till)" },
+  { channel: "Paybill", name: "M-PESA (Paybill)" },
+];
+
+/** UI-only key for a virtually split KES M-Pesa option. */
+export function kesMpesaUiKey(channel: KesMpesaChannel): string {
+  return `${KES_MPESA_INSTITUTION_CODE}:${channel}`;
+}
+
+/** Display label for a KES M-Pesa channel (falls back to M-PESA). */
+export function getKesMpesaInstitutionLabel(
+  channel?: KesMpesaChannel | "" | null,
+): string {
+  const match = KES_MPESA_VIRTUAL_OPTIONS.find((o) => o.channel === channel);
+  return match?.name ?? "M-PESA";
+}
+
+/**
+ * Expand SAFAKEPC into Send Money / Till / Paybill UI options for KES.
+ * Other institutions (banks, Airtel) are unchanged. API code remains SAFAKEPC.
+ */
+export function expandKesMpesaInstitutions(
+  institutions: InstitutionProps[] | undefined,
+  currency?: string,
+): InstitutionProps[] {
+  if (!institutions?.length) return [];
+  if ((currency ?? "").toUpperCase() !== "KES") return [...institutions];
+
+  const result: InstitutionProps[] = [];
+  for (const inst of institutions) {
+    if (inst.code !== KES_MPESA_INSTITUTION_CODE) {
+      result.push(inst);
+      continue;
+    }
+    for (const option of KES_MPESA_VIRTUAL_OPTIONS) {
+      result.push({
+        name: option.name,
+        code: KES_MPESA_INSTITUTION_CODE,
+        type: "mobile_money",
+        channel: option.channel,
+        uiKey: kesMpesaUiKey(option.channel),
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Preview/history account line for KES M-Pesa rails.
+ * e.g. `Till • 123456 • M-PESA` or `Paybill • 400200 / INV-001 • M-PESA`.
+ */
+export function formatKesMpesaAccountDisplay(
+  accountIdentifier: string,
+  channel?: KesMpesaChannel | "" | null,
+  businessNumber?: string | null,
+): string {
+  const id = (accountIdentifier ?? "").trim();
+  if (channel === "Till") {
+    return `Till • ${id} • M-PESA`;
+  }
+  if (channel === "Paybill") {
+    const biz = (businessNumber ?? "").trim();
+    return biz
+      ? `Paybill • ${biz} / ${id} • M-PESA`
+      : `Paybill • ${id} • M-PESA`;
+  }
+  return `${id} • M-PESA`;
+}
+
+/**
+ * Resolve institution display for preview/history, including KES channel rails.
+ * With `accountIdentifier` set, returns the full account line (`id • name`);
+ * otherwise just the institution label. Channel-less KES M-Pesa recipients get
+ * the generic `M-PESA` label — never a channel name, even against an expanded list.
+ */
+export function formatRecipientInstitutionDisplay(
+  institutionCode: string,
+  supportedInstitutions: InstitutionProps[],
+  options?: {
+    currency?: string;
+    channel?: KesMpesaChannel | "" | null;
+    accountIdentifier?: string;
+    businessNumber?: string | null;
+  },
+): string {
+  const channel = options?.channel;
+  const isKesMpesa =
+    (options?.currency ?? "").toUpperCase() === "KES" &&
+    institutionCode === KES_MPESA_INSTITUTION_CODE;
+
+  if (isKesMpesa && options?.accountIdentifier !== undefined) {
+    return formatKesMpesaAccountDisplay(
+      options.accountIdentifier,
+      channel,
+      options.businessNumber,
+    );
+  }
+
+  if (isKesMpesa) {
+    return getKesMpesaInstitutionLabel(channel);
+  }
+
+  const institutionName =
+    getInstitutionNameByCode(institutionCode, supportedInstitutions) ??
+    institutionCode;
+  return options?.accountIdentifier !== undefined
+    ? `${options.accountIdentifier} • ${institutionName}`
+    : institutionName;
 }
 
 /**
@@ -187,27 +310,29 @@ export const getCurrencySymbol = (currency: string): string => {
 
 /**
  * Off-ramp account/phone field placeholder. Banks use a generic label; mobile money
- * uses a country-appropriate example. All mobile-money values share an "eg: " prefix
- * (no leading space before the label) so the placeholder is aligned in the input.
+ * uses a country-appropriate example. KES is channel-aware for M-Pesa Send Money / Till / Paybill.
  * Examples use local-style numbers only (no international country calling prefix).
  */
 export function getOfframpAccountIdentifierPlaceholder(
   currency: string,
   institutionType: "bank" | "mobile_money" | undefined,
+  channel?: KesMpesaChannel | "" | null,
 ): string {
   if (institutionType !== "mobile_money") {
     return "Account number";
   }
+  if (currency.toUpperCase() === "KES") {
+    if (channel === "Till") return "Till number (5–7 digits)";
+    if (channel === "Paybill") return "Account / reference";
+    return "07XXXXXXXX";
+  }
   const examples: Record<string, string> = {
-    KES: "07XXXXXXXX",
     NGN: "08XXXXXXXX",
     UGX: "07XXXXXXXX",
     TZS: "07XXXXXXXX",
     GHS: "0XXXXXXXXX",
   };
-  return (
-    examples[currency.toUpperCase()] ?? "eg: phone number"
-  );
+  return examples[currency.toUpperCase()] ?? "eg: phone number";
 }
 
 /** Fiat codes supported in Noblocks swap (matches `mocks.acceptedCurrencies` names). */

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,7 +16,7 @@ This document lists all environment variables used by the Noblocks application. 
    - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard
    - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
 
-   `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` is optional for local UI exploration; set it when you need live order creation against the aggregator.
+   `AGGREGATOR_SENDER_API_KEY_ID` (server-only — never `NEXT_PUBLIC_`) is optional for local UI exploration; set it when you need live order creation against the aggregator.
 
 ## Variable Reference
 
@@ -25,10 +25,6 @@ This document lists all environment variables used by the Noblocks application. 
 ```bash
 # Aggregator API base URL
 NEXT_PUBLIC_AGGREGATOR_URL=https://api.paycrest.io/v1
-
-# Optional: Sender API key UUID (aggregator dashboard). Required for live order creation;
-# used by the payment-orders proxy and client for encrypted gateway.createOrder messageHash.
-NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID=
 
 # KYC tier monthly swap limits (USD). Omitted or empty = use defaults below.
 # Tier 3 also accepts "unlimited" (case-insensitive) to remove cap.
@@ -149,6 +145,12 @@ NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=false          # Send events from local dev whe
 # Secret for internal API endpoints
 # Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=
+
+# Server-only: Sender API key UUID (aggregator dashboard). Used by the
+# /api/v1/payment-orders* routes (API-Key header + encrypted offramp messageHash).
+# Never NEXT_PUBLIC_ — it must not reach the browser. Rotate it in the aggregator
+# dashboard if it was ever exposed in a client bundle.
+AGGREGATOR_SENDER_API_KEY_ID=
 ```
 
 ### Injected-Wallet Session Auth (SIWE)
@@ -388,6 +390,7 @@ NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 4. **Wallet Private Keys**: `CASHBACK_WALLET_PRIVATE_KEY`, `SPONSOR_EVM_WALLET_PRIVATE_KEY` control funds — use vaulted secrets in CI/CD
 5. **Internal API Key**: All internal endpoints require this — generate randomly and rotate periodically
 6. **SmileID/Dojah**: Treat as any third-party API credential — never commit raw values
+7. **Aggregator Sender API Key**: `AGGREGATOR_SENDER_API_KEY_ID` is server-only — never prefix it `NEXT_PUBLIC_`. It is both the aggregator `API-Key` credential and the value that attributes on-chain orders to our sender profile; if it was ever exposed in a client bundle, rotate it in the aggregator dashboard
 
 ## Related Documentation
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -16,6 +16,16 @@ export async function register() {
   // Skipped on the Edge runtime (middleware): dd-trace is a Node library and
   // importing it there breaks the Edge bundle.
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Non-fatal: the key is read lazily at request time (app/lib/server-config.ts),
+  // so a missing value surfaces as 503s on offramp order creation and the
+  // sender API proxies rather than a failed boot. Warn here so it is visible in
+  // container logs at deploy.
+  if (!process.env.AGGREGATOR_SENDER_API_KEY_ID?.trim()) {
+    console.warn(
+      "[startup] AGGREGATOR_SENDER_API_KEY_ID is not set — offramp order creation and /api/v1/payment-orders* will return 503",
+    );
+  }
   // Read once, here, at process startup — flipping this on a running
   // container has no effect until it restarts.
   if (process.env.DD_TRACE_ENABLED === "false") return;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -88,7 +88,7 @@ const nextConfig = {
   // "can't be external" version skew when https-proxy-agent was listed here).
   // dd-trace ships native addons and patches modules at require time, and pino
   // resolves transports through worker threads — bundling either breaks them.
-  serverExternalPackages: ["mixpanel", "twilio", "dd-trace", "pino"],
+  serverExternalPackages: ["mixpanel", "twilio", "dd-trace", "pino", "@hyperbridge/sdk"],
   webpack: (config, { isServer }) => {
     // Handle both client and server-side fallbacks
     config.resolve.fallback = {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "hugeicons-react": "^0.3.0",
     "jose": "^6.0.11",
     "js-cookie": "^3.0.5",
-    "jsencrypt": "^3.3.2",
     "jsonwebtoken": "^9.0.2",
     "libphonenumber-js": "^1.12.42",
     "lottie-react": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@hotjar/browser": "^1.0.9",
     "@hpke/chacha20poly1305": "^1.6.2",
     "@hpke/core": "^1.9.0",
+    "@hyperbridge/sdk": "^2.8.4",
     "@portabletext/react": "^3.2.1",
     "@portabletext/types": "^2.0.13",
     "@privy-io/react-auth": "^3.22.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hotjar/browser": "^1.0.9",
     "@hpke/chacha20poly1305": "^1.6.2",
     "@hpke/core": "^1.9.0",
-    "@hyperbridge/sdk": "^2.8.4",
+    "@hyperbridge/sdk": "^2.8.8",
     "@portabletext/react": "^3.2.1",
     "@portabletext/types": "^2.0.13",
     "@privy-io/react-auth": "^3.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
-      jsencrypt:
-        specifier: ^3.3.2
-        version: 3.3.2
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -7706,9 +7703,6 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
-
-  jsencrypt@3.3.2:
-    resolution: {integrity: sha512-arQR1R1ESGdAxY7ZheWr12wCaF2yF47v5qpB76TtV64H1pyGudk9Hvw8Y9tb/FiTIaaTRUyaSnm5T/Y53Ghm/A==}
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -21561,8 +21555,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  jsencrypt@3.3.2: {}
 
   jsesc@3.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@hpke/core':
         specifier: ^1.7.5
         version: 1.9.0
+      '@hyperbridge/sdk':
+        specifier: ^2.8.4
+        version: 2.8.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)
       '@portabletext/react':
         specifier: ^3.2.1
         version: 3.2.1(react@19.2.1)
@@ -362,6 +365,12 @@ packages:
 
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
+
+  '@async-generator/merge-race@1.0.3':
+    resolution: {integrity: sha512-6bbKfLJoRpMdqWhR8MuoSdgtqXZ0S1MnPv21QRi1BefOPBNCJJZJikk3U9LhZVEw9RuqIwd56AuLroTC+EeFgQ==}
+
+  '@async-generator/subject@1.0.3':
+    resolution: {integrity: sha512-8aa17UMPPmhSEGcsjsoo7GqJvgw6L8um+8YQPeKYxK/zEZdSh1Mep/QoOo4/3sAYzFBtTwDSoib7J15SZAqfwg==}
 
   '@avnu/avnu-sdk@4.1.0-rc.0':
     resolution: {integrity: sha512-f/y2898hzhjXpPk5e2mxcyHbbbBwqq9EdJLtjku04BlgkZwk9qfviMBgRPw2oKGTbGu9nd+WSKI+rNBfLUSVCg==}
@@ -1005,6 +1014,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.27.6':
     resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
@@ -1855,6 +1868,11 @@ packages:
     peerDependencies:
       viem: '>=2.0.0'
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@hcaptcha/loader@2.3.0':
     resolution: {integrity: sha512-i4lnNxKBe+COf3R1nFZEWaZoHIoJjvDgWqvcNrdZq8ehoSNMN6KVZ56dcQ02qKie2h3+BkbkwlJA9DOIuLlK/g==}
 
@@ -1910,6 +1928,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@hyperbridge/sdk@2.8.4':
+    resolution: {integrity: sha512-SN6Iz0X5r/3llIA74BOT83zEjWABztwrcMCUeJDozVGCWlLRu2RqEJjzjzFuv94/cg/ejwSVp4ipz4jann2VfA==}
+    engines: {node: '>=22.x.x'}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2816,6 +2840,173 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@polkadot-api/json-rpc-provider-proxy@0.1.0':
+    resolution: {integrity: sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==}
+
+  '@polkadot-api/json-rpc-provider@0.0.1':
+    resolution: {integrity: sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==}
+
+  '@polkadot-api/metadata-builders@0.3.2':
+    resolution: {integrity: sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==}
+
+  '@polkadot-api/observable-client@0.3.2':
+    resolution: {integrity: sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==}
+    peerDependencies:
+      '@polkadot-api/substrate-client': 0.1.4
+      rxjs: '>=7.8.0'
+
+  '@polkadot-api/substrate-bindings@0.6.0':
+    resolution: {integrity: sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==}
+
+  '@polkadot-api/substrate-client@0.1.4':
+    resolution: {integrity: sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==}
+
+  '@polkadot-api/utils@0.1.0':
+    resolution: {integrity: sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==}
+
+  '@polkadot/api-augment@16.5.6':
+    resolution: {integrity: sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api-base@16.5.6':
+    resolution: {integrity: sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api-derive@16.5.6':
+    resolution: {integrity: sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api@16.5.6':
+    resolution: {integrity: sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==}
+    engines: {node: '>=18'}
+
+  '@polkadot/keyring@14.0.3':
+    resolution: {integrity: sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3
+
+  '@polkadot/networks@14.0.3':
+    resolution: {integrity: sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/rpc-augment@16.5.6':
+    resolution: {integrity: sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/rpc-core@16.5.6':
+    resolution: {integrity: sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/rpc-provider@16.5.6':
+    resolution: {integrity: sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types-augment@16.5.6':
+    resolution: {integrity: sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types-codec@16.5.6':
+    resolution: {integrity: sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types-create@16.5.6':
+    resolution: {integrity: sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types-known@16.5.6':
+    resolution: {integrity: sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types-support@16.5.6':
+    resolution: {integrity: sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/types@16.5.6':
+    resolution: {integrity: sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/util-crypto@14.0.3':
+    resolution: {integrity: sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 14.0.3
+
+  '@polkadot/util@14.0.3':
+    resolution: {integrity: sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/wasm-bridge@7.5.4':
+    resolution: {integrity: sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-crypto-asmjs@7.5.4':
+    resolution: {integrity: sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/wasm-crypto-init@7.5.4':
+    resolution: {integrity: sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-crypto-wasm@7.5.4':
+    resolution: {integrity: sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/wasm-crypto@7.5.4':
+    resolution: {integrity: sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-util@7.5.4':
+    resolution: {integrity: sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/x-bigint@14.0.3':
+    resolution: {integrity: sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-fetch@14.0.3':
+    resolution: {integrity: sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-global@14.0.3':
+    resolution: {integrity: sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-randomvalues@14.0.3':
+    resolution: {integrity: sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-util': '*'
+
+  '@polkadot/x-textdecoder@14.0.3':
+    resolution: {integrity: sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-textencoder@14.0.3':
+    resolution: {integrity: sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-ws@14.0.3':
+    resolution: {integrity: sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==}
+    engines: {node: '>=18'}
+
   '@portabletext/block-tools@3.2.1':
     resolution: {integrity: sha512-ExtvQC5Z63QevruxS9GDidqP1whUTgWDlx314TNu5pYNcF986r2IatoVuB9y6MrXw8XzQvCnjIFgSlGWnCS/XQ==}
     peerDependencies:
@@ -3544,6 +3735,9 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@scure/sr25519@0.2.0':
+    resolution: {integrity: sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==}
+
   '@scure/starknet@1.1.0':
     resolution: {integrity: sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==}
 
@@ -4016,6 +4210,24 @@ packages:
   '@starknet-io/types-js@0.9.2':
     resolution: {integrity: sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==}
 
+  '@substrate/connect-extension-protocol@2.2.2':
+    resolution: {integrity: sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==}
+
+  '@substrate/connect-known-chains@1.10.3':
+    resolution: {integrity: sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==}
+
+  '@substrate/connect@0.8.11':
+    resolution: {integrity: sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==}
+    deprecated: versions below 1.x are no longer maintained
+
+  '@substrate/light-client-extension-helpers@1.0.0':
+    resolution: {integrity: sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==}
+    peerDependencies:
+      smoldot: 2.x
+
+  '@substrate/ss58-registry@1.51.0':
+    resolution: {integrity: sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==}
+
   '@supabase/auth-js@2.70.0':
     resolution: {integrity: sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==}
 
@@ -4135,6 +4347,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bn.js@5.2.0':
+    resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
+
   '@types/canvas-confetti@1.9.0':
     resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
 
@@ -4188,6 +4403,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
@@ -4976,6 +5194,9 @@ packages:
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -5073,6 +5294,9 @@ packages:
 
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
+  bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
 
   bin-links@6.0.0:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
@@ -5299,6 +5523,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -5475,6 +5703,10 @@ packages:
   configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-table-printer@2.14.6:
     resolution: {integrity: sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==}
@@ -6218,6 +6450,10 @@ packages:
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
+  ethers@6.13.5:
+    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
+    engines: {node: '>=14.0.0'}
+
   ethers@6.16.0:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
@@ -6660,6 +6896,9 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -6669,6 +6908,11 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql-request@7.4.0:
+    resolution: {integrity: sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==}
+    peerDependencies:
+      graphql: 14 - 16
 
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
@@ -7735,6 +7979,10 @@ packages:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -7916,6 +8164,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mock-socket@9.3.1:
+    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
+    engines: {node: '>= 8'}
+
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
 
@@ -8031,6 +8283,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  nock@13.5.6:
+    resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
+    engines: {node: '>= 10.13'}
 
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
@@ -8167,6 +8423,9 @@ packages:
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
 
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
 
@@ -8227,6 +8486,14 @@ packages:
 
   ox@0.14.27:
     resolution: {integrity: sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.7:
+    resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -8340,6 +8607,14 @@ packages:
   p-queue@2.4.2:
     resolution: {integrity: sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==}
     engines: {node: '>=4'}
+
+  p-queue@8.1.1:
+    resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
+    engines: {node: '>=18'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -8748,6 +9023,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -8971,6 +9250,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
+    engines: {node: '>= 20.19.0'}
+
   real-require@0.1.0:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
@@ -9005,6 +9288,9 @@ packages:
 
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -9107,6 +9393,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rpc-websocket-client@1.1.4:
+    resolution: {integrity: sha512-UDMVcsNDJ3WET+0EFdmseYX+60MOCA3BpgpZ5dbtiGsqHo+9uWfgNbPZ4iGDtNcX+EUhCt/Y7C0fTmUU3CkkWA==}
+    engines: {node: '>=6.0.0'}
+
   rpc-websockets@9.1.1:
     resolution: {integrity: sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==}
 
@@ -9190,6 +9480,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scale-ts@1.6.1:
+    resolution: {integrity: sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==}
+
   scheduler@0.25.0-rc-603e6108-20241029:
     resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
@@ -9222,6 +9515,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.2:
@@ -9361,6 +9659,9 @@ packages:
     resolution: {integrity: sha512-ZTIhHEJQS40ubqB3gbSLS098TuH2loXXiLyDJLM5DQNtMJb8E6K+HEGn2ZRn5GKm0CKIZK35cArNTfiM1BACOQ==}
     engines: {node: '>=v12.0.0'}
 
+  smoldot@2.0.26:
+    resolution: {integrity: sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==}
+
   socket.io-client@4.8.3:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
@@ -9489,6 +9790,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -9838,6 +10142,9 @@ packages:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
 
+  tronweb@6.4.0:
+    resolution: {integrity: sha512-WyrjHKN6YSnV/Dvc4cdULDyXVKJfj4bqQ/8dib6FlOaQ1T/EiOjLtOx24hDgcn8lY/iVMy4Axchzurk1wGcRJg==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -9855,6 +10162,9 @@ packages:
 
   ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -10114,6 +10424,68 @@ packages:
       uploadthing:
         optional: true
 
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
@@ -10245,6 +10617,10 @@ packages:
   validate.js@0.13.1:
     resolution: {integrity: sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g==}
 
+  validator@13.15.23:
+    resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
+    engines: {node: '>= 0.10'}
+
   valtio@1.13.2:
     resolution: {integrity: sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==}
     engines: {node: '>=12.20.0'}
@@ -10299,6 +10675,14 @@ packages:
 
   viem@2.38.0:
     resolution: {integrity: sha512-YU5TG8dgBNeYPrCMww0u9/JVeq2ZCk9fzk6QybrPkBooFysamHXL1zC3ua10aLPt9iWoA/gSVf1D9w7nc5B1aA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.47.6:
+    resolution: {integrity: sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -10873,6 +11257,12 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
+
+  '@async-generator/merge-race@1.0.3':
+    dependencies:
+      '@async-generator/subject': 1.0.3
+
+  '@async-generator/subject@1.0.3': {}
 
   '@avnu/avnu-sdk@4.1.0-rc.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(starknet@9.4.2(typescript@5.8.3)(zod@3.25.76))':
     dependencies:
@@ -11681,6 +12071,10 @@ snapshots:
       make-dir: 2.1.0
       pirates: 4.0.7
       source-map-support: 0.5.21
+
+  '@babel/runtime@7.26.10':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.27.6': {}
 
@@ -12504,6 +12898,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
+    dependencies:
+      graphql: 16.12.0
+
   '@hcaptcha/loader@2.3.0': {}
 
   '@hcaptcha/react-hcaptcha@1.17.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
@@ -12552,6 +12950,55 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@hyperbridge/sdk@2.8.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)':
+    dependencies:
+      '@async-generator/merge-race': 1.0.3
+      '@polkadot/api': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      '@types/lodash-es': 4.17.12
+      consola: 3.4.2
+      decimal.js: 10.6.0
+      graphql: 16.12.0
+      graphql-request: 7.4.0(graphql@16.12.0)
+      idb-keyval: 6.2.2
+      lodash-es: 4.18.1
+      p-queue: 8.1.1
+      rpc-websocket-client: 1.1.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      scale-ts: 1.6.1
+      std-env: 3.10.0
+      tronweb: 6.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ts-pattern: 5.9.0
+      unstorage: 1.17.5(idb-keyval@6.2.2)
+      viem: 2.47.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      vite: 7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - ioredis
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
 
   '@img/colour@1.0.0':
     optional: true
@@ -13138,7 +13585,7 @@ snapshots:
 
   '@metamask/sdk@0.33.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.7
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
       '@metamask/sdk-analytics': 0.0.5
@@ -13561,6 +14008,322 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@polkadot-api/json-rpc-provider-proxy@0.1.0':
+    optional: true
+
+  '@polkadot-api/json-rpc-provider@0.0.1':
+    optional: true
+
+  '@polkadot-api/metadata-builders@0.3.2':
+    dependencies:
+      '@polkadot-api/substrate-bindings': 0.6.0
+      '@polkadot-api/utils': 0.1.0
+    optional: true
+
+  '@polkadot-api/observable-client@0.3.2(@polkadot-api/substrate-client@0.1.4)(rxjs@7.8.2)':
+    dependencies:
+      '@polkadot-api/metadata-builders': 0.3.2
+      '@polkadot-api/substrate-bindings': 0.6.0
+      '@polkadot-api/substrate-client': 0.1.4
+      '@polkadot-api/utils': 0.1.0
+      rxjs: 7.8.2
+    optional: true
+
+  '@polkadot-api/substrate-bindings@0.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@polkadot-api/utils': 0.1.0
+      '@scure/base': 1.2.6
+      scale-ts: 1.6.1
+    optional: true
+
+  '@polkadot-api/substrate-client@0.1.4':
+    dependencies:
+      '@polkadot-api/json-rpc-provider': 0.0.1
+      '@polkadot-api/utils': 0.1.0
+    optional: true
+
+  '@polkadot-api/utils@0.1.0':
+    optional: true
+
+  '@polkadot/api-augment@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/api-base': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/rpc-augment': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-augment': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/api-base@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/rpc-core': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/util': 14.0.3
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/api-derive@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/api': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/api-augment': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/api-base': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/rpc-core': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/api@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/api-augment': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/api-base': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/api-derive': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/keyring': 14.0.3(@polkadot/util-crypto@14.0.3(@polkadot/util@14.0.3))(@polkadot/util@14.0.3)
+      '@polkadot/rpc-augment': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/rpc-core': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/rpc-provider': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-augment': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/types-create': 16.5.6
+      '@polkadot/types-known': 16.5.6
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      eventemitter3: 5.0.1
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/keyring@14.0.3(@polkadot/util-crypto@14.0.3(@polkadot/util@14.0.3))(@polkadot/util@14.0.3)':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      tslib: 2.8.1
+
+  '@polkadot/networks@14.0.3':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@substrate/ss58-registry': 1.51.0
+      tslib: 2.8.1
+
+  '@polkadot/rpc-augment@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/rpc-core': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/rpc-core@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/rpc-augment': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/rpc-provider': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@polkadot/types': 16.5.6
+      '@polkadot/util': 14.0.3
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/rpc-provider@16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/keyring': 14.0.3(@polkadot/util-crypto@14.0.3(@polkadot/util@14.0.3))(@polkadot/util@14.0.3)
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-support': 16.5.6
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      '@polkadot/x-fetch': 14.0.3
+      '@polkadot/x-global': 14.0.3
+      '@polkadot/x-ws': 14.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      eventemitter3: 5.0.1
+      mock-socket: 9.3.1
+      nock: 13.5.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@substrate/connect': 0.8.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot/types-augment@16.5.6':
+    dependencies:
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/types-codec@16.5.6':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/x-bigint': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/types-create@16.5.6':
+    dependencies:
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/types-known@16.5.6':
+    dependencies:
+      '@polkadot/networks': 14.0.3
+      '@polkadot/types': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/types-create': 16.5.6
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/types-support@16.5.6':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/types@16.5.6':
+    dependencies:
+      '@polkadot/keyring': 14.0.3(@polkadot/util-crypto@14.0.3(@polkadot/util@14.0.3))(@polkadot/util@14.0.3)
+      '@polkadot/types-augment': 16.5.6
+      '@polkadot/types-codec': 16.5.6
+      '@polkadot/types-create': 16.5.6
+      '@polkadot/util': 14.0.3
+      '@polkadot/util-crypto': 14.0.3(@polkadot/util@14.0.3)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@polkadot/util-crypto@14.0.3(@polkadot/util@14.0.3)':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@polkadot/networks': 14.0.3
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-crypto': 7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/x-bigint': 14.0.3
+      '@polkadot/x-randomvalues': 14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3))
+      '@scure/base': 1.2.6
+      '@scure/sr25519': 0.2.0
+      tslib: 2.8.1
+
+  '@polkadot/util@14.0.3':
+    dependencies:
+      '@polkadot/x-bigint': 14.0.3
+      '@polkadot/x-global': 14.0.3
+      '@polkadot/x-textdecoder': 14.0.3
+      '@polkadot/x-textencoder': 14.0.3
+      '@types/bn.js': 5.2.0
+      bn.js: 5.2.3
+      tslib: 2.8.1
+
+  '@polkadot/wasm-bridge@7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/x-randomvalues': 14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-asmjs@7.5.4(@polkadot/util@14.0.3)':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-init@7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-bridge': 7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))
+      '@polkadot/wasm-crypto-asmjs': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/wasm-crypto-wasm': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/x-randomvalues': 14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-wasm@7.5.4(@polkadot/util@14.0.3)':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto@7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-bridge': 7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))
+      '@polkadot/wasm-crypto-asmjs': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/wasm-crypto-init': 7.5.4(@polkadot/util@14.0.3)(@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)))
+      '@polkadot/wasm-crypto-wasm': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/x-randomvalues': 14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3)':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/x-bigint@14.0.3':
+    dependencies:
+      '@polkadot/x-global': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/x-fetch@14.0.3':
+    dependencies:
+      '@polkadot/x-global': 14.0.3
+      node-fetch: 3.3.2
+      tslib: 2.8.1
+
+  '@polkadot/x-global@14.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@polkadot/x-randomvalues@14.0.3(@polkadot/util@14.0.3)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.3))':
+    dependencies:
+      '@polkadot/util': 14.0.3
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@14.0.3)
+      '@polkadot/x-global': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/x-textdecoder@14.0.3':
+    dependencies:
+      '@polkadot/x-global': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/x-textencoder@14.0.3':
+    dependencies:
+      '@polkadot/x-global': 14.0.3
+      tslib: 2.8.1
+
+  '@polkadot/x-ws@14.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@polkadot/x-global': 14.0.3
+      tslib: 2.8.1
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@portabletext/block-tools@3.2.1(@sanity/schema@4.4.1(@types/react@19.0.8)(debug@4.4.1))(@sanity/types@4.4.1(@types/react@19.0.8))(@types/react@19.0.8)':
     dependencies:
@@ -15176,6 +15939,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/sr25519@0.2.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+
   '@scure/starknet@1.1.0':
     dependencies:
       '@noble/curves': 1.7.0
@@ -15752,6 +16520,37 @@ snapshots:
 
   '@starknet-io/types-js@0.9.2': {}
 
+  '@substrate/connect-extension-protocol@2.2.2':
+    optional: true
+
+  '@substrate/connect-known-chains@1.10.3':
+    optional: true
+
+  '@substrate/connect@0.8.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@substrate/connect-extension-protocol': 2.2.2
+      '@substrate/connect-known-chains': 1.10.3
+      '@substrate/light-client-extension-helpers': 1.0.0(smoldot@2.0.26(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      smoldot: 2.0.26(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@substrate/light-client-extension-helpers@1.0.0(smoldot@2.0.26(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@polkadot-api/json-rpc-provider': 0.0.1
+      '@polkadot-api/json-rpc-provider-proxy': 0.1.0
+      '@polkadot-api/observable-client': 0.3.2(@polkadot-api/substrate-client@0.1.4)(rxjs@7.8.2)
+      '@polkadot-api/substrate-client': 0.1.4
+      '@substrate/connect-extension-protocol': 2.2.2
+      '@substrate/connect-known-chains': 1.10.3
+      rxjs: 7.8.2
+      smoldot: 2.0.26(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optional: true
+
+  '@substrate/ss58-registry@1.51.0': {}
+
   '@supabase/auth-js@2.70.0':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -15909,6 +16708,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
+  '@types/bn.js@5.2.0':
+    dependencies:
+      '@types/node': 22.15.31
+
   '@types/canvas-confetti@1.9.0': {}
 
   '@types/connect@3.4.38':
@@ -15965,6 +16768,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.24
 
   '@types/lodash@4.17.24': {}
 
@@ -17611,6 +18418,16 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.18.0:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.1)
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   b4a@1.6.7: {}
@@ -17735,6 +18552,8 @@ snapshots:
       require-from-string: 2.0.2
 
   big.js@6.2.2: {}
+
+  bignumber.js@9.1.2: {}
 
   bin-links@6.0.0:
     dependencies:
@@ -17969,6 +18788,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.1.1
+
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
@@ -18127,6 +18950,8 @@ snapshots:
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
+
+  consola@3.4.2: {}
 
   console-table-printer@2.14.6:
     dependencies:
@@ -19169,6 +19994,19 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
+  ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
@@ -19670,11 +20508,18 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-protobuf@3.21.4: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql-request@7.4.0(graphql@16.12.0):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
+      graphql: 16.12.0
 
   graphql@16.12.0: {}
 
@@ -21004,6 +21849,8 @@ snapshots:
 
   lru-cache@11.1.0: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -21182,6 +22029,8 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mock-socket@9.3.1: {}
+
   module-alias@2.2.3: {}
 
   module-details-from-path@1.0.4: {}
@@ -21308,6 +22157,14 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nock@13.5.6:
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   node-addon-api@2.0.2: {}
 
@@ -21449,6 +22306,12 @@ snapshots:
       node-fetch-native: 1.6.7
       ufo: 1.6.4
 
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
   on-exit-leak-free@0.2.0: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -21540,6 +22403,21 @@ snapshots:
       - zod
 
   ox@0.14.27(typescript@5.8.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.8.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.7(typescript@5.8.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -21736,6 +22614,13 @@ snapshots:
   p-map@7.0.3: {}
 
   p-queue@2.4.2: {}
+
+  p-queue@8.1.1:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
+
+  p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
 
@@ -22084,6 +22969,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  propagate@2.0.1: {}
+
   property-information@7.1.0: {}
 
   proxy-compare@2.6.0: {}
@@ -22312,6 +23199,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readdirp@5.1.1: {}
+
   real-require@0.1.0: {}
 
   real-require@0.2.0: {}
@@ -22352,6 +23241,8 @@ snapshots:
       regenerate: 1.4.2
 
   regenerate@1.4.2: {}
+
+  regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -22474,6 +23365,15 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
+
+  rpc-websocket-client@1.1.4(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      uuid: 14.0.0
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   rpc-websockets@9.1.1:
     dependencies:
@@ -22733,6 +23633,8 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  scale-ts@1.6.1: {}
+
   scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.27.0: {}
@@ -22756,6 +23658,8 @@ snapshots:
   semver@5.7.2: {}
 
   semver@6.3.1: {}
+
+  semver@7.7.1: {}
 
   semver@7.7.2: {}
 
@@ -22943,6 +23847,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  smoldot@2.0.26(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
   socket.io-client@4.8.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -23068,6 +23980,8 @@ snapshots:
       - zod
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -23493,6 +24407,23 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
+  tronweb@6.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/runtime': 7.26.10
+      axios: 1.18.0
+      bignumber.js: 9.1.2
+      ethereum-cryptography: 2.2.1
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      eventemitter3: 5.0.1
+      google-protobuf: 3.21.4
+      semver: 7.7.1
+      validator: 13.15.23
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
@@ -23504,6 +24435,8 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   ts-mixer@6.0.4: {}
+
+  ts-pattern@5.9.0: {}
 
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:
@@ -23742,6 +24675,19 @@ snapshots:
     optionalDependencies:
       idb-keyval: 6.2.2
 
+  unstorage@1.17.5(idb-keyval@6.2.2):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      idb-keyval: 6.2.2
+
   until-async@3.0.2: {}
 
   untildify@4.0.0: {}
@@ -23857,6 +24803,8 @@ snapshots:
 
   validate.js@0.13.1: {}
 
+  validator@13.15.23: {}
+
   valtio@1.13.2(@types/react@19.0.8)(react@19.2.1):
     dependencies:
       derive-valtio: 0.1.0(valtio@1.13.2(@types/react@19.0.8)(react@19.2.1))
@@ -23939,6 +24887,23 @@ snapshots:
       abitype: 1.1.0(typescript@5.8.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.9.6(typescript@5.8.3)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.47.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.14.7(typescript@5.8.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.7.5
         version: 1.9.0
       '@hyperbridge/sdk':
-        specifier: ^2.8.4
-        version: 2.8.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)
+        specifier: ^2.8.8
+        version: 2.8.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)
       '@portabletext/react':
         specifier: ^3.2.1
         version: 3.2.1(react@19.2.1)
@@ -1929,8 +1929,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@hyperbridge/sdk@2.8.4':
-    resolution: {integrity: sha512-SN6Iz0X5r/3llIA74BOT83zEjWABztwrcMCUeJDozVGCWlLRu2RqEJjzjzFuv94/cg/ejwSVp4ipz4jann2VfA==}
+  '@hyperbridge/sdk@2.8.8':
+    resolution: {integrity: sha512-cGssN1c7JRRiSiRjSYzke/13I64ceFZG1jZXkShCrCwKYVkmoPB5e4XLO2BJ6S9UHRtjEBNYbz4j3xNczCSG2w==}
     engines: {node: '>=22.x.x'}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
@@ -12951,7 +12951,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@hyperbridge/sdk@2.8.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)':
+  '@hyperbridge/sdk@2.8.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.3.2(@types/node@22.15.31)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.3))(zod@3.25.76)':
     dependencies:
       '@async-generator/merge-race': 1.0.3
       '@polkadot/api': 16.5.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -16301,7 +16301,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.8.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.8.3)
       '@solana/subscribable': 5.5.1(typescript@5.8.3)
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -18126,11 +18126,6 @@ snapshots:
       typescript: 5.8.3
       zod: 3.25.76
 
-  abitype@1.1.0(typescript@5.8.3)(zod@4.4.3):
-    optionalDependencies:
-      typescript: 5.8.3
-      zod: 4.4.3
-
   abitype@1.2.3(typescript@5.8.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.8.3
@@ -18150,6 +18145,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
       zod: 3.25.76
+
+  abitype@1.2.4(typescript@5.8.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.8.3
+      zod: 4.4.3
 
   abort-controller@3.0.0:
     dependencies:
@@ -21555,7 +21555,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -22527,7 +22527,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.8.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@5.8.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -22542,7 +22542,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.8.3)(zod@4.4.3)
+      abitype: 1.2.4(typescript@5.8.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -22686,7 +22686,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.5.2
       minipass: 7.1.2
 
   path-sort@0.1.0: {}
@@ -23055,7 +23055,7 @@ snapshots:
 
   react-clientside-effect@1.2.8(react@19.2.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.7
       react: 19.2.1
 
   react-compiler-runtime@19.1.0-rc.2(react@19.2.1):
@@ -24670,7 +24670,7 @@ snapshots:
       h3: 1.15.11
       lru-cache: 10.4.3
       node-fetch-native: 1.6.7
-      ofetch: 1.4.1
+      ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
       idb-keyval: 6.2.2

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,8 @@
 // Bump BOTH versions on any deploy that changes build-time config (e.g. a
 // NEXT_PUBLIC_* key). The activate handler below purges every cache that does
 // not match, which is the only thing that evicts a stale precached shell.
-const CACHE_NAME = 'noblocks-pwa-v4';
-const RUNTIME_CACHE = 'noblocks-runtime-v4';
+const CACHE_NAME = 'noblocks-pwa-v5';
+const RUNTIME_CACHE = 'noblocks-runtime-v5';
 const OFFLINE_URL = '/offline.html';
 
 // Static assets to cache immediately

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,8 @@
-const CACHE_NAME = 'noblocks-pwa-v3';
-const RUNTIME_CACHE = 'noblocks-runtime-v3';
+// Bump BOTH versions on any deploy that changes build-time config (e.g. a
+// NEXT_PUBLIC_* key). The activate handler below purges every cache that does
+// not match, which is the only thing that evicts a stale precached shell.
+const CACHE_NAME = 'noblocks-pwa-v4';
+const RUNTIME_CACHE = 'noblocks-runtime-v4';
 const OFFLINE_URL = '/offline.html';
 
 // Static assets to cache immediately

--- a/supabase/migrations/20260818143000_restore_bridge_transaction_type.sql
+++ b/supabase/migrations/20260818143000_restore_bridge_transaction_type.sql
@@ -1,0 +1,8 @@
+-- Restore 'bridge' omitted when 'credit' was added (20260727130000).
+
+ALTER TABLE transactions
+  DROP CONSTRAINT IF EXISTS transactions_transaction_type_check;
+
+ALTER TABLE transactions
+  ADD CONSTRAINT transactions_transaction_type_check
+  CHECK (transaction_type IN ('onramp', 'offramp', 'transfer', 'bridge', 'swap', 'credit'));

--- a/supabase/migrations/20260903120000_saved_recipients_kes_channel.sql
+++ b/supabase/migrations/20260903120000_saved_recipients_kes_channel.sql
@@ -1,0 +1,28 @@
+-- Add KES M-Pesa channel + Paybill business number to saved recipients.
+-- The unique key includes both, so Send Money / Till / Paybill can share SAFAKEPC with
+-- the same identifier, and two Paybills can share a reference under different businesses
+-- (e.g. "INV-001" billed by 400200 and by 888880) without collapsing into one recipient.
+
+alter table public.saved_recipients
+  add column if not exists channel text not null default '',
+  add column if not exists business_number text not null default '';
+
+-- business_number must never be NULL: Postgres treats NULLs as distinct in a unique
+-- constraint, so nullable values here would stop every non-Paybill recipient from
+-- deduping. Normalize in case an earlier revision of this migration added it nullable.
+update public.saved_recipients
+  set business_number = ''
+  where business_number is null;
+
+alter table public.saved_recipients
+  alter column business_number set default '',
+  alter column business_number set not null;
+
+alter table public.saved_recipients
+  drop constraint if exists unique_wallet_recipient;
+
+drop index if exists unique_wallet_recipient_with_channel;
+
+alter table public.saved_recipients
+  add constraint unique_wallet_recipient
+  unique (normalized_wallet_address, institution_code, account_identifier, channel, business_number);


### PR DESCRIPTION
Production release: `main` → `stable`. 14 PRs since #688.

> ## ⚠️ Read before deploying
>
> **1. `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` is renamed to `AGGREGATOR_SENDER_API_KEY_ID` (#696).** Set the new server-only variable on stable **before** this deploy. The old `NEXT_PUBLIC_` name is gone; if only it is set, the sender `API-Key` header is empty and **order creation fails**. Do not carry the value over under a `NEXT_PUBLIC_` prefix — the point of the change is that it must not reach the browser.
>
> **2. The key was readable from the client bundle.** It was inlined at build time, and the same value is the aggregator sender credential. **Rotate it in the aggregator dashboard**, then set the rotated value as `AGGREGATOR_SENDER_API_KEY_ID`.
>
> **3. Two migrations.** Both additive; see below.

## What ships

### Security / config

| PR | Change |
| --- | --- |
| #696 | KAN-790 — move the aggregator sender API key server-side (`AGGREGATOR_SENDER_API_KEY_ID`) |
| #695 | KAN-789 — bump the SW cache and reload stale PWA tabs on worker update |

#695 is the prerequisite for #696 landing safely: without the reload-on-update handler, a PWA tab running a pre-rotation precached shell keeps writing the old `metadata.apiKey` into the encrypted on-chain order payload, and the aggregator attributes the order to the previous sender profile. That is exactly what happened to two orders on 18 and 19 Aug after the 12 Aug rotation. `public/sw.js` goes `v3` → `v5` (both `CACHE_NAME` and `RUNTIME_CACHE`); the `activate` handler purging non-matching caches is the only thing that evicts a stale shell. They ship together here, in order.

### KES M-Pesa payouts

| PR | Change |
| --- | --- |
| #635 | KES M-Pesa channel foundations |
| #636 | User-facing M-Pesa payout channels (Send Money / Till / Paybill) |
| #637 | Persist KES M-Pesa details on saved recipients |
| #694 | Drop the dead `SAFAKEPC` exception from NUBAN validation |

The API still returns a single `SAFAKEPC` institution; the picker presents three virtual rails and carries the selection as channel metadata. Till is a 5–7 digit field with no phone formatting; Paybill adds a required business number. No API or contract changes.

### Convert / bridge engines (both ship dark)

| PR | Change |
| --- | --- |
| #680 | HyperFX — USDC/USDT↔cNGN on Base via Hyperbridge IntentGateway |
| #682 | Textile FX — USDT↔cNGN on BSC (56) and Celo (42220) |
| #693 | Bump `@hyperbridge/sdk` to 2.8.8 |

Both are gated behind flags that default to `false` and both require `NEXT_PUBLIC_BRIDGE_ENABLED=true`. With the flags off, Convert routing is unchanged.

### Correctness and instrumentation

| PR | Change |
| --- | --- |
| #689 | KAN-784 — quote the offramp token amount at token precision |
| #687 | Fix EVM wallet total calculations |
| #692 | KAN-786 — instrument the KYC flow for Datadog |
| #690 | Nigeria ID type validation + tests (SmileID) |
| #691 | Noblocks Play regression fixes (`PlayPromo`) |

**#689 is the money-facing one.** The Send leg was derived from the fiat Receive field with `.toFixed(4)`, and that token amount is deposited on-chain verbatim — the precision dropped at 4 decimals came off the recipient. Reported case: ₦50,000 at 1370.79 quoted `36.4753` USDC, paid back `₦49,999.98`. Systemic, not a one-off. Quoting now happens at token precision.

## Deployment notes

**Environment variables**

| Variable | Action | Notes |
| --- | --- | --- |
| `AGGREGATOR_SENDER_API_KEY_ID` | **Add — required** | Server-only. Replaces `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID`. Use a **rotated** key |
| `NEXT_PUBLIC_AGGREGATOR_SENDER_API_KEY_ID` | **Remove** | No longer read. Leaving it set exposes the key in the bundle for nothing |
| `NEXT_PUBLIC_TEXTILE_ENABLED` | Add, `false` | Textile FX RFQ |
| `TEXTILE_API_KEY` | Add if enabling Textile | Server-only |
| `NEXT_PUBLIC_HYPERFX_ENABLED` | Add, `false` | HyperFX on Base |
| `ALCHEMY_API_KEY` | Add if enabling HyperFX | Server-only ERC-4337 bundler |

> **Rotation has a second consumer.** The `reconcile-pending-orders` Supabase edge function already reads `AGGREGATOR_SENDER_API_KEY_ID` as a project secret (unchanged in this release). If you rotate the key, update that secret too — otherwise its onramp scan silently degrades to offramp-only with `onrampSkippedReason` set, rather than failing loudly.

**Migrations** — both additive, both safe to apply around the deploy:

- `20260818143000_restore_bridge_transaction_type.sql` — restores `'bridge'` to the `transactions_transaction_type_check` constraint, dropped by accident when `'credit'` was added in `20260727130000`. Verify `'bridge'` rows are writable after applying.
- `20260903120000_saved_recipients_kes_channel.sql` — adds `channel` and `business_number` (both `NOT NULL DEFAULT ''`) to `saved_recipients` and widens `unique_wallet_recipient` to include them. Existing rows normalize to `''`, so dedup behaviour for non-KES recipients is unchanged. Expand-safe: currently deployed code inserts without either column and gets the defaults.

**Dependencies** — `@hyperbridge/sdk` ^2.8.8 added; `jsencrypt` removed. `pnpm-lock.yaml` moves ~1,000 lines; a clean `pnpm install --frozen-lockfile` on the build host is worth confirming.

## Post-deploy checks

1. **Order creation first.** Create one onramp and one offramp order on stable. An empty `AGGREGATOR_SENDER_API_KEY_ID` fails here, and it is the failure that matters most.
2. **Sender attribution.** Confirm the new order is attributed to the correct (rotated) sender profile in the aggregator — this is the bug #695/#696 exist to close.
3. **PWA tabs.** Open a previously-installed PWA and confirm it reloads onto the new worker rather than serving the `v3` shell.
4. **Offramp precision (#689).** Quote a round fiat amount and confirm the deposited token amount carries full token precision and the payout lands on the requested figure, not two kobo short.
5. **KES rails.** Save a recipient on each of Send Money / Till / Paybill and confirm all three coexist under `SAFAKEPC` without collapsing into one row.
6. **Flags stay off.** Confirm `NEXT_PUBLIC_TEXTILE_ENABLED` and `NEXT_PUBLIC_HYPERFX_ENABLED` are `false` on stable unless the launch is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
