### PR TITLE
feat(recipients): collect the account name when verification can't resolve one

### DIFF
--- a/__tests__/kes-mpesa-channel.test.ts
+++ b/__tests__/kes-mpesa-channel.test.ts
@@ -4,6 +4,7 @@ import {
   formatKesMpesaAccountDisplay,
   formatRecipientInstitutionDisplay,
   isSameSavedRecipient,
+  isUnresolvedAccountName,
   normalizeSavedRecipientChannel,
   getKesMpesaInstitutionLabel,
   KES_MPESA_INSTITUTION_CODE,
@@ -170,5 +171,29 @@ describe("KES M-Pesa virtual institution split", () => {
     expect(
       isSameSavedRecipient(base, { ...base, businessNumber: null }),
     ).toBe(true);
+  });
+});
+
+describe("unresolved account names", () => {
+  it("treats the aggregator's OK sentinel as unresolved, in any casing", () => {
+    expect(isUnresolvedAccountName("OK")).toBe(true);
+    expect(isUnresolvedAccountName("ok")).toBe(true);
+    expect(isUnresolvedAccountName("Ok")).toBe(true);
+    expect(isUnresolvedAccountName("  OK  ")).toBe(true);
+  });
+
+  it("treats empty and missing names as unresolved", () => {
+    expect(isUnresolvedAccountName("")).toBe(true);
+    expect(isUnresolvedAccountName("   ")).toBe(true);
+    expect(isUnresolvedAccountName(undefined)).toBe(true);
+    expect(isUnresolvedAccountName(null)).toBe(true);
+  });
+
+  it("keeps real account names, including ones that merely contain 'ok'", () => {
+    expect(isUnresolvedAccountName("John Doe")).toBe(false);
+    expect(isUnresolvedAccountName("Okon Effiong")).toBe(false);
+    expect(isUnresolvedAccountName("Koko Stores")).toBe(false);
+    // A name that is only "ok" plus more text is a real name.
+    expect(isUnresolvedAccountName("OK Foods Ltd")).toBe(false);
   });
 });

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDown01Icon,
   Tick02Icon,
   InformationCircleIcon,
+  InformationSquareIcon,
 } from "hugeicons-react";
 import Image from "next/image";
 
@@ -15,7 +16,7 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, isSameSavedRecipient, NGN_NUBAN_LENGTH } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, isSameSavedRecipient, NGN_NUBAN_LENGTH, isUnresolvedAccountName } from "@/app/utils";
 import type { KesMpesaChannel } from "@/app/types";
 import {
   RecipientDetails,
@@ -32,6 +33,7 @@ import { validateWalletAddress } from "@/app/lib/validation";
 import { getNetworkImageUrl } from "@/app/utils";
 import { useActualTheme } from "@/app/hooks/useActualTheme";
 import { useNetwork } from "@/app/context";
+import { trackEvent } from "@/app/hooks/analytics/useMixpanel";
 import config from "@/app/lib/config";
 
 export const RecipientDetailsForm = ({
@@ -77,6 +79,15 @@ export const RecipientDetailsForm = ({
 
   const [isFetchingRecipientName, setIsFetchingRecipientName] = useState(false);
   const [recipientNameError, setRecipientNameError] = useState("");
+  /**
+   * The aggregator answers "OK" when no provider can resolve a name (Pretium fiats that
+   * soft-fail, and every currency with no verification at all). That is not a real account
+   * holder, so the user types one instead of being shown "ok" next to a success tick.
+   */
+  const [isRecipientNameEditable, setIsRecipientNameEditable] = useState(false);
+  const [alertViewed, setAlertViewed] = useState(false);
+  /** Guards against a slow verify overwriting a newer one (see getRecipientName). */
+  const nameRequestIdRef = useRef(0);
 
   const [savedRecipients, setSavedRecipients] = useState<
     RecipientDetailsWithId[]
@@ -125,8 +136,14 @@ export const RecipientDetailsForm = ({
         shouldValidate: true,
       });
     } else {
-      // Handle bank/mobile money selection for offramp
-      const channel = recipient.channel;
+      // Handle bank/mobile money selection for offramp.
+      // Send Money rows store channel as "" (the column default), so the API omits it.
+      // Restore the explicit Mobile rail, or the option cannot be matched back to its
+      // virtual split and the row shows unselected when the bank modal is reopened.
+      const channel: KesMpesaChannel | undefined =
+        recipient.institutionCode === KES_MPESA_INSTITUTION_CODE
+          ? (recipient.channel ?? "Mobile")
+          : recipient.channel;
       setSelectedInstitution({
         name:
           recipient.institutionCode === KES_MPESA_INSTITUTION_CODE && channel
@@ -147,6 +164,8 @@ export const RecipientDetailsForm = ({
       setValue("businessNumber", recipient.businessNumber ?? "", {
         shouldDirty: true,
       });
+      // Saved recipients carry a name already; never open the manual-entry input for them.
+      setIsRecipientNameEditable(false);
 
       // Remove extra spaces from recipient name
       recipient.name = recipient.name.replace(/\s+/g, " ").trim();
@@ -284,6 +303,7 @@ export const RecipientDetailsForm = ({
         setValue("accountIdentifier", "");
         setValue("businessNumber", "");
         setRecipientNameError("");
+        setIsRecipientNameEditable(false);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -294,6 +314,11 @@ export const RecipientDetailsForm = ({
     let timeoutId: NodeJS.Timeout;
     const getRecipientName = async () => {
       if (!isManualEntry) return;
+
+      // Re-evaluating: drop the manual-name input until this attempt resolves. The
+      // local validation branches below render their error in the input's else branch,
+      // so leaving it mounted would make those messages unreachable.
+      setIsRecipientNameEditable(false);
 
       const isNGN = currency === "NGN";
       const digits = String(accountIdentifier ?? "").replace(/\D/g, "");
@@ -336,6 +361,11 @@ export const RecipientDetailsForm = ({
       setIsFetchingRecipientName(true);
       setValue("recipientName", "");
 
+      // Verify runs on a debounce, so a slow response can land after the user has
+      // already changed the institution or identifier. Only the newest request is
+      // allowed to write state.
+      const requestId = ++nameRequestIdRef.current;
+
       try {
         const channel = (kesChannel || undefined) as
           | KesMpesaChannel
@@ -355,9 +385,22 @@ export const RecipientDetailsForm = ({
           accountIdentifier: accountIdentifier.toString(),
           ...(metadata ? { metadata } : {}),
         });
-        setValue("recipientName", accountName);
+        if (requestId !== nameRequestIdRef.current) return;
+
+        if (isUnresolvedAccountName(accountName)) {
+          // No provider could resolve a name. Ask for one instead of presenting
+          // the literal "OK" as a verified account holder.
+          setIsRecipientNameEditable(true);
+          setValue("recipientName", "");
+          setRecipientNameError("");
+        } else {
+          setIsRecipientNameEditable(false);
+          setValue("recipientName", accountName);
+        }
         setIsFetchingRecipientName(false);
       } catch (error) {
+        if (requestId !== nameRequestIdRef.current) return;
+        setIsRecipientNameEditable(false);
         setRecipientNameError("No recipient account found.");
         setIsFetchingRecipientName(false);
       }
@@ -423,6 +466,38 @@ export const RecipientDetailsForm = ({
     kesChannel,
   ]);
 
+  const handleLearnMore = () => {
+    trackEvent("recipient_alert_learn_more_clicked", {
+      currency,
+      institution: selectedInstitution?.name || "",
+    });
+    window.open(
+      "https://noblocks.xyz/blog/understanding-account-name-verification-on-noblocks",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  };
+
+  // Fire once per time the manual-name alert becomes visible, not on every render.
+  useEffect(() => {
+    if (isRecipientNameEditable && !alertViewed) {
+      trackEvent("recipient_alert_viewed", {
+        currency,
+        institution: selectedInstitution?.name || "",
+        kes_channel: kesChannel || "",
+      });
+      setAlertViewed(true);
+    } else if (!isRecipientNameEditable && alertViewed) {
+      setAlertViewed(false);
+    }
+  }, [
+    isRecipientNameEditable,
+    alertViewed,
+    currency,
+    selectedInstitution?.name,
+    kesChannel,
+  ]);
+
   // Simplified recipient details management
   const clearRecipientDetails = () => {
     setSelectedInstitution(null);
@@ -433,6 +508,7 @@ export const RecipientDetailsForm = ({
     setValue("kesChannel", "");
     setValue("businessNumber", "");
     setRecipientNameError("");
+    setIsRecipientNameEditable(false);
     setIsManualEntry(true);
   };
 
@@ -509,6 +585,20 @@ export const RecipientDetailsForm = ({
       if (digits.length !== NGN_NUBAN_LENGTH) {
         return "Please enter a valid 10-digit account number.";
       }
+      return true;
+    },
+  });
+
+  const recipientNameRegister = register("recipientName", {
+    validate: (value) => {
+      if (!isRecipientNameEditable) return true;
+      const name = String(value ?? "").replace(/\s+/g, " ").trim();
+      if (!name) return "Recipient name is required";
+      // Never let the sentinel through as if it were a real account holder.
+      if (isUnresolvedAccountName(name)) {
+        return "Enter the recipient's account name";
+      }
+      if (name.length < 2) return "Enter the recipient's full account name";
       return true;
     },
   });
@@ -740,6 +830,39 @@ export const RecipientDetailsForm = ({
                     <ImSpinner className="size-4 animate-spin" />
                     <p className="text-xs">Verifying account name...</p>
                   </AnimatedFeedbackItem>
+                </div>
+              ) : isRecipientNameEditable ? (
+                <div className="w-full space-y-2">
+                  <input
+                    type="text"
+                    autoComplete="off"
+                    placeholder="Enter recipient name"
+                    {...recipientNameRegister}
+                    className={classNames(
+                      "w-full rounded-xl border bg-transparent px-4 py-2.5 text-base outline-none transition-all duration-300 placeholder:text-text-placeholder focus:outline-none dark:text-white/80 dark:placeholder:text-white/30 sm:text-sm",
+                      errors.recipientName
+                        ? "border-input-destructive focus:border-gray-400 dark:border-input-destructive"
+                        : "border-border-input dark:border-white/20 dark:focus:border-white/40 dark:focus:ring-offset-neutral-900",
+                    )}
+                  />
+                  {errors.recipientName && (
+                    <InputError message={errors.recipientName.message} />
+                  )}
+                  <div className="flex w-full min-w-0 items-start gap-2 rounded-xl bg-warning-background/[8%] px-3 py-2">
+                    <InformationSquareIcon className="mt-0.5 size-5 shrink-0 text-warning-foreground dark:text-warning-text" />
+                    <p className="min-w-0 flex-1 break-words text-xs font-light leading-snug text-warning-foreground dark:text-warning-text">
+                      We couldn&apos;t confirm this account name. Make sure the
+                      recipient&apos;s account number is accurate before proceeding
+                      with your swap.{" "}
+                      <button
+                        type="button"
+                        onClick={handleLearnMore}
+                        className="font-semibold text-lavender-500"
+                      >
+                        Learn more.
+                      </button>
+                    </p>
+                  </div>
                 </div>
               ) : (
                 <>

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -137,12 +137,13 @@ export const RecipientDetailsForm = ({
       });
     } else {
       // Handle bank/mobile money selection for offramp.
-      // Send Money rows store channel as "" (the column default), so the API omits it.
-      // Restore the explicit Mobile rail, or the option cannot be matched back to its
-      // virtual split and the row shows unselected when the bank modal is reopened.
+      // Send Money rows store channel as "" (the column default). The API omits an
+      // empty channel, but a cached or hand-built recipient can still carry the ""
+      // itself, and `??` would preserve it — so treat any falsy channel as Mobile.
+      // Only Till and Paybill are real business rails.
       const channel: KesMpesaChannel | undefined =
         recipient.institutionCode === KES_MPESA_INSTITUTION_CODE
-          ? (recipient.channel ?? "Mobile")
+          ? (recipient.channel || "Mobile")
           : recipient.channel;
       setSelectedInstitution({
         name:
@@ -311,60 +312,65 @@ export const RecipientDetailsForm = ({
 
   // Fetch recipient name based on institution and account identifier (only enforce digit-length for NGN)
   useEffect(() => {
+    // Bump synchronously on every dependency change, not just before a fetch: a
+    // lookup already in flight must be invalidated even when this run bails out in
+    // validation below, or its response would still be "current" and populate a
+    // name for an identifier the user has since replaced.
+    const requestId = ++nameRequestIdRef.current;
     let timeoutId: NodeJS.Timeout;
     const getRecipientName = async () => {
       if (!isManualEntry) return;
 
-      // Re-evaluating: drop the manual-name input until this attempt resolves. The
-      // local validation branches below render their error in the input's else branch,
-      // so leaving it mounted would make those messages unreachable.
+      // Re-evaluating: drop the manual-name input and any name already resolved or
+      // typed for the previous identifier. Both matter — the validation branches
+      // below render their error in the input's else branch, so a surviving name
+      // would show with a success tick and suppress the error entirely.
       setIsRecipientNameEditable(false);
+      setValue("recipientName", "");
 
       const isNGN = currency === "NGN";
       const digits = String(accountIdentifier ?? "").replace(/\D/g, "");
 
+      // Bail out without starting a lookup. Clears the spinner too: an earlier
+      // request may still be in flight, and its response now returns at the stale
+      // guard without touching state, which would leave the spinner up forever.
+      const stopWithoutLookup = (message: string) => {
+        setRecipientNameError(message);
+        setIsFetchingRecipientName(false);
+      };
+
       if (!institution || !accountIdentifier) {
-        setRecipientNameError("");
+        stopWithoutLookup("");
         return;
       }
 
       if (isKesPaybill && !(businessNumber ?? "").trim()) {
-        setRecipientNameError("");
+        stopWithoutLookup("");
         return;
       }
 
       if (isKesTill) {
         if (digits.length < 5 || digits.length > 7) {
-          if (digits.length > 0) {
-            setRecipientNameError(
-              "Please enter a valid till number (5–7 digits).",
-            );
-          } else {
-            setRecipientNameError("");
-          }
+          stopWithoutLookup(
+            digits.length > 0
+              ? "Please enter a valid till number (5–7 digits)."
+              : "",
+          );
           return;
         }
       }
 
       if (isNGN && digits.length !== NGN_NUBAN_LENGTH) {
-        if (digits.length > 0) {
-          setRecipientNameError(
-            "Please enter a valid 10-digit account number.",
-          );
-        } else {
-          setRecipientNameError("");
-        }
+        stopWithoutLookup(
+          digits.length > 0
+            ? "Please enter a valid 10-digit account number."
+            : "",
+        );
         return;
       }
 
       setRecipientNameError("");
       setIsFetchingRecipientName(true);
-      setValue("recipientName", "");
-
-      // Verify runs on a debounce, so a slow response can land after the user has
-      // already changed the institution or identifier. Only the newest request is
-      // allowed to write state.
-      const requestId = ++nameRequestIdRef.current;
 
       try {
         const channel = (kesChannel || undefined) as
@@ -595,10 +601,11 @@ export const RecipientDetailsForm = ({
       const name = String(value ?? "").replace(/\s+/g, " ").trim();
       if (!name) return "Recipient name is required";
       // Never let the sentinel through as if it were a real account holder.
+      // Any other non-empty name is accepted — no minimum length, since a short
+      // trading name is legitimate and there is no product rule requiring one.
       if (isUnresolvedAccountName(name)) {
         return "Enter the recipient's account name";
       }
-      if (name.length < 2) return "Enter the recipient's full account name";
       return true;
     },
   });

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -202,6 +202,25 @@ export function normalizeSavedRecipientChannel(
 }
 
 /**
+ * True when the aggregator could not resolve a real account holder.
+ *
+ * `/verify-account` answers the literal string "OK" in two cases: a Pretium fiat
+ * (KES, GHS, UGX, MWK) where every provider soft-failed, and any currency with no
+ * verification path at all, which returns "OK" unconditionally. KES M-Pesa Till and
+ * Paybill always land here — a Paybill lookup is structurally impossible because the
+ * identifier is only the reference and the business number never reaches the PSP.
+ *
+ * "OK" is a sentinel, not a name, so the UI must collect one from the user rather than
+ * display it. The aggregator keeps a client-supplied name in that case
+ * (ResolveAccountNameAfterValidation), and the on-chain path noblocks uses never
+ * re-validates it at all.
+ */
+export function isUnresolvedAccountName(name?: string | null): boolean {
+  const value = (name ?? "").trim();
+  return value === "" || value.toLowerCase() === "ok";
+}
+
+/**
  * True when two saved recipients are the same payout target.
  *
  * Mirrors the saved-recipient unique key exactly. Channel matters because Send


### PR DESCRIPTION
### Jira Issue

Jira Issue: <!-- none; restores legacy GitHub issues #229 / #275 -->

### Description

`/verify-account` answers the literal string **`"OK"`** when no provider can resolve an account holder. The recipient form treated that as a name: it rendered `ok` **inside the success block, next to the green tick**, then saved `OK` as the beneficiary name and sent it on as the order `accountName`. So the user got an affirmative "verified" signal for a payment destination that was never verified.

This is not an edge case for KES M-Pesa. Confirmed against production:

```
POST /v1/verify-account {"institution":"SAFAKEPC","accountIdentifier":"123456","metadata":{"channel":"Till"}}
-> {"data":"OK"}

POST /v1/verify-account {"institution":"SAFAKEPC","accountIdentifier":"0712345678"}
-> {"data":"Vivian Adhiambo Okingo"}
```

Till and Paybill hit it on **every** order — a Paybill lookup is structurally impossible, since the identifier is only the reference and the business number never reaches the PSP. So does any Pretium fiat whose providers soft-fail, and every currency with no verification path at all.

This PR shows an **"Enter recipient name"** input instead, with a warning that the name could not be confirmed, and requires a non-empty name that is not itself the sentinel. `TransactionForm` already gates the preview on `recipientName`, so the empty state blocks the swap until the user supplies one.

**No aggregator change is needed.** The sender API already keeps a client-supplied name via `ResolveAccountNameAfterValidation`, and the on-chain path noblocks actually uses persists `recipient.AccountName` verbatim without ever re-validating it.

#### Blast radius by currency

Driven by the `switch` in `utils.ValidateAccount`. Enabled currencies are NGN, KES, UGX, TZS (GHS/BRL/ARS are `disabled` in `app/mocks.ts`):

| Currency | Behaviour |
|---|---|
| **NGN** | **Unaffected.** Never returns `"OK"` — it errors instead, so bank names keep auto-resolving. |
| **KES, UGX** | Pretium fiats; `"OK"` only on soft-fail, so the input appears only when verification genuinely can't resolve. Covers Till/Paybill. |
| **TZS** | Falls to `default: return "OK", nil`, so verification *never* resolves. **Manual entry becomes required for every TZS order** — an intended improvement over showing "ok", but a whole-currency change worth flagging. |

#### Prior art

This restores #407, which shipped this behaviour on 2026-03-10 and was reverted wholesale a day later by #412 with no stated reason. #407 also carried client-side UGX country-code prepending, which the aggregator superseded server-side six days later in `NormalizeMobileMoneyAccountIdentifier` (the function aggregator#968 later refined). The revert almost certainly targeted that half; **only the name half is restored here.**

#### Two defects fixed while restoring it

- **A slow verify could overwrite a newer one.** The fetch is debounced, so a response for a stale institution or identifier could land last and win. CodeRabbit flagged this on #407 and it shipped unaddressed. Requests now carry a monotonic id and only the newest may write state.
- **A saved KES "Send Money" recipient showed unselected.** Those rows store `channel` as `""` (the column default), so the API omits it and no `uiKey` was restored — `"SAFAKEPC"` then never matched the `"SAFAKEPC:Mobile"` option when the bank modal was reopened. The Mobile rail is now restored explicitly.

#### Deliberately not included

Issue #229 AC#1 also asks for an accuracy reminder next to a *successfully verified* name. That would add a banner to every NGN transaction, so it is left out of this PR.

Real Till/Paybill name resolution (forwarding metadata in `validateAccountViaProviders` plus extending the provider `/verify_account` PSP interface) spans two more repos and is unnecessary once the name can be entered.

### Self-review

- [x] Reviewed diff against acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### References

- Restores the reverted half of #407 (reverted by #412)
- Legacy issues #229 and #275 — auto-closed by the #407 merge and never reopened, so the requirement reads as shipped but never was
- Follows the KES M-Pesa stack: #635, #636, #637

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

`isUnresolvedAccountName` is covered in `__tests__/kes-mpesa-channel.test.ts`: the `OK` sentinel in any casing and with surrounding whitespace, empty/`undefined`/`null`, and real names that merely contain "ok" (`Okon Effiong`, `OK Foods Ltd`) which must **not** be treated as unresolved.

```
npx jest --testPathIgnorePatterns "/node_modules/" "/\.claude/" "/\.worktrees/"
# 626 passed (623 on main + 3 new); the 2 failing suites are pre-existing
# module-resolution failures, identical on main
npx tsc --noEmit
# 10 errors, byte-identical to main (missing optional deps)
```

Manual, against the production aggregator:

1. KES → **M-PESA (Till)** → till `123456` → an "Enter recipient name" input appears with the warning; no "ok", no green tick. Continue is blocked until a name is typed.
2. KES → **M-PESA (Send Money)** → `0712345678` → a real name still resolves and shows with the tick; no manual input.
3. Save a Send Money recipient, reload, reselect it, reopen the bank modal → the row is highlighted.

Developed on macOS, Node via pnpm, Next.js 15.5.15.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual recipient-name entry when account verification cannot provide a usable name.
  - Added validation and a warning message with a “Learn more” option for unresolved recipient names.
  - Saved KES M-PESA recipients now restore the Mobile channel when needed.

- **Bug Fixes**
  - Prevented outdated verification responses from overwriting current recipient details.
  - Improved saved-recipient selection and reset behavior for manual name entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->