### PR TITLE
chore(env): fix env var drift, move server secrets out of client config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
-
-
 # Noblocks Environment Variables
 # Copy this file to .env.local and fill in your values
 # See: docs/environment-variables.md for detailed info about each env. variable
+#
+# This file is the canonical list. __tests__/envDocumentation.test.ts fails CI if
+# code reads a variable that is missing here, or if an entry here is read nowhere.
 
 # =============================================================================
 # Core Application
@@ -21,12 +22,25 @@ NEXT_PUBLIC_KYC_TIER_3_MONTHLY=2
 
 # Authentication Services
 NEXT_PUBLIC_PRIVY_APP_ID=
+
+# RPC provider key (Dwellir), interpolated into per-network RPC URLs.
+# ⚠️ Ships in the browser bundle — balance reads happen client-side. Treat it as
+# public and restrict it by origin at the provider; it is not a secret.
 NEXT_PUBLIC_RPC_URL_KEY=
 
+# Starknet JSON-RPC endpoint. REQUIRED whenever Starknet is reachable —
+# app/lib/starknet.ts throws when it is missing or empty.
+NEXT_PUBLIC_STARKNET_RPC_URL=
+
 # Client error reporting (Sentry-compatible DSN, e.g. GlitchTip)
-# Leave empty to disable. Optional: NEXT_PUBLIC_SENTRY_ENVIRONMENT, NEXT_PUBLIC_SENTRY_RELEASE
-# Set NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=true to send events from local dev
+# Leave empty to disable. Browser-only; no @sentry/nextjs plugin or sourcemap upload.
 NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_ENVIRONMENT=
+NEXT_PUBLIC_SENTRY_RELEASE=
+# 0–1; default 0 (tracing off)
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0
+# Send events from local dev when "true"
+NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=false
 
 # =============================================================================
 # Database & Authentication
@@ -34,21 +48,25 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # Supabase Database
 # Get these from: Supabase Dashboard → Project Settings → API
+# Server code reads SUPABASE_URL only — there is no NEXT_PUBLIC_ variant.
 SUPABASE_URL=https://your-project.supabase.co
-# Optional Next.js-style URL (either works for server)
-# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-#
 # Server API routes (supabaseAdmin): **Secret** key only — sb_secret
 SUPABASE_SECRET_KEY=
-#
-# Client-only if you add a browser Supabase client later (not used by current server admin)
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-#
+
+# Passphrase for the encrypt_recipient_data / decrypt_recipient_data Postgres
+# functions that protect saved recipient details. Rotating it makes existing
+# encrypted rows unreadable.
+ENCRYPTION_KEY=
 
 # Privy Authentication
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=https://auth.privy.io/api/v1/apps/<your-privy-app-id>/jwks.json
 PRIVY_ISSUER=privy.io
+# Optional: Privy wallet API base (defaults to https://api.privy.io)
+PRIVY_WALLET_API_URL=
+# Optional: authorization key for Privy wallet API calls (Starknet key export).
+# When unset, only the user signature is sent.
+PRIVY_WALLET_AUTH_PRIVATE_KEY=
 
 # =============================================================================
 # Analytics
@@ -82,8 +100,11 @@ DD_TRACE_AGENT_PORT=8126
 DD_TRACE_ENABLED=true
 LOG_LEVEL=info
 
-# Server-side Analytics
-MIXPANEL_TOKEN=
+# Server-side Analytics (app/lib/server-analytics.ts).
+# Mixpanel's server token IS the project token, so this is usually the same
+# value as NEXT_PUBLIC_MIXPANEL_TOKEN. Unset here, NEXT_PUBLIC_MIXPANEL_TOKEN is
+# used as a fallback; with neither set, every server-side event is dropped.
+MIXPANEL_SERVER_TOKEN=
 MIXPANEL_PRIVACY_MODE=strict
 MIXPANEL_INCLUDE_IP=false
 MIXPANEL_INCLUDE_ERROR_STACKS=false
@@ -112,6 +133,13 @@ ENABLE_WALLET_CONTEXT_SYNC=false
 # Starknet Earn (Vesu / Starkzap): wallet Earn CTA, deposit/withdraw, activity tab
 NEXT_PUBLIC_EARN_ENABLED=false
 
+# AVNU paymaster for Starknet gas sponsorship.
+# Required whenever Starknet Earn is on (the paymaster runs in "sponsored" mode).
+STARKNET_PAYMASTER_API_KEY=
+# Optional: gas token address, used only in non-sponsored mode.
+# Defaults to the first token the paymaster reports as supported.
+STARKNET_GAS_TOKEN_ADDRESS=
+
 # EVM → Starknet Earn (LayerSwap bridge + Vesu). Requires NEXT_PUBLIC_EARN_ENABLED=true
 NEXT_PUBLIC_EVM_EARN_ENABLED=false
 LAYERSWAP_API_KEY=
@@ -120,9 +148,11 @@ LAYERSWAP_API_BASE_URL=https://api.layerswap.io #optional
 
 NEXT_PUBLIC_TRON_ENABLED=false
 # Optional: custom Tron RPC URL (defaults to https://api.trongrid.io)
-# NEXT_PUBLIC_TRON_RPC_URL=
-# Optional: TronGrid API key for balance lookups (higher rate limits)
-# NEXT_PUBLIC_TRONGRID_API_KEY=
+NEXT_PUBLIC_TRON_RPC_URL=
+# Optional: TronGrid API key for balance lookups (higher rate limits).
+# ⚠️ Ships in the browser bundle and is sent as the TRON-PRO-API-KEY header from
+# client code. Restrict it by origin at TronGrid; treat it as public.
+NEXT_PUBLIC_TRONGRID_API_KEY=
 
 # Referral Program: show/hide all referral UI and API routes
 NEXT_PUBLIC_REFERRAL_ENABLED=true
@@ -143,6 +173,13 @@ NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 # Requires NEXT_PUBLIC_BRIDGE_ENABLED=true and ALCHEMY_API_KEY (server-only ERC-4337 bundler).
 NEXT_PUBLIC_HYPERFX_ENABLED=false
 ALCHEMY_API_KEY=
+# Hyperbridge Nexus endpoints. The NEXT_PUBLIC_ pair is read by the browser swap
+# client; the unprefixed pair by the server quote route. Both optional — each
+# falls back to the public Polytope endpoint.
+NEXT_PUBLIC_HYPERBRIDGE_WS_URL=
+NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL=
+HYPERBRIDGE_WS_URL=
+HYPERBRIDGE_INDEXER_URL=
 
 # Embeddable widget (/widget route, iframed by whitelisted partners)
 NEXT_PUBLIC_EMBED_ENABLED=false
@@ -169,14 +206,14 @@ INJECTED_SESSION_SECRET=
 # SIWE sign-in messages must name this host (or an allowed embed origin) —
 # configured, never derived from the request Host header, so a signature
 # phished on another domain can't mint a session here.
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Read on the server only. NEXT_PUBLIC_APP_URL is the legacy name and still
+# works as a fallback; prefer APP_URL.
+APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=
 
 # =============================================================================
 # External Services
 # =============================================================================
-
-# SEO
-NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE=
 
 # Notice Banner
 # See docs/notice-banner.md
@@ -194,15 +231,27 @@ NEXT_PUBLIC_MAINTENANCE_SCHEDULE=Friday, February 13th, from 7:00 PM to 11:00 PM
 BREVO_API_KEY=
 # List ID from: Brevo Dashboard → Contacts → Lists (numeric ID)
 BREVO_LIST_ID=
-BREVO_LIST_ID=
+# From address on transactional email (defaults to no-reply@noblocks.xyz)
+BREVO_SENDER_EMAIL=
 # Brevo Conversations (Chat Widget)
 # Get from: Brevo Dashboard → Conversations → Settings
 NEXT_PUBLIC_BREVO_CONVERSATIONS_ID=
 NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID=
 
-# Activepieces webhooks for KYC
+# Activepieces webhooks. Each is optional — an unset URL skips that forward.
+# Deposit forwarding, fired from the Moralis stream webhook:
+ACTIVEPIECES_WEBHOOK_URL=
 ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL=
 ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL=
+
+# Moralis EVM streams — deposit watching. Server-only.
+# Stream and key from: Moralis Dashboard → Streams
+MORALIS_STREAM_ID=
+MORALIS_API_KEY=
+MORALIS_BASE_URL=https://api.moralis-streams.com
+# Shared secret used to verify the x-signature header on incoming stream webhooks
+MORALIS_WEBHOOK_SECRET=
+
 # =============================================================================
 # Phone Verification Services
 # =============================================================================
@@ -213,6 +262,8 @@ KUDISMS_API_KEY=your_kudisms_api_key
 KUDISMS_APP_NAME_CODE=your_app_name_code
 KUDISMS_TEMPLATE_CODE=your_template_code
 KUDISMS_SENDER_ID=Noblocks
+# Optional request timeout, default 10000
+KUDISMS_TIMEOUT_MS=
 
 # Twilio (for international phone numbers via Verify API)
 # Get from: Twilio Console → Account Dashboard
@@ -220,13 +271,13 @@ TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 # Verify service SID: Twilio Console → Verify → Services → create or use default
 TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Optional request timeout, default 5000
+TWILIO_VERIFY_TIMEOUT_MS=
 
 # =============================================================================
 # SmileID KYC Verification Services
 # =============================================================================
 
-# API base URL — see Smile Identity docs (sandbox vs production)
-SMILE_IDENTITY_BASE_URL="XXXXXX"
 # API key from Smile Identity portal
 SMILE_IDENTITY_API_KEY="your_api_key_here"
 # Partner ID from Smile Identity portal
@@ -235,6 +286,8 @@ SMILE_IDENTITY_PARTNER_ID="your_partner_id_here"
 SMILE_ID_CALLBACK_URL=""
 # "0" = sandbox, "1" = production (or a legacy full API URL string)
 SMILE_IDENTITY_SERVER="0"
+# Optional override, checked before SMILE_IDENTITY_SERVER. "0" or "1" only.
+SMILE_IDENTITY_SERVER_MODE=
 
 # =============================================================================
 # Dojah – Tier 3 address / proof-of-address verification
@@ -243,10 +296,8 @@ SMILE_IDENTITY_SERVER="0"
 DOJAH_APP_ID=<DOJAH_APP_ID_PLACEHOLDER>
 DOJAH_SECRET_KEY=<DOJAH_SECRET_KEY_PLACEHOLDER>
 DOJAH_BASE_URL=https://api.dojah.io
-# Optional. Default false — send only input_type + input_value per Dojah docs (avoids some 5xx).
-# DOJAH_UTILITY_BILL_SEND_ADDRESS_FIELDS=true
-# Optional. Default true — if URL submission gets 500/502/503/504, retry with base64 (Dojah often cannot fetch Supabase URLs).
-# DOJAH_UTILITY_BILL_BASE64_FALLBACK=false
+# Optional request timeout, default 25000
+DOJAH_TIMEOUT_MS=
 # Supabase Storage bucket for KYC document uploads (create in Supabase Dashboard → Storage)
 KYC_DOCUMENTS_BUCKET=kyc-documents
 
@@ -265,6 +316,17 @@ NEXT_PUBLIC_FANTASY_ENABLED=true
 NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED=true
 # World Cup footer Lottie (requires fantasy enabled and not campaign-ended; ends Jul 19 2026 by default)
 NEXT_PUBLIC_WORLDCUP_FOOTER_END_DATE=2026-07-19T23:59:59+01:00
+
+# Noblocks Play backend.
+# Admin key for /api/play/admin/* (sent as x-admin-key). Unset = admin tooling OFF.
+FANTASY_ADMIN_KEY=
+# Shared secret for the Cloudflare worker that POSTs /api/play/worker
+# (sent as x-internal-auth). Falls back to INTERNAL_API_KEY when unset.
+FANTASY_WORKER_SECRET=
+# Dev-only: "true" compresses gameweek timing for local testing. Ignored in production.
+FANTASY_LOCAL_TIMELAPSE=
+# API-Football key used to pull fixtures, players and live scores
+API_FOOTBALL_KEY=
 
 # BlockFest Cashback Wallet
 # ⚠️ WARNING: These credentials control funds and must be kept secure
@@ -288,9 +350,14 @@ SANITY_STUDIO_PROJECT_ID=your_project_id_here
 NEXT_PUBLIC_SANITY_DATASET=production
 NEXT_PUBLIC_SANITY_PROJECT_ID=your_project_id_here
 
+# =============================================================================
 # Bundler / EIP-7702 sponsor
-NEXT_PUBLIC_BUNDLER_SERVER_URL=
+# =============================================================================
+
+# Sponsor wallet that pays gas for batched EIP-7702 calls.
+# PRIVATE_KEY is a legacy alias, still accepted as a fallback.
 SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
+PRIVATE_KEY=
 
 # Onramp chained forwarding
 # When true, onramp crypto settles to the user's Noblocks wallet first, then is auto-forwarded
@@ -301,3 +368,16 @@ NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
 
 NEXT_PUBLIC_REFERRAL_MIN_QUALIFYING_VOLUME_USD=20 # in USDC
 NEXT_PUBLIC_REFERRAL_REWARD_AMOUNT_USD=1 # in USDC
+
+# =============================================================================
+# Scripts only (not read by the app)
+# =============================================================================
+
+# scripts/seed-fantasy.ts
+SEED_DELAY_MS=
+SEED_SKIP_PLAYERS=
+SEED_TIMELAPSE_HOURS=
+SEED_TIMELAPSE_GWS=
+# scripts/backfill-moralis-from-privy.ts
+DRY_RUN=
+MORALIS_MS_DELAY=

--- a/.env.example
+++ b/.env.example
@@ -140,7 +140,8 @@ STARKNET_PAYMASTER_API_KEY=
 # Defaults to the first token the paymaster reports as supported.
 STARKNET_GAS_TOKEN_ADDRESS=
 
-# EVM → Starknet Earn (LayerSwap bridge + Vesu). Requires NEXT_PUBLIC_EARN_ENABLED=true
+# EVM → Starknet Earn (LayerSwap bridge + Vesu). Needs NEXT_PUBLIC_EARN_ENABLED=true
+# as well — isEvmEarnEnabled() requires both flags.
 NEXT_PUBLIC_EVM_EARN_ENABLED=false
 LAYERSWAP_API_KEY=
 # Optional; must use HTTPS if set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Configured repo secrets
-      AGGREGATOR_DATABASE_URL: ${{ secrets.AGGREGATOR_DATABASE_URL }}
+      # Configured repo secrets. Nothing else belongs here: an env var no code
+      # reads is a secret exposed to the build for no reason. SENTRY_AUTH_TOKEN,
+      # SENTRY_URL, AGGREGATOR_DATABASE_URL and NEXT_PUBLIC_SUPABASE_URL were
+      # removed for that reason — the first two only matter with a sourcemap
+      # upload step, which this project does not have (@sentry/react only, no
+      # @sentry/nextjs); re-add them alongside the step that needs them.
       BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
       BREVO_LIST_ID: ${{ secrets.BREVO_LIST_ID }}
       NEXT_PUBLIC_AGGREGATOR_URL: ${{ secrets.NEXT_PUBLIC_AGGREGATOR_URL }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_URL: ${{ secrets.SENTRY_URL }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       # Dummy values for vars required at build time but not in repo secrets

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Visit the live site at [noblocks.xyz](https://noblocks.xyz).
      - `NEXT_PUBLIC_PRIVY_APP_ID` – Your Privy app ID ([sign up here](https://www.privy.io/))
      - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard → Project Settings → API
      - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
+     - `NEXT_PUBLIC_STARKNET_RPC_URL` – A Starknet JSON-RPC endpoint; anything touching Starknet throws without it
 
    See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
 

--- a/__tests__/envDocumentation.test.ts
+++ b/__tests__/envDocumentation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Keeps .env.example in step with the environment variables the code actually
+ * reads, in both directions:
+ *
+ *   - a `process.env.X` read with no entry in .env.example is a variable nobody
+ *     knows to set (this is how NEXT_PUBLIC_STARKNET_RPC_URL became a required
+ *     but undocumented var);
+ *   - an entry in .env.example that nothing reads is a variable people set in
+ *     good faith and wonder why it has no effect (this is how MIXPANEL_TOKEN
+ *     survived after the code moved to MIXPANEL_SERVER_TOKEN).
+ *
+ * .env.example is canonical. docs/environment-variables.md is prose and is not
+ * checked here.
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const REPO_ROOT = join(__dirname, "..");
+
+/** Directories and files scanned for `process.env` reads. */
+const SCAN_TARGETS = [
+  "app",
+  "middleware.ts",
+  "instrumentation.ts",
+  "next.config.mjs",
+  "sanity.config.ts",
+  "sanity.cli.ts",
+];
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+/**
+ * Variables deliberately absent from .env.example. Every entry needs a reason —
+ * "it is noisy" is not one. Prefer documenting the variable instead.
+ */
+const NOT_IN_ENV_EXAMPLE = new Set([
+  // Supplied by Node and Next.js themselves; never set by an operator.
+  "NODE_ENV",
+  "NEXT_RUNTIME",
+]);
+
+function collectSourceFiles(target: string): string[] {
+  const absolute = join(REPO_ROOT, target);
+  let stats;
+  try {
+    stats = statSync(absolute);
+  } catch {
+    return []; // Optional target (e.g. instrumentation.ts) not present.
+  }
+
+  if (stats.isFile()) {
+    return SOURCE_EXTENSIONS.some((ext) => absolute.endsWith(ext))
+      ? [absolute]
+      : [];
+  }
+
+  const files: string[] = [];
+  for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const child = join(target, entry.name);
+    files.push(...collectSourceFiles(child));
+  }
+  return files;
+}
+
+/** `process.env.FOO` and `process.env["FOO"]`, uppercase names only. */
+const ENV_READ_RE =
+  /process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]/g;
+
+function envVarsReadInCode(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  for (const target of SCAN_TARGETS) {
+    for (const file of collectSourceFiles(target)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(ENV_READ_RE)) {
+        const name = match[1] ?? match[2];
+        const relative = file.slice(REPO_ROOT.length + 1);
+        const seen = found.get(name);
+        if (seen) {
+          if (!seen.includes(relative)) seen.push(relative);
+        } else {
+          found.set(name, [relative]);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+/** Entries in .env.example, whether set (`X=`) or commented out (`# X=`). */
+function envVarsInExample(): Set<string> {
+  const contents = readFileSync(join(REPO_ROOT, ".env.example"), "utf8");
+  const names = new Set<string>();
+  for (const line of contents.split("\n")) {
+    const match = /^\s*#?\s*([A-Z][A-Z0-9_]*)\s*=/.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+describe(".env.example", () => {
+  const readInCode = envVarsReadInCode();
+  const documented = envVarsInExample();
+
+  it("scans a plausible number of files", () => {
+    // Guards against a refactor silently emptying SCAN_TARGETS and turning both
+    // assertions below into no-ops.
+    expect(readInCode.size).toBeGreaterThan(50);
+  });
+
+  it("documents every environment variable the code reads", () => {
+    const undocumented = [...readInCode.entries()]
+      .filter(([name]) => !documented.has(name))
+      .filter(([name]) => !NOT_IN_ENV_EXAMPLE.has(name))
+      .map(([name, files]) => `  ${name} — read in ${files.join(", ")}`)
+      .sort();
+
+    expect(
+      undocumented.length === 0
+        ? ""
+        : `These variables are read by the app but missing from .env.example.\n` +
+            `Add an entry (an empty \`NAME=\` is fine) so operators know it exists:\n` +
+            undocumented.join("\n"),
+    ).toBe("");
+  });
+
+  it("has no entries the code never reads", () => {
+    const unused = [...documented]
+      .filter((name) => !readInCode.has(name))
+      // Script-only variables live in .env.example for discoverability but are
+      // read under scripts/, which is outside SCAN_TARGETS.
+      .filter((name) => !SCRIPT_ONLY.has(name))
+      .sort();
+
+    expect(
+      unused.length === 0
+        ? ""
+        : `These entries in .env.example are read nowhere in the app.\n` +
+            `Remove them, or fix the name if the code uses a different one:\n` +
+            unused.map((name) => `  ${name}`).join("\n"),
+    ).toBe("");
+  });
+});
+
+/** Documented for operators, but only read by files under scripts/. */
+const SCRIPT_ONLY = new Set([
+  "SEED_DELAY_MS",
+  "SEED_SKIP_PLAYERS",
+  "SEED_TIMELAPSE_HOURS",
+  "SEED_TIMELAPSE_GWS",
+  "DRY_RUN",
+  "MORALIS_MS_DELAY",
+]);

--- a/__tests__/layerswapStarknetExecute.test.ts
+++ b/__tests__/layerswapStarknetExecute.test.ts
@@ -1,3 +1,5 @@
+jest.mock("server-only", () => ({}));
+
 import { layerswapDepositActionsToStarknetCalls } from "../app/lib/layerswap";
 
 describe("layerswapDepositActionsToStarknetCalls", () => {

--- a/app/api/auth/injected/verify/route.ts
+++ b/app/api/auth/injected/verify/route.ts
@@ -5,6 +5,7 @@ import { rateLimit } from "@/app/lib/rate-limit";
 import { supabaseAdmin } from "@/app/lib/supabase";
 import { SUPPORTED_CHAINS } from "@/app/lib/bundler/chains";
 import { getRpcUrl } from "@/app/utils";
+import { getAppUrl } from "@/app/lib/server-config";
 import {
   isSiweDomainAllowed,
   isSiweIssuedAtFresh,
@@ -41,7 +42,7 @@ const ORIGIN_RE =
 async function getAllowedSiweOrigins(): Promise<string[]> {
   const origins: string[] = [];
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  const appUrl = getAppUrl();
   if (appUrl && ORIGIN_RE.test(appUrl)) {
     origins.push(appUrl);
   }

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -6,7 +6,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import { getEmailForMonitoredAddress } from "@/app/utils";
-import config from "@/app/lib/config";
+import { activepiecesConfig } from "@/app/lib/server-config";
 import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 /**
@@ -45,7 +45,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       );
     }
 
-    const webhookUrl = config.activepiecesSignupVerifyWebhookUrl;
+    const webhookUrl = activepiecesConfig.signupVerifyWebhookUrl;
     if (!webhookUrl) {
       report.failed({
         walletAddress,

--- a/app/api/track-logout/route.ts
+++ b/app/api/track-logout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { trackServerEvent } from "@/app/lib/server-analytics";
+import { getAppUrl } from "@/app/lib/server-config";
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,7 +14,7 @@ export async function POST(request: NextRequest) {
 
     if (process.env.NODE_ENV === "production") {
       const origin = request.headers.get("origin");
-      const allowed = process.env.NEXT_PUBLIC_APP_URL;
+      const allowed = getAppUrl();
       if (
         origin &&
         allowed &&

--- a/app/api/webhooks/moralis/route.ts
+++ b/app/api/webhooks/moralis/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/app/lib/server-analytics";
 import { verifyMoralisSignature } from "@/app/utils";
 import { processMoralisDepositPayload } from "@/app/lib/moralis-deposit-processing";
-import config from "@/app/lib/config";
+import { moralisConfig } from "@/app/lib/server-config";
 import type { MoralisWebhookBody } from "@/app/types";
 
 /**
@@ -25,7 +25,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     });
 
     const raw = await request.text();
-    const secret = config.moralisWebhookSecret;
+    const secret = moralisConfig.webhookSecret;
     const sig = request.headers.get("x-signature");
 
     if (secret) {

--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -132,7 +132,7 @@ export function useDelegationContractAuth() {
             }
             const delegationAddress = getDelegationContractAddress(chainId);
             if (!delegationAddress || delegationAddress === "") {
-                throw new Error(`Delegation contract not configured for chain ${chainId}. Add the contract for this chain or set NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS.`);
+                throw new Error(`Delegation contract not configured for chain ${chainId}. Add it to DELEGATION_CONTRACT_BY_CHAIN in app/lib/config.ts.`);
             }
             const signed = await signAuthorization(
                 {

--- a/app/hooks/useEarnBridgeStatusTracker.ts
+++ b/app/hooks/useEarnBridgeStatusTracker.ts
@@ -7,7 +7,7 @@ import { useEarnHandler } from "./useEarnHandler";
 import {
   isLayerswapSuccessStatus,
   isLayerswapTerminalStatus,
-} from "../lib/layerswap";
+} from "../lib/layerswapStatus";
 import {
   addEarnSourcePosition,
   isStaleLiveFlowClaim,

--- a/app/hooks/useEvmEarnHandler.ts
+++ b/app/hooks/useEvmEarnHandler.ts
@@ -15,8 +15,11 @@ import {
 import {
   isLayerswapSuccessStatus,
   isLayerswapTerminalStatus,
-  type LayerswapDepositAction,
-  type LayerswapQuote,
+} from "../lib/layerswapStatus";
+// Type-only: layerswap.ts is server-only, so this import must stay erasable.
+import type {
+  LayerswapDepositAction,
+  LayerswapQuote,
 } from "../lib/layerswap";
 import { buildLayerswapDepositBatchCalls } from "../lib/layerswapExecute";
 import { executeBatchCalls } from "../lib/bridge";

--- a/app/hooks/useSmartWalletTransfer.ts
+++ b/app/hooks/useSmartWalletTransfer.ts
@@ -343,7 +343,7 @@ export function useSmartWalletTransfer({
           const chainName = selectedNetwork.chain.name;
           throw new Error(
             isNetworkErr
-              ? `Cannot reach the transaction server. Check that NEXT_PUBLIC_BUNDLER_SERVER_URL is set and the server is running. For ${chainName}, ensure the server has been restarted with support for this network.`
+              ? `Cannot reach the transaction service. Check your connection and try again. If this persists, ${chainName} may not be configured for sponsored transactions.`
               : (fetchErr as Error)?.message ?? "Network request failed",
           );
         }

--- a/app/lib/activepieces-deposit.ts
+++ b/app/lib/activepieces-deposit.ts
@@ -1,4 +1,4 @@
-import config from "./config";
+import { activepiecesConfig } from "./server-config";
 import type { ActivepiecesDepositPayload } from "../types";
 
 /**
@@ -7,7 +7,7 @@ import type { ActivepiecesDepositPayload } from "../types";
 export async function triggerActivepiecesDeposit(
   payload: ActivepiecesDepositPayload,
 ): Promise<void> {
-  const url = config.activepiecesWebhookUrl;
+  const url = activepiecesConfig.depositWebhookUrl;
   if (!url) {
     console.error(
       "[activepieces] ACTIVEPIECES_WEBHOOK_URL not set — skipping forward",

--- a/app/lib/activepieces-kyc-result.ts
+++ b/app/lib/activepieces-kyc-result.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { after } from "next/server";
-import config from "@/app/lib/config";
+import { activepiecesConfig } from "@/app/lib/server-config";
 import type { ActivepiecesKycResultPayload } from "@/app/types";
 import { getEmailForMonitoredAddress } from "@/app/utils";
 import {
@@ -33,7 +33,7 @@ export async function triggerActivepiecesKycResult(
   payload: ActivepiecesKycResultPayload,
   walletAddress?: string,
 ): Promise<void> {
-  const url = config.activepiecesKycResultWebhookUrl;
+  const url = activepiecesConfig.kycResultWebhookUrl;
   if (!url) {
     console.error(
       "[activepieces] ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL not set — skipping KYC result email",

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -1,5 +1,4 @@
 import { Config, JWTProviderConfig } from "@/app/types";
-import { resolveLayerswapApiBaseUrl } from "./layerswapConfig";
 
 /** EIP-7702 delegation contract (ProviderBatchCallAndSponsor) per chain. */
 export const DELEGATION_CONTRACT_BY_CHAIN: Record<number, string> = {
@@ -12,7 +11,7 @@ export const DELEGATION_CONTRACT_BY_CHAIN: Record<number, string> = {
   1: "0x25054a2b9D4544ed292DC1a74E8bF1f6F449d988",
 };
 
-/** Returns the delegation contract address for the given chainId. Uses NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS if set, else DELEGATION_CONTRACT_BY_CHAIN, else "". */
+/** Returns the delegation contract address for the given chainId from DELEGATION_CONTRACT_BY_CHAIN, else "". */
 export function getDelegationContractAddress(chainId: number): string {
   return DELEGATION_CONTRACT_BY_CHAIN[chainId] ?? "";
 }
@@ -29,8 +28,6 @@ const config: Config = {
   rpcUrlKey: process.env.NEXT_PUBLIC_RPC_URL_KEY || "",
   mixpanelToken: process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || "",
   hotjarSiteId: Number(process.env.NEXT_PUBLIC_HOTJAR_SITE_ID || ""),
-  googleVerificationCode:
-    process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE || "",
   noticeBannerText: process.env.NEXT_PUBLIC_NOTICE_BANNER_TEXT || "",
   brevoConversationsId: process.env.NEXT_PUBLIC_BREVO_CONVERSATIONS_ID || "",
   brevoConversationsGroupId: process.env.NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID || "",
@@ -56,16 +53,6 @@ const config: Config = {
     );
     return Number.isFinite(parsed) ? parsed : 0;
   })(),
-  moralisWebhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
-  activepiecesWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
-  activepiecesSignupVerifyWebhookUrl:
-    process.env.ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL || "",
-  activepiecesKycResultWebhookUrl:
-    process.env.ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL || "",
-  moralisStreamId: process.env.MORALIS_STREAM_ID || "",
-  moralisApiKey: process.env.MORALIS_API_KEY || "",
-  moralisBaseUrl:
-    process.env.MORALIS_BASE_URL || "https://api.moralis-streams.com",
   earnEnabled: process.env.NEXT_PUBLIC_EARN_ENABLED === "true",
   evmEarnEnabled: process.env.NEXT_PUBLIC_EVM_EARN_ENABLED === "true",
   tronEnabled: process.env.NEXT_PUBLIC_TRON_ENABLED === "true",
@@ -83,11 +70,6 @@ const config: Config = {
   fantasyCampaignEnded:
     process.env.NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED === "true",
   embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
-  /** Server-side LayerSwap API key (EVM earn bridge). */
-  layerswapApiKey: (process.env.LAYERSWAP_API_KEY || "").trim(),
-  layerswapApiBaseUrl: resolveLayerswapApiBaseUrl(
-    process.env.LAYERSWAP_API_BASE_URL,
-  ),
 };
 
 export default config;
@@ -98,14 +80,6 @@ export const DEFAULT_PRIVY_CONFIG: JWTProviderConfig = {
     jwksUrl: process.env.PRIVY_JWKS_URL || "",
     issuer: process.env.PRIVY_ISSUER || "",
     algorithms: ["ES256"],
-  },
-};
-
-export const DEFAULT_THIRDWEB_CONFIG: JWTProviderConfig = {
-  provider: "thirdweb",
-  thirdweb: {
-    clientId: process.env.THIRDWEB_CLIENT_ID || "",
-    domain: process.env.THIRDWEB_DOMAIN || "",
   },
 };
 

--- a/app/lib/hyperfx.ts
+++ b/app/lib/hyperfx.ts
@@ -40,13 +40,14 @@ import {
 } from "@/app/lib/hyperfxStatus";
 import type { HyperfxIntentQuote } from "./bridge";
 
+// This module runs in the browser, where only NEXT_PUBLIC_ vars are inlined —
+// the server-side HYPERBRIDGE_* names would always be undefined here. The
+// quote route reads those separately.
 const WS_URL =
   process.env.NEXT_PUBLIC_HYPERBRIDGE_WS_URL ||
-  process.env.HYPERBRIDGE_WS_URL ||
   "wss://nexus.rpc.polytope.technology";
 const INDEXER_URL =
   process.env.NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL ||
-  process.env.HYPERBRIDGE_INDEXER_URL ||
   "https://nexus.indexer.polytope.technology";
 
 const NOBLOCKS_GRAFFITI = padHex(stringToHex("noblocks.xyz"), {

--- a/app/lib/jwt.ts
+++ b/app/lib/jwt.ts
@@ -2,7 +2,7 @@ import { jwtVerify, createRemoteJWKSet } from 'jose';
 import { JWTPayload, JWTProviderConfig, VerifyJWTResult } from '@/app/types';
 
 /**
- * Verifies a JWT token for either Privy or Thirdweb provider
+ * Verifies a Privy-issued JWT token
  * @param token - The JWT token to verify
  * @param config - Configuration for the JWT provider
  * @returns The verified payload and provider
@@ -21,11 +21,6 @@ export async function verifyJWT(token: string, config: JWTProviderConfig): Promi
                 payload: payload as JWTPayload,
                 provider: config.provider,
             };
-        } else if (config.provider === 'thirdweb' && config.thirdweb) {
-            // Placeholder for thirdweb JWT verification
-            // TODO: Thirdweb verification will be implemented when ready to migrate
-            throw new Error('Thirdweb JWT verification not implemented yet');
-
         } else {
             throw new Error('Invalid JWT provider configuration');
         }

--- a/app/lib/layerswap.ts
+++ b/app/lib/layerswap.ts
@@ -1,33 +1,30 @@
 /**
  * LayerSwap API client (server-side). Proxied via /api/earn/layerswap/* routes.
+ *
+ * Status vocabulary and predicates live in ./layerswapStatus so client code can
+ * import them without dragging this module — and LAYERSWAP_API_KEY — into the
+ * browser bundle. They are re-exported here for server callers.
  */
 
+import "server-only";
 import axios from "axios";
 import type { Call } from "starknet";
-import config from "./config";
+import { getLayerswapApiBase, getLayerswapApiKey } from "./server-config";
 import {
   EARN_USDC_SYMBOL,
   LAYERSWAP_STARKNET_NETWORK,
   layerswapSourceNetwork,
 } from "./earnChains";
+import type { LayerswapSwapStatus } from "./layerswapStatus";
 
-export const LAYERSWAP_API_BASE = config.layerswapApiBaseUrl;
-
-/** LayerSwap API key from config (server routes only). */
-export function getLayerswapApiKey(): string {
-  return config.layerswapApiKey;
-}
+export {
+  isLayerswapSuccessStatus,
+  isLayerswapTerminalStatus,
+} from "./layerswapStatus";
+export type { LayerswapSwapStatus };
+export { getLayerswapApiKey };
 
 const UPSTREAM_TIMEOUT_MS = 30_000;
-
-export type LayerswapSwapStatus =
-  | "user_transfer_pending"
-  | "completed"
-  | "failed"
-  | "expired"
-  | "ls_transfer_pending"
-  | "pending_refund"
-  | "refunded";
 
 export interface LayerswapDepositAction {
   type: string;
@@ -80,7 +77,7 @@ export async function layerswapGetQuote(params: {
   destinationNetwork?: string;
 }): Promise<LayerswapQuote> {
   const { data } = await axios.get<LayerswapApiResponse<LayerswapQuote>>(
-    `${LAYERSWAP_API_BASE}/api/v2/quote`,
+    `${getLayerswapApiBase()}/api/v2/quote`,
     {
       headers: layerswapHeaders(params.apiKey),
       params: {
@@ -119,7 +116,7 @@ export async function layerswapCreateEarnSwap(params: {
   }
 
   const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
-    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    `${getLayerswapApiBase()}/api/v2/swaps`,
     {
       source_network: sourceNetwork,
       source_token: EARN_USDC_SYMBOL,
@@ -168,7 +165,7 @@ export async function layerswapCreateEarnWithdrawSwap(params: {
   }
 
   const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
-    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    `${getLayerswapApiBase()}/api/v2/swaps`,
     {
       source_network: LAYERSWAP_STARKNET_NETWORK,
       source_token: EARN_USDC_SYMBOL,
@@ -204,7 +201,7 @@ export async function layerswapGetSwap(params: {
 }): Promise<LayerswapPreparedSwap & { swap: NonNullable<LayerswapPreparedSwap["swap"]> }> {
   const { data } = await axios.get<
     LayerswapApiResponse<LayerswapPreparedSwap>
-  >(`${LAYERSWAP_API_BASE}/api/v2/swaps/${encodeURIComponent(params.swapId)}`, {
+  >(`${getLayerswapApiBase()}/api/v2/swaps/${encodeURIComponent(params.swapId)}`, {
     headers: layerswapHeaders(params.apiKey),
     timeout: UPSTREAM_TIMEOUT_MS,
     validateStatus: () => true,
@@ -218,21 +215,6 @@ export async function layerswapGetSwap(params: {
   return data.data as LayerswapPreparedSwap & {
     swap: NonNullable<LayerswapPreparedSwap["swap"]>;
   };
-}
-
-export function isLayerswapTerminalStatus(
-  status: LayerswapSwapStatus,
-): boolean {
-  return (
-    status === "completed" ||
-    status === "failed" ||
-    status === "expired" ||
-    status === "refunded"
-  );
-}
-
-export function isLayerswapSuccessStatus(status: LayerswapSwapStatus): boolean {
-  return status === "completed";
 }
 
 interface ParsedLayerswapCall {

--- a/app/lib/layerswapStatus.ts
+++ b/app/lib/layerswapStatus.ts
@@ -1,0 +1,31 @@
+/**
+ * LayerSwap swap status vocabulary and predicates.
+ *
+ * Split out of layerswap.ts so client components can poll swap status without
+ * pulling the API client — and its server-only credentials — into the browser
+ * bundle. Pure: no env access, no network, no imports.
+ */
+
+export type LayerswapSwapStatus =
+  | "user_transfer_pending"
+  | "completed"
+  | "failed"
+  | "expired"
+  | "ls_transfer_pending"
+  | "pending_refund"
+  | "refunded";
+
+export function isLayerswapTerminalStatus(
+  status: LayerswapSwapStatus,
+): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "expired" ||
+    status === "refunded"
+  );
+}
+
+export function isLayerswapSuccessStatus(status: LayerswapSwapStatus): boolean {
+  return status === "completed";
+}

--- a/app/lib/register-moralis-stream-address.ts
+++ b/app/lib/register-moralis-stream-address.ts
@@ -1,4 +1,4 @@
-import config from "./config";
+import { moralisConfig } from "./server-config";
 /**
  * Add a wallet address to the configured Moralis EVM stream (e.g. after a new user gets a wallet).
  * Server-only; uses MORALIS_API_KEY, MORALIS_STREAM_ID, and MORALIS_BASE_URL.
@@ -7,9 +7,9 @@ export async function registerWalletForMoralisStream(
   walletAddress: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const address = walletAddress.trim().toLowerCase();
-  const streamId = config.moralisStreamId;
-  const apiKey = config.moralisApiKey;
-  const baseUrl = (config.moralisBaseUrl || "").trim();
+  const streamId = moralisConfig.streamId;
+  const apiKey = moralisConfig.apiKey;
+  const baseUrl = (moralisConfig.baseUrl || "").trim();
   if (!streamId || !apiKey || !baseUrl) {
     return {
       ok: false,

--- a/app/lib/server-config.ts
+++ b/app/lib/server-config.ts
@@ -8,6 +8,8 @@
  * Security is maintained because these env vars are not NEXT_PUBLIC_ prefixed.
  */
 
+import { resolveLayerswapApiBaseUrl } from "./layerswapConfig";
+
 /**
  * Validates environment variable and logs a warning or throws if missing
  * @param name - Environment variable name
@@ -50,13 +52,24 @@ export const cashbackConfig = {
   ),
 };
 
+/**
+ * Mixpanel project token for server-side tracking.
+ *
+ * Mixpanel's server token IS the project token, so NEXT_PUBLIC_MIXPANEL_TOKEN is
+ * a valid value here. It is accepted as a fallback because deployments have
+ * historically set only the public name, which left every event emitted by
+ * app/lib/server-analytics.ts silently dropped. Prefer MIXPANEL_SERVER_TOKEN so
+ * the two can be pointed at separate projects later.
+ */
 export function getServerMixpanelToken(): string {
   // Return empty string on client side
   if (typeof window !== "undefined") return "";
 
   return validateConfig(
     "MIXPANEL_SERVER_TOKEN",
-    process.env.MIXPANEL_SERVER_TOKEN || "",
+    process.env.MIXPANEL_SERVER_TOKEN ||
+      process.env.NEXT_PUBLIC_MIXPANEL_TOKEN ||
+      "",
     false, // Optional - analytics can fail gracefully
   );
 }
@@ -74,4 +87,61 @@ export function getServerMixpanelToken(): string {
 export function getAggregatorSenderApiKey(): string {
   if (typeof window !== "undefined") return "";
   return (process.env.AGGREGATOR_SENDER_API_KEY_ID || "").trim();
+}
+
+/**
+ * Canonical public origin of this deployment (e.g. https://noblocks.xyz).
+ *
+ * A security boundary, not a display value: it is the SIWE `domain` allowed to
+ * mint a session (app/api/auth/injected/verify) and the origin allowed to POST
+ * to /api/track-logout. Configured, never derived from the request Host header —
+ * a phisher could otherwise have a victim sign for their domain and replay it
+ * here behind a spoofed Host.
+ *
+ * NEXT_PUBLIC_APP_URL is the legacy name and still works. No client code reads
+ * it, so the prefix only ever misrepresented this as browser-facing config.
+ */
+export function getAppUrl(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "").trim();
+}
+
+/**
+ * Moralis stream credentials, used to register deposit-watch addresses and to
+ * verify the signature on incoming stream webhooks. SERVER-ONLY.
+ */
+export const moralisConfig = {
+  streamId: process.env.MORALIS_STREAM_ID || "",
+  apiKey: process.env.MORALIS_API_KEY || "",
+  baseUrl: process.env.MORALIS_BASE_URL || "https://api.moralis-streams.com",
+  webhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
+};
+
+/**
+ * Activepieces webhook endpoints. Each is optional — an unset URL means that
+ * forward is skipped rather than failing the request. SERVER-ONLY.
+ */
+export const activepiecesConfig = {
+  /** Deposit forwarding, fired from the Moralis stream webhook. */
+  depositWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
+  /** Signup email verification flow. */
+  signupVerifyWebhookUrl:
+    process.env.ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL || "",
+  /** KYC decision notifications (SmileID callback, tier 3, phone OTP). */
+  kycResultWebhookUrl: process.env.ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL || "",
+};
+
+/** LayerSwap API key (EVM earn bridge). SERVER-ONLY. */
+export function getLayerswapApiKey(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.LAYERSWAP_API_KEY || "").trim();
+}
+
+/**
+ * LayerSwap API base URL. Read lazily rather than at module scope so the
+ * validation warning in resolveLayerswapApiBaseUrl fires per call on the
+ * server instead of once during `next build`.
+ */
+export function getLayerswapApiBase(): string {
+  return resolveLayerswapApiBaseUrl(process.env.LAYERSWAP_API_BASE_URL);
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -479,7 +479,6 @@ export type Config = {
   rpcUrlKey: string;
   mixpanelToken: string;
   hotjarSiteId: number;
-  googleVerificationCode: string;
   noticeBannerText?: string; // Optional, for dynamic notice banner text
   brevoConversationsId: string; // Brevo chat widget ID
   brevoConversationsGroupId?: string; // Brevo chat widget group ID for routing
@@ -490,21 +489,6 @@ export type Config = {
   maintenanceSchedule: string; // e.g. "Friday, February 13th, from 7:00 PM to 11:00 PM WAT"
   referralMinQualifyingVolumeUsd: number;
   referralRewardAmountUsd: number;
-  moralisWebhookSecret: string;
-  activepiecesWebhookUrl: string;
-  /**
-   * Activepieces webhook for the Tier 1 "verify your phone" email (Brevo flow),
-   * triggered on new email signups. Payload `event`: "signup_verify_phone".
-   */
-  activepiecesSignupVerifyWebhookUrl: string;
-  /**
-   * Activepieces webhook for SmileID identity result emails (Brevo flow).
-   * Payload `event`: "kyc_result" with `status`: "success" | "failure".
-   */
-  activepiecesKycResultWebhookUrl: string;
-  moralisStreamId: string;
-  moralisApiKey: string;
-  moralisBaseUrl: string;
   /** Starknet Earn (Vesu via Starkzap). Requires Starknet wallet + API routes. */
   earnEnabled: boolean;
   /** EVM → Starknet Earn via LayerSwap (Phase 2). Requires LAYERSWAP_API_KEY server-side. */
@@ -534,9 +518,6 @@ export type Config = {
   fantasyCampaignEnded: boolean;
   /** Embeddable widget feature flag. Gates the /widget route (iframe embed for whitelisted partners). */
   embedEnabled: boolean;
-  /** LayerSwap API key (server-side only; used by /api/earn/layerswap/*). */
-  layerswapApiKey: string;
-  layerswapApiBaseUrl: string;
 };
 
 export type Network = {
@@ -646,7 +627,7 @@ export interface TransactionUpdateInput {
   txHash?: string;
 }
 
-export type JWTProvider = "privy" | "thirdweb";
+export type JWTProvider = "privy";
 
 export interface JWTProviderConfig {
   provider: JWTProvider;
@@ -654,10 +635,6 @@ export interface JWTProviderConfig {
     jwksUrl: string;
     issuer: string;
     algorithms: string[];
-  };
-  thirdweb?: {
-    clientId: string;
-    domain: string;
   };
 }
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -263,6 +263,11 @@ CREATE POLICY "Allow user registration"
 
 ### Client-Side Auth Setup
 
+> Illustrative only — Noblocks has no browser Supabase client today, and neither
+> `NEXT_PUBLIC_SUPABASE_URL` nor `NEXT_PUBLIC_SUPABASE_ANON_KEY` exists. Server
+> code reads `SUPABASE_URL` / `SUPABASE_SECRET_KEY`; see
+> [environment-variables.md](environment-variables.md).
+
 ```typescript
 import { createClient } from '@supabase/supabase-js';
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,6 +1,8 @@
 # Environment Variables
 
-This document lists all environment variables used by the Noblocks application. Most variables are optional; required ones depend on which features you want to enable locally.
+This document explains the environment variables used by the Noblocks application. Most variables are optional; required ones depend on which features you want to enable locally.
+
+[`.env.example`](../.env.example) is the canonical list — `__tests__/envDocumentation.test.ts` fails CI when it drifts from the variables the code reads. This document is the prose companion and is not machine-checked, so treat `.env.example` as the authority if the two ever disagree.
 
 ## Quick Start
 
@@ -15,6 +17,7 @@ This document lists all environment variables used by the Noblocks application. 
    - `NEXT_PUBLIC_PRIVY_APP_ID` – Your Privy app ID
    - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard
    - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
+   - `NEXT_PUBLIC_STARKNET_RPC_URL` – A Starknet JSON-RPC endpoint. `app/lib/starknet.ts` throws when it is missing, so any page that touches Starknet fails without it.
 
    `AGGREGATOR_SENDER_API_KEY_ID` (server-only — never `NEXT_PUBLIC_`) is optional for local UI exploration; set it when you need live order creation against the aggregator.
 
@@ -41,13 +44,21 @@ NEXT_PUBLIC_KYC_TIER_3_MONTHLY=2
 # Privy authentication app ID
 NEXT_PUBLIC_PRIVY_APP_ID=
 
-# RPC URL provider key
+# RPC URL provider key (Dwellir) — see "Keys that ship to the browser" below
 NEXT_PUBLIC_RPC_URL_KEY=
+
+# Starknet JSON-RPC endpoint. Required — app/lib/starknet.ts throws when unset
+NEXT_PUBLIC_STARKNET_RPC_URL=
 
 # Privy server-side secrets
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=https://auth.privy.io/api/v1/apps/<your-privy-app-id>/jwks.json
 PRIVY_ISSUER=privy.io
+# Optional: Privy wallet API base (defaults to https://api.privy.io)
+PRIVY_WALLET_API_URL=
+# Optional: authorization key for Privy wallet API calls (Starknet key export).
+# When unset, only the user signature is sent.
+PRIVY_WALLET_AUTH_PRIVATE_KEY=
 ```
 
 ### Database (Supabase)
@@ -61,9 +72,13 @@ SUPABASE_URL=https://your-project.supabase.co
 # Server admin secret key (sb_secret_...) — bypasses RLS, keep private!
 SUPABASE_SECRET_KEY=
 
-# Optional: Client-only publishable key if adding browser Supabase client later
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+# Passphrase for the encrypt_recipient_data / decrypt_recipient_data Postgres
+# functions protecting saved recipient details. Rotating it makes existing
+# encrypted rows unreadable.
+ENCRYPTION_KEY=
 ```
+
+There is no `NEXT_PUBLIC_SUPABASE_URL`: `app/lib/supabase.ts` reads `SUPABASE_URL` only, and the client never talks to Supabase directly.
 
 ### Client Analytics
 
@@ -120,12 +135,18 @@ Locally the tracer defaults to `localhost:8126` and is harmless with no agent ru
 
 ### Server-Side Analytics
 
+Powers `app/lib/server-analytics.ts`, which instruments every API route. With no token set, those events are dropped silently.
+
+Mixpanel's server token **is** the project token, so this is usually the same value as `NEXT_PUBLIC_MIXPANEL_TOKEN` — which is accepted as a fallback. Set `MIXPANEL_SERVER_TOKEN` explicitly if you want server events in a separate project.
+
 ```bash
-MIXPANEL_TOKEN=
+MIXPANEL_SERVER_TOKEN=              # Falls back to NEXT_PUBLIC_MIXPANEL_TOKEN
 MIXPANEL_PRIVACY_MODE=strict        # "strict" or "normal"
 MIXPANEL_INCLUDE_IP=false
 MIXPANEL_INCLUDE_ERROR_STACKS=false
 ```
+
+Defaults are privacy-safe when unset: wallet addresses and transaction IDs are always hashed, and IPs are hashed and error stacks dropped unless you opt in above.
 
 ### Client Error Reporting (Optional)
 
@@ -170,7 +191,10 @@ INJECTED_SESSION_SECRET=
 # SIWE messages must name this host (or an allowed embed origin) — configured,
 # never derived from the request Host header, so a signature phished on another
 # domain can't mint a session here.
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+#
+# Read on the server only (app/lib/server-config.ts → getAppUrl). The legacy
+# NEXT_PUBLIC_APP_URL still works as a fallback; prefer APP_URL.
+APP_URL=http://localhost:3000
 ```
 
 - **Minimum 32 characters.** The check runs lazily — when a token is actually
@@ -186,7 +210,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
   settings, not in a tracked file.
 - **Rotating it invalidates all live sessions.** Cost is low: users re-sign
   once, and tokens only last an hour anyway.
-- `NEXT_PUBLIC_APP_URL` must match the deployment's real public origin. If it
+- `APP_URL` must match the deployment's real public origin. If it
   still says `localhost:3000` in a deployed environment, sign-in fails with
   `401 Sign-in domain is not allowed` (embedded widgets additionally need the
   partner origin in `EMBED_ALLOWED_ORIGINS` or the `embed_allowed_origins`
@@ -200,6 +224,52 @@ ENABLE_WALLET_CONTEXT_SYNC=false
 
 # Starknet Earn (Vesu / Starkzap): wallet Earn CTA, deposit/withdraw, activity tab
 NEXT_PUBLIC_EARN_ENABLED=false
+# AVNU paymaster key — required whenever Starknet Earn is on, since the
+# paymaster runs in "sponsored" mode and throws without it
+STARKNET_PAYMASTER_API_KEY=
+# Gas token address; only used in non-sponsored mode (defaults to the first
+# token the paymaster reports as supported)
+STARKNET_GAS_TOKEN_ADDRESS=
+
+# EVM → Starknet Earn via LayerSwap. Requires NEXT_PUBLIC_EARN_ENABLED=true
+NEXT_PUBLIC_EVM_EARN_ENABLED=false
+LAYERSWAP_API_KEY=
+LAYERSWAP_API_BASE_URL=https://api.layerswap.io   # Optional; HTTPS only
+
+# Tron network + Privy Tron wallet
+NEXT_PUBLIC_TRON_ENABLED=false
+NEXT_PUBLIC_TRON_RPC_URL=                         # Optional; defaults to https://api.trongrid.io
+NEXT_PUBLIC_TRONGRID_API_KEY=                     # Optional; see the browser-exposed keys note below
+
+# HyperFX (Hyperbridge IntentGateway) USDC/USDT↔cNGN. Requires bridge enabled.
+NEXT_PUBLIC_HYPERFX_ENABLED=false
+ALCHEMY_API_KEY=                                  # Server-only ERC-4337 bundler
+# Hyperbridge Nexus endpoints; both optional, each falling back to the public
+# Polytope endpoint. The NEXT_PUBLIC_ pair is read by the browser swap client,
+# the unprefixed pair by the server quote route.
+NEXT_PUBLIC_HYPERBRIDGE_WS_URL=
+NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL=
+HYPERBRIDGE_WS_URL=
+HYPERBRIDGE_INDEXER_URL=
+
+# Textile FX v2 RFQ: USDT↔cNGN on BSC + Celo
+NEXT_PUBLIC_TEXTILE_ENABLED=false
+TEXTILE_API_KEY=
+
+# Noblocks Play (fantasy league)
+NEXT_PUBLIC_FANTASY_ENABLED=true
+# When true, public /play shows the campaign-ended announcement; /play/admin stays live
+NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED=true
+NEXT_PUBLIC_WORLDCUP_FOOTER_END_DATE=2026-07-19T23:59:59+01:00
+# Admin key for /api/play/admin/* (x-admin-key header). Unset = admin tooling OFF, never open
+FANTASY_ADMIN_KEY=
+# Shared secret for the Cloudflare worker POSTing /api/play/worker
+# (x-internal-auth header); falls back to INTERNAL_API_KEY
+FANTASY_WORKER_SECRET=
+# Dev-only: "true" compresses gameweek timing for local testing. Ignored in production
+FANTASY_LOCAL_TIMELAPSE=
+# API-Football key for fixtures, players and live scores
+API_FOOTBALL_KEY=
 
 # Referral program: show/hide UI and API routes
 NEXT_PUBLIC_REFERRAL_ENABLED=true
@@ -235,12 +305,15 @@ EMBED_ALLOWED_ORIGINS=
 INTERNAL_API_BASE_URL=
 ```
 
+#### Keys that ship to the browser
+
+`NEXT_PUBLIC_RPC_URL_KEY` (Dwellir) and `NEXT_PUBLIC_TRONGRID_API_KEY` are real provider credentials that are inlined into the client bundle by design — balance reads and RPC calls happen directly from the browser, so a server proxy would add a round trip to every one. Anyone can extract them from a deployed page.
+
+Treat them as public: restrict each key by origin in the provider's dashboard, and expect to rotate them like any published identifier. They protect quota, not access. `ALCHEMY_API_KEY` shows the alternative pattern — it stays server-side because `resolveHyperfxBundlerUrl` in `app/utils.ts` proxies through `/api/bridge/hyperfx/bundler` when called from the browser.
+
 ### External Services
 
 ```bash
-# SEO verification
-NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE=
-
 # Notice banner text (see docs/notice-banner.md)
 NEXT_PUBLIC_NOTICE_BANNER_TEXT=
 
@@ -260,10 +333,17 @@ SANITY_STUDIO_PROJECT_ID=your_project_id_here
 # Next.js App (client-side)
 NEXT_PUBLIC_SANITY_DATASET=production
 NEXT_PUBLIC_SANITY_PROJECT_ID=your_project_id_here
+```
 
-# Bundler / EIP-7702 sponsor
-NEXT_PUBLIC_BUNDLER_SERVER_URL=
+### Bundler / EIP-7702 Sponsor
+
+Sponsored batch calls are served by the in-process `/api/bundler` route; there is no external bundler URL to configure.
+
+```bash
+# Sponsor wallet that pays gas for batched EIP-7702 calls.
+# PRIVATE_KEY is a legacy alias, still accepted as a fallback.
 SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
+PRIVATE_KEY=
 ```
 
 ### Email & Communications
@@ -274,9 +354,28 @@ SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
 BREVO_API_KEY=
 # List ID from: Brevo Dashboard → Contacts → Lists (numeric)
 BREVO_LIST_ID=
+# From address on transactional email (defaults to no-reply@noblocks.xyz)
+BREVO_SENDER_EMAIL=
 # Brevo Conversations (chat widget)
 NEXT_PUBLIC_BREVO_CONVERSATIONS_ID=
 NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID=
+
+# Activepieces webhooks. Each is optional — an unset URL skips that forward.
+ACTIVEPIECES_WEBHOOK_URL=                  # Deposit forwarding, from the Moralis stream webhook
+ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL=    # Tier 1 "verify your phone" email
+ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL=       # SmileID identity result emails
+```
+
+### Moralis EVM Streams (Deposit Watching)
+
+Server-only. Stream and key from the Moralis Dashboard → Streams.
+
+```bash
+MORALIS_STREAM_ID=
+MORALIS_API_KEY=
+MORALIS_BASE_URL=https://api.moralis-streams.com
+# Verifies the x-signature header on incoming stream webhooks
+MORALIS_WEBHOOK_SECRET=
 ```
 
 ### Phone Verification
@@ -288,12 +387,14 @@ KUDISMS_API_KEY=your_kudisms_api_key
 KUDISMS_APP_NAME_CODE=your_app_name_code
 KUDISMS_TEMPLATE_CODE=your_template_code
 KUDISMS_SENDER_ID=Noblocks
+KUDISMS_TIMEOUT_MS=                   # Optional; default 10000
 
 # Twilio (international via Verify API)
 # Get from: Twilio Console → Account Dashboard
 TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_VERIFY_TIMEOUT_MS=             # Optional; default 5000
 ```
 
 ### KYC Verification Services
@@ -301,13 +402,14 @@ TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #### SmileID (Identity Verification)
 
 ```bash
-# API base URL — sandbox ("0"), production ("1"), or full URL
-SMILE_IDENTITY_BASE_URL="XXXXXX"
 SMILE_IDENTITY_API_KEY="your_api_key_here"
 SMILE_IDENTITY_PARTNER_ID="your_partner_id_here"
 SMILE_ID_CALLBACK_URL=""              # Callback URL for async results
-SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production
+SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production, or a legacy full API URL
+SMILE_IDENTITY_SERVER_MODE=           # Optional override, checked first. "0" or "1" only
 ```
+
+`resolveSmileIdServerConfig` in `app/lib/smileID.ts` checks `SMILE_IDENTITY_SERVER_MODE` before `SMILE_IDENTITY_SERVER`. A legacy full URL in `SMILE_IDENTITY_SERVER` is accepted and its mode inferred from whether the host looks like sandbox. Anything unrecognized logs a warning and fails closed, so KYC requests error rather than hitting the wrong environment.
 
 #### Dojah (Tier 3 Address / Proof-of-Address)
 
@@ -315,15 +417,13 @@ SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production
 DOJAH_APP_ID=<YOUR_APP_ID>
 DOJAH_SECRET_KEY=<YOUR_SECRET_KEY>
 DOJAH_BASE_URL=https://api.dojah.io
-
-# Optional: Default false — send only input_type + input_value per Dojah docs
-# DOJAH_UTILITY_BILL_SEND_ADDRESS_FIELDS=true
-# Optional: Default true — retry base64 if URL submission fails (Dojah often can't fetch URLs)
-# DOJAH_UTILITY_BILL_BASE64_FALLBACK=false
+DOJAH_TIMEOUT_MS=                     # Optional; default 25000
 
 # Supabase Storage bucket for KYC documents (create in Supabase Dashboard → Storage)
 KYC_DOCUMENTS_BUCKET=kyc-documents
 ```
+
+Utility-bill submission has no toggles: `app/lib/dojah.ts` always sends the address fields alongside `input_type: "url"`, and submits the document URL with no base64 retry.
 
 ### Campaign Management
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -231,7 +231,8 @@ STARKNET_PAYMASTER_API_KEY=
 # token the paymaster reports as supported)
 STARKNET_GAS_TOKEN_ADDRESS=
 
-# EVM → Starknet Earn via LayerSwap. Requires NEXT_PUBLIC_EARN_ENABLED=true
+# EVM → Starknet Earn via LayerSwap. Needs NEXT_PUBLIC_EARN_ENABLED=true as
+# well — isEvmEarnEnabled() requires both flags.
 NEXT_PUBLIC_EVM_EARN_ENABLED=false
 LAYERSWAP_API_KEY=
 LAYERSWAP_API_BASE_URL=https://api.layerswap.io   # Optional; HTTPS only

--- a/docs/kyc-aml-workflow.md
+++ b/docs/kyc-aml-workflow.md
@@ -119,6 +119,11 @@ Limited verification for very small transaction caps (primarily testing).
 
 ### SmileID Integration
 
+> Sketch, not the shipped code. The identifiers here are placeholders — the real
+> implementation lives in `app/lib/smileID.ts` and resolves its base URL from
+> `SMILE_IDENTITY_SERVER` / `SMILE_IDENTITY_SERVER_MODE`. There is no
+> `SMILE_IDENTITY_BASE_URL` or `SMILE_IDENTITY_PROJECT_ID` variable.
+
 ```typescript
 interface SmileIDRequest {
   url: string;


### PR DESCRIPTION
Audits every `process.env` read against `.env.example`, `docs/environment-variables.md` and `ci.yml`, and fixes the drift. Two findings had real runtime impact.

## Server-side Mixpanel has never worked

`getServerMixpanelToken()` read `MIXPANEL_SERVER_TOKEN`; deployments set only `NEXT_PUBLIC_MIXPANEL_TOKEN`. With no token, `getMixpanel()` returns `null` and **all 326 instrumented call sites across 46 files** dropped every event, logging `"Mixpanel token not configured for server-side tracking"` per call.

Mixpanel's server token *is* the project token, so the public name is now accepted as a fallback.

> [!IMPORTANT]
> **Server analytics starts reporting on deploy** — 326 event types that have never reached Mixpanel. Privacy defaults are unchanged and safe: wallet addresses and transaction IDs are always hashed; IPs are hashed and error stacks dropped unless explicitly opted in via `MIXPANEL_INCLUDE_IP` / `MIXPANEL_INCLUDE_ERROR_STACKS`.

## Server secrets lived in a client-imported module

`app/lib/config.ts` held `MORALIS_API_KEY`, `MORALIS_WEBHOOK_SECRET`, `LAYERSWAP_API_KEY` and the Activepieces webhook URLs while being imported by 14 `"use client"` files. Nothing leaked — webpack replaces non-`NEXT_PUBLIC_` reads with `undefined` in the browser — but the fields were silently empty client-side, which is exactly what `server-config.ts` exists to prevent.

`layerswap.ts` was the sharp edge: it read config at module scope *and* was pulled into the client graph by two hooks importing its status predicates. Those predicates move to `app/lib/layerswapStatus.ts`, and `layerswap.ts` now declares `server-only` — so `next build` itself proves the client edge is cut.

## Also in this PR

- **Dead code removed** — `DEFAULT_THIRDWEB_CONFIG` (zero importers; `jwt.ts` threw `"not implemented yet"`), `config.googleVerificationCode` (read, never consumed), and error strings citing `NEXT_PUBLIC_BUNDLER_SERVER_URL` / `NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS` — both ignored by the code that named them. The `HYPERBRIDGE_*` fallbacks in the client hyperfx module could never fire.
- **`NEXT_PUBLIC_APP_URL` → `APP_URL`** — it gates SIWE sign-in and a CSRF check and is read only on the server, so the prefix misrepresented a security boundary as browser config.
- **`.env.example` is now canonical** — ~30 live but undocumented variables added (including the *required* `NEXT_PUBLIC_STARKNET_RPC_URL`, which `app/lib/starknet.ts` throws without), six phantom entries removed (`MIXPANEL_TOKEN`, `SMILE_IDENTITY_BASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, and the two `DOJAH_UTILITY_BILL_*` flags that git history shows were never implemented), duplicate `BREVO_LIST_ID` deduped.
- **`ci.yml`** drops four env vars nothing reads — including `SENTRY_AUTH_TOKEN` / `SENTRY_URL`, which only matter with a sourcemap-upload step this project doesn't have.
- **`__tests__/envDocumentation.test.ts`** fails CI in both directions, so this class of drift cannot silently return.

## Deployment

**No environment change is needed before merging.** Both renames keep a fallback (`APP_URL || NEXT_PUBLIC_APP_URL`, `MIXPANEL_SERVER_TOKEN || NEXT_PUBLIC_MIXPANEL_TOKEN`).

Follow-up: set `APP_URL` per environment, then drop the `NEXT_PUBLIC_APP_URL` fallback.

Worth confirming separately that `NEXT_PUBLIC_STARKNET_RPC_URL` is actually set everywhere — it was required and documented nowhere.

## Verification

- `pnpm test` — 62 suites, 647 tests pass
- `pnpm build` — succeeds; the load-bearing check, since `server-only` in `layerswap.ts` only compiles if no client importer remains
- `tsc --noEmit` — clean
- The drift guard was confirmed to fail in both directions (removed an entry, added a bogus one)

## Out of scope

Proxying `NEXT_PUBLIC_RPC_URL_KEY` / `NEXT_PUBLIC_TRONGRID_API_KEY` behind server routes — both are real provider keys that ship in the bundle by design for direct-from-browser RPC. Now documented as such, with a note to origin-restrict them at the provider. `ALCHEMY_API_KEY` shows the alternative pattern if we ever want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup and environment-variable guidance, including Starknet RPC requirements and current service settings.
  * Clarified authentication and KYC documentation, including illustrative-only examples and active server-side configuration.

* **Configuration**
  * Added canonical application URL support and expanded wallet, analytics, bridge, monitoring, webhook, and provider settings.
  * Updated Mixpanel naming while retaining legacy application URL compatibility.

* **Bug Fixes**
  * Improved configuration validation and user-facing errors for sponsored transactions and delegation contracts.

* **Tests**
  * Added checks to ensure application environment variables are fully documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->