### PR TITLE
fix(refund): ask for account name when verify returns OK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
-
-
 # Noblocks Environment Variables
 # Copy this file to .env.local and fill in your values
 # See: docs/environment-variables.md for detailed info about each env. variable
+#
+# This file is the canonical list. __tests__/envDocumentation.test.ts fails CI if
+# code reads a variable that is missing here, or if an entry here is read nowhere.
 
 # =============================================================================
 # Core Application
@@ -21,12 +22,25 @@ NEXT_PUBLIC_KYC_TIER_3_MONTHLY=2
 
 # Authentication Services
 NEXT_PUBLIC_PRIVY_APP_ID=
+
+# RPC provider key (Dwellir), interpolated into per-network RPC URLs.
+# ⚠️ Ships in the browser bundle — balance reads happen client-side. Treat it as
+# public and restrict it by origin at the provider; it is not a secret.
 NEXT_PUBLIC_RPC_URL_KEY=
 
+# Starknet JSON-RPC endpoint. REQUIRED whenever Starknet is reachable —
+# app/lib/starknet.ts throws when it is missing or empty.
+NEXT_PUBLIC_STARKNET_RPC_URL=
+
 # Client error reporting (Sentry-compatible DSN, e.g. GlitchTip)
-# Leave empty to disable. Optional: NEXT_PUBLIC_SENTRY_ENVIRONMENT, NEXT_PUBLIC_SENTRY_RELEASE
-# Set NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=true to send events from local dev
+# Leave empty to disable. Browser-only; no @sentry/nextjs plugin or sourcemap upload.
 NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_ENVIRONMENT=
+NEXT_PUBLIC_SENTRY_RELEASE=
+# 0–1; default 0 (tracing off)
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0
+# Send events from local dev when "true"
+NEXT_PUBLIC_SENTRY_ENABLE_IN_DEV=false
 
 # =============================================================================
 # Database & Authentication
@@ -34,21 +48,25 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # Supabase Database
 # Get these from: Supabase Dashboard → Project Settings → API
+# Server code reads SUPABASE_URL only — there is no NEXT_PUBLIC_ variant.
 SUPABASE_URL=https://your-project.supabase.co
-# Optional Next.js-style URL (either works for server)
-# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-#
 # Server API routes (supabaseAdmin): **Secret** key only — sb_secret
 SUPABASE_SECRET_KEY=
-#
-# Client-only if you add a browser Supabase client later (not used by current server admin)
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-#
+
+# Passphrase for the encrypt_recipient_data / decrypt_recipient_data Postgres
+# functions that protect saved recipient details. Rotating it makes existing
+# encrypted rows unreadable.
+ENCRYPTION_KEY=
 
 # Privy Authentication
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=https://auth.privy.io/api/v1/apps/<your-privy-app-id>/jwks.json
 PRIVY_ISSUER=privy.io
+# Optional: Privy wallet API base (defaults to https://api.privy.io)
+PRIVY_WALLET_API_URL=
+# Optional: authorization key for Privy wallet API calls (Starknet key export).
+# When unset, only the user signature is sent.
+PRIVY_WALLET_AUTH_PRIVATE_KEY=
 
 # =============================================================================
 # Analytics
@@ -82,8 +100,11 @@ DD_TRACE_AGENT_PORT=8126
 DD_TRACE_ENABLED=true
 LOG_LEVEL=info
 
-# Server-side Analytics
-MIXPANEL_TOKEN=
+# Server-side Analytics (app/lib/server-analytics.ts).
+# Mixpanel's server token IS the project token, so this is usually the same
+# value as NEXT_PUBLIC_MIXPANEL_TOKEN. Unset here, NEXT_PUBLIC_MIXPANEL_TOKEN is
+# used as a fallback; with neither set, every server-side event is dropped.
+MIXPANEL_SERVER_TOKEN=
 MIXPANEL_PRIVACY_MODE=strict
 MIXPANEL_INCLUDE_IP=false
 MIXPANEL_INCLUDE_ERROR_STACKS=false
@@ -112,7 +133,15 @@ ENABLE_WALLET_CONTEXT_SYNC=false
 # Starknet Earn (Vesu / Starkzap): wallet Earn CTA, deposit/withdraw, activity tab
 NEXT_PUBLIC_EARN_ENABLED=false
 
-# EVM → Starknet Earn (LayerSwap bridge + Vesu). Requires NEXT_PUBLIC_EARN_ENABLED=true
+# AVNU paymaster for Starknet gas sponsorship.
+# Required whenever Starknet Earn is on (the paymaster runs in "sponsored" mode).
+STARKNET_PAYMASTER_API_KEY=
+# Optional: gas token address, used only in non-sponsored mode.
+# Defaults to the first token the paymaster reports as supported.
+STARKNET_GAS_TOKEN_ADDRESS=
+
+# EVM → Starknet Earn (LayerSwap bridge + Vesu). Needs NEXT_PUBLIC_EARN_ENABLED=true
+# as well — isEvmEarnEnabled() requires both flags.
 NEXT_PUBLIC_EVM_EARN_ENABLED=false
 LAYERSWAP_API_KEY=
 # Optional; must use HTTPS if set
@@ -120,9 +149,11 @@ LAYERSWAP_API_BASE_URL=https://api.layerswap.io #optional
 
 NEXT_PUBLIC_TRON_ENABLED=false
 # Optional: custom Tron RPC URL (defaults to https://api.trongrid.io)
-# NEXT_PUBLIC_TRON_RPC_URL=
-# Optional: TronGrid API key for balance lookups (higher rate limits)
-# NEXT_PUBLIC_TRONGRID_API_KEY=
+NEXT_PUBLIC_TRON_RPC_URL=
+# Optional: TronGrid API key for balance lookups (higher rate limits).
+# ⚠️ Ships in the browser bundle and is sent as the TRON-PRO-API-KEY header from
+# client code. Restrict it by origin at TronGrid; treat it as public.
+NEXT_PUBLIC_TRONGRID_API_KEY=
 
 # Referral Program: show/hide all referral UI and API routes
 NEXT_PUBLIC_REFERRAL_ENABLED=true
@@ -143,6 +174,13 @@ NEXT_PUBLIC_BRIDGE_DEFAULT_SLIPPAGE_BPS=50
 # Requires NEXT_PUBLIC_BRIDGE_ENABLED=true and ALCHEMY_API_KEY (server-only ERC-4337 bundler).
 NEXT_PUBLIC_HYPERFX_ENABLED=false
 ALCHEMY_API_KEY=
+# Hyperbridge Nexus endpoints. The NEXT_PUBLIC_ pair is read by the browser swap
+# client; the unprefixed pair by the server quote route. Both optional — each
+# falls back to the public Polytope endpoint.
+NEXT_PUBLIC_HYPERBRIDGE_WS_URL=
+NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL=
+HYPERBRIDGE_WS_URL=
+HYPERBRIDGE_INDEXER_URL=
 
 # Embeddable widget (/widget route, iframed by whitelisted partners)
 NEXT_PUBLIC_EMBED_ENABLED=false
@@ -169,14 +207,14 @@ INJECTED_SESSION_SECRET=
 # SIWE sign-in messages must name this host (or an allowed embed origin) —
 # configured, never derived from the request Host header, so a signature
 # phished on another domain can't mint a session here.
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Read on the server only. NEXT_PUBLIC_APP_URL is the legacy name and still
+# works as a fallback; prefer APP_URL.
+APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=
 
 # =============================================================================
 # External Services
 # =============================================================================
-
-# SEO
-NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE=
 
 # Notice Banner
 # See docs/notice-banner.md
@@ -194,15 +232,27 @@ NEXT_PUBLIC_MAINTENANCE_SCHEDULE=Friday, February 13th, from 7:00 PM to 11:00 PM
 BREVO_API_KEY=
 # List ID from: Brevo Dashboard → Contacts → Lists (numeric ID)
 BREVO_LIST_ID=
-BREVO_LIST_ID=
+# From address on transactional email (defaults to no-reply@noblocks.xyz)
+BREVO_SENDER_EMAIL=
 # Brevo Conversations (Chat Widget)
 # Get from: Brevo Dashboard → Conversations → Settings
 NEXT_PUBLIC_BREVO_CONVERSATIONS_ID=
 NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID=
 
-# Activepieces webhooks for KYC
+# Activepieces webhooks. Each is optional — an unset URL skips that forward.
+# Deposit forwarding, fired from the Moralis stream webhook:
+ACTIVEPIECES_WEBHOOK_URL=
 ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL=
 ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL=
+
+# Moralis EVM streams — deposit watching. Server-only.
+# Stream and key from: Moralis Dashboard → Streams
+MORALIS_STREAM_ID=
+MORALIS_API_KEY=
+MORALIS_BASE_URL=https://api.moralis-streams.com
+# Shared secret used to verify the x-signature header on incoming stream webhooks
+MORALIS_WEBHOOK_SECRET=
+
 # =============================================================================
 # Phone Verification Services
 # =============================================================================
@@ -213,6 +263,8 @@ KUDISMS_API_KEY=your_kudisms_api_key
 KUDISMS_APP_NAME_CODE=your_app_name_code
 KUDISMS_TEMPLATE_CODE=your_template_code
 KUDISMS_SENDER_ID=Noblocks
+# Optional request timeout, default 10000
+KUDISMS_TIMEOUT_MS=
 
 # Twilio (for international phone numbers via Verify API)
 # Get from: Twilio Console → Account Dashboard
@@ -220,13 +272,13 @@ TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 # Verify service SID: Twilio Console → Verify → Services → create or use default
 TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Optional request timeout, default 5000
+TWILIO_VERIFY_TIMEOUT_MS=
 
 # =============================================================================
 # SmileID KYC Verification Services
 # =============================================================================
 
-# API base URL — see Smile Identity docs (sandbox vs production)
-SMILE_IDENTITY_BASE_URL="XXXXXX"
 # API key from Smile Identity portal
 SMILE_IDENTITY_API_KEY="your_api_key_here"
 # Partner ID from Smile Identity portal
@@ -235,6 +287,8 @@ SMILE_IDENTITY_PARTNER_ID="your_partner_id_here"
 SMILE_ID_CALLBACK_URL=""
 # "0" = sandbox, "1" = production (or a legacy full API URL string)
 SMILE_IDENTITY_SERVER="0"
+# Optional override, checked before SMILE_IDENTITY_SERVER. "0" or "1" only.
+SMILE_IDENTITY_SERVER_MODE=
 
 # =============================================================================
 # Dojah – Tier 3 address / proof-of-address verification
@@ -243,10 +297,8 @@ SMILE_IDENTITY_SERVER="0"
 DOJAH_APP_ID=<DOJAH_APP_ID_PLACEHOLDER>
 DOJAH_SECRET_KEY=<DOJAH_SECRET_KEY_PLACEHOLDER>
 DOJAH_BASE_URL=https://api.dojah.io
-# Optional. Default false — send only input_type + input_value per Dojah docs (avoids some 5xx).
-# DOJAH_UTILITY_BILL_SEND_ADDRESS_FIELDS=true
-# Optional. Default true — if URL submission gets 500/502/503/504, retry with base64 (Dojah often cannot fetch Supabase URLs).
-# DOJAH_UTILITY_BILL_BASE64_FALLBACK=false
+# Optional request timeout, default 25000
+DOJAH_TIMEOUT_MS=
 # Supabase Storage bucket for KYC document uploads (create in Supabase Dashboard → Storage)
 KYC_DOCUMENTS_BUCKET=kyc-documents
 
@@ -265,6 +317,17 @@ NEXT_PUBLIC_FANTASY_ENABLED=true
 NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED=true
 # World Cup footer Lottie (requires fantasy enabled and not campaign-ended; ends Jul 19 2026 by default)
 NEXT_PUBLIC_WORLDCUP_FOOTER_END_DATE=2026-07-19T23:59:59+01:00
+
+# Noblocks Play backend.
+# Admin key for /api/play/admin/* (sent as x-admin-key). Unset = admin tooling OFF.
+FANTASY_ADMIN_KEY=
+# Shared secret for the Cloudflare worker that POSTs /api/play/worker
+# (sent as x-internal-auth). Falls back to INTERNAL_API_KEY when unset.
+FANTASY_WORKER_SECRET=
+# Dev-only: "true" compresses gameweek timing for local testing. Ignored in production.
+FANTASY_LOCAL_TIMELAPSE=
+# API-Football key used to pull fixtures, players and live scores
+API_FOOTBALL_KEY=
 
 # BlockFest Cashback Wallet
 # ⚠️ WARNING: These credentials control funds and must be kept secure
@@ -288,9 +351,14 @@ SANITY_STUDIO_PROJECT_ID=your_project_id_here
 NEXT_PUBLIC_SANITY_DATASET=production
 NEXT_PUBLIC_SANITY_PROJECT_ID=your_project_id_here
 
+# =============================================================================
 # Bundler / EIP-7702 sponsor
-NEXT_PUBLIC_BUNDLER_SERVER_URL=
+# =============================================================================
+
+# Sponsor wallet that pays gas for batched EIP-7702 calls.
+# PRIVATE_KEY is a legacy alias, still accepted as a fallback.
 SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
+PRIVATE_KEY=
 
 # Onramp chained forwarding
 # When true, onramp crypto settles to the user's Noblocks wallet first, then is auto-forwarded
@@ -301,3 +369,16 @@ NEXT_PUBLIC_KES_ONRAMP_ENABLED=false
 
 NEXT_PUBLIC_REFERRAL_MIN_QUALIFYING_VOLUME_USD=20 # in USDC
 NEXT_PUBLIC_REFERRAL_REWARD_AMOUNT_USD=1 # in USDC
+
+# =============================================================================
+# Scripts only (not read by the app)
+# =============================================================================
+
+# scripts/seed-fantasy.ts
+SEED_DELAY_MS=
+SEED_SKIP_PLAYERS=
+SEED_TIMELAPSE_HOURS=
+SEED_TIMELAPSE_GWS=
+# scripts/backfill-moralis-from-privy.ts
+DRY_RUN=
+MORALIS_MS_DELAY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Configured repo secrets
-      AGGREGATOR_DATABASE_URL: ${{ secrets.AGGREGATOR_DATABASE_URL }}
+      # Configured repo secrets. Nothing else belongs here: an env var no code
+      # reads is a secret exposed to the build for no reason. SENTRY_AUTH_TOKEN,
+      # SENTRY_URL, AGGREGATOR_DATABASE_URL and NEXT_PUBLIC_SUPABASE_URL were
+      # removed for that reason — the first two only matter with a sourcemap
+      # upload step, which this project does not have (@sentry/react only, no
+      # @sentry/nextjs); re-add them alongside the step that needs them.
       BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
       BREVO_LIST_ID: ${{ secrets.BREVO_LIST_ID }}
       NEXT_PUBLIC_AGGREGATOR_URL: ${{ secrets.NEXT_PUBLIC_AGGREGATOR_URL }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_URL: ${{ secrets.SENTRY_URL }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       # Dummy values for vars required at build time but not in repo secrets

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Visit the live site at [noblocks.xyz](https://noblocks.xyz).
      - `NEXT_PUBLIC_PRIVY_APP_ID` – Your Privy app ID ([sign up here](https://www.privy.io/))
      - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard → Project Settings → API
      - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
+     - `NEXT_PUBLIC_STARKNET_RPC_URL` – A Starknet JSON-RPC endpoint; anything touching Starknet throws without it
 
    See [`.env.example`](.env.example) or [docs/environment-variables.md](docs/environment-variables.md) for all options, including optional variables such as `AGGREGATOR_SENDER_API_KEY_ID` for live order creation.
 

--- a/__tests__/envDocumentation.test.ts
+++ b/__tests__/envDocumentation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Keeps .env.example in step with the environment variables the code actually
+ * reads, in both directions:
+ *
+ *   - a `process.env.X` read with no entry in .env.example is a variable nobody
+ *     knows to set (this is how NEXT_PUBLIC_STARKNET_RPC_URL became a required
+ *     but undocumented var);
+ *   - an entry in .env.example that nothing reads is a variable people set in
+ *     good faith and wonder why it has no effect (this is how MIXPANEL_TOKEN
+ *     survived after the code moved to MIXPANEL_SERVER_TOKEN).
+ *
+ * .env.example is canonical. docs/environment-variables.md is prose and is not
+ * checked here.
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const REPO_ROOT = join(__dirname, "..");
+
+/** Directories and files scanned for `process.env` reads. */
+const SCAN_TARGETS = [
+  "app",
+  "middleware.ts",
+  "instrumentation.ts",
+  "next.config.mjs",
+  "sanity.config.ts",
+  "sanity.cli.ts",
+];
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+/**
+ * Variables deliberately absent from .env.example. Every entry needs a reason —
+ * "it is noisy" is not one. Prefer documenting the variable instead.
+ */
+const NOT_IN_ENV_EXAMPLE = new Set([
+  // Supplied by Node and Next.js themselves; never set by an operator.
+  "NODE_ENV",
+  "NEXT_RUNTIME",
+]);
+
+function collectSourceFiles(target: string): string[] {
+  const absolute = join(REPO_ROOT, target);
+  let stats;
+  try {
+    stats = statSync(absolute);
+  } catch {
+    return []; // Optional target (e.g. instrumentation.ts) not present.
+  }
+
+  if (stats.isFile()) {
+    return SOURCE_EXTENSIONS.some((ext) => absolute.endsWith(ext))
+      ? [absolute]
+      : [];
+  }
+
+  const files: string[] = [];
+  for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const child = join(target, entry.name);
+    files.push(...collectSourceFiles(child));
+  }
+  return files;
+}
+
+/** `process.env.FOO` and `process.env["FOO"]`, uppercase names only. */
+const ENV_READ_RE =
+  /process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]/g;
+
+function envVarsReadInCode(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  for (const target of SCAN_TARGETS) {
+    for (const file of collectSourceFiles(target)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(ENV_READ_RE)) {
+        const name = match[1] ?? match[2];
+        const relative = file.slice(REPO_ROOT.length + 1);
+        const seen = found.get(name);
+        if (seen) {
+          if (!seen.includes(relative)) seen.push(relative);
+        } else {
+          found.set(name, [relative]);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+/** Entries in .env.example, whether set (`X=`) or commented out (`# X=`). */
+function envVarsInExample(): Set<string> {
+  const contents = readFileSync(join(REPO_ROOT, ".env.example"), "utf8");
+  const names = new Set<string>();
+  for (const line of contents.split("\n")) {
+    const match = /^\s*#?\s*([A-Z][A-Z0-9_]*)\s*=/.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+describe(".env.example", () => {
+  const readInCode = envVarsReadInCode();
+  const documented = envVarsInExample();
+
+  it("scans a plausible number of files", () => {
+    // Guards against a refactor silently emptying SCAN_TARGETS and turning both
+    // assertions below into no-ops.
+    expect(readInCode.size).toBeGreaterThan(50);
+  });
+
+  it("documents every environment variable the code reads", () => {
+    const undocumented = [...readInCode.entries()]
+      .filter(([name]) => !documented.has(name))
+      .filter(([name]) => !NOT_IN_ENV_EXAMPLE.has(name))
+      .map(([name, files]) => `  ${name} — read in ${files.join(", ")}`)
+      .sort();
+
+    expect(
+      undocumented.length === 0
+        ? ""
+        : `These variables are read by the app but missing from .env.example.\n` +
+            `Add an entry (an empty \`NAME=\` is fine) so operators know it exists:\n` +
+            undocumented.join("\n"),
+    ).toBe("");
+  });
+
+  it("has no entries the code never reads", () => {
+    const unused = [...documented]
+      .filter((name) => !readInCode.has(name))
+      // Script-only variables live in .env.example for discoverability but are
+      // read under scripts/, which is outside SCAN_TARGETS.
+      .filter((name) => !SCRIPT_ONLY.has(name))
+      .sort();
+
+    expect(
+      unused.length === 0
+        ? ""
+        : `These entries in .env.example are read nowhere in the app.\n` +
+            `Remove them, or fix the name if the code uses a different one:\n` +
+            unused.map((name) => `  ${name}`).join("\n"),
+    ).toBe("");
+  });
+});
+
+/** Documented for operators, but only read by files under scripts/. */
+const SCRIPT_ONLY = new Set([
+  "SEED_DELAY_MS",
+  "SEED_SKIP_PLAYERS",
+  "SEED_TIMELAPSE_HOURS",
+  "SEED_TIMELAPSE_GWS",
+  "DRY_RUN",
+  "MORALIS_MS_DELAY",
+]);

--- a/__tests__/kes-mpesa-channel.test.ts
+++ b/__tests__/kes-mpesa-channel.test.ts
@@ -4,6 +4,7 @@ import {
   formatKesMpesaAccountDisplay,
   formatRecipientInstitutionDisplay,
   isSameSavedRecipient,
+  isUnresolvedAccountName,
   normalizeSavedRecipientChannel,
   getKesMpesaInstitutionLabel,
   KES_MPESA_INSTITUTION_CODE,
@@ -170,5 +171,29 @@ describe("KES M-Pesa virtual institution split", () => {
     expect(
       isSameSavedRecipient(base, { ...base, businessNumber: null }),
     ).toBe(true);
+  });
+});
+
+describe("unresolved account names", () => {
+  it("treats the aggregator's OK sentinel as unresolved, in any casing", () => {
+    expect(isUnresolvedAccountName("OK")).toBe(true);
+    expect(isUnresolvedAccountName("ok")).toBe(true);
+    expect(isUnresolvedAccountName("Ok")).toBe(true);
+    expect(isUnresolvedAccountName("  OK  ")).toBe(true);
+  });
+
+  it("treats empty and missing names as unresolved", () => {
+    expect(isUnresolvedAccountName("")).toBe(true);
+    expect(isUnresolvedAccountName("   ")).toBe(true);
+    expect(isUnresolvedAccountName(undefined)).toBe(true);
+    expect(isUnresolvedAccountName(null)).toBe(true);
+  });
+
+  it("keeps real account names, including ones that merely contain 'ok'", () => {
+    expect(isUnresolvedAccountName("John Doe")).toBe(false);
+    expect(isUnresolvedAccountName("Okon Effiong")).toBe(false);
+    expect(isUnresolvedAccountName("Koko Stores")).toBe(false);
+    // A name that is only "ok" plus more text is a real name.
+    expect(isUnresolvedAccountName("OK Foods Ltd")).toBe(false);
   });
 });

--- a/__tests__/layerswapStarknetExecute.test.ts
+++ b/__tests__/layerswapStarknetExecute.test.ts
@@ -1,3 +1,5 @@
+jest.mock("server-only", () => ({}));
+
 import { layerswapDepositActionsToStarknetCalls } from "../app/lib/layerswap";
 
 describe("layerswapDepositActionsToStarknetCalls", () => {

--- a/__tests__/refundAccountRoute.test.ts
+++ b/__tests__/refundAccountRoute.test.ts
@@ -169,6 +169,22 @@ describe("handlePutRefundAccount", () => {
     expect(mockedFrom).not.toHaveBeenCalled();
   });
 
+  it("returns 422 when accountName is the unresolved OK sentinel", async () => {
+    const res = await handlePutRefundAccount(
+      putRequest({ ...validBody, accountName: "OK" }),
+    );
+    expect(res).toEqual({
+      status: 422,
+      body: {
+        success: false,
+        error:
+          "Account name could not be verified. Please enter the name on the account.",
+      },
+    });
+    expect(mockedResolveInstitution).not.toHaveBeenCalled();
+    expect(mockedFrom).not.toHaveBeenCalled();
+  });
+
   it("upserts with wallet+currency conflict target and aggregator institution name", async () => {
     mockedResolveInstitution.mockResolvedValue({
       ok: true,

--- a/app/api/auth/injected/verify/route.ts
+++ b/app/api/auth/injected/verify/route.ts
@@ -5,6 +5,7 @@ import { rateLimit } from "@/app/lib/rate-limit";
 import { supabaseAdmin } from "@/app/lib/supabase";
 import { SUPPORTED_CHAINS } from "@/app/lib/bundler/chains";
 import { getRpcUrl } from "@/app/utils";
+import { getAppUrl } from "@/app/lib/server-config";
 import {
   isSiweDomainAllowed,
   isSiweIssuedAtFresh,
@@ -41,7 +42,7 @@ const ORIGIN_RE =
 async function getAllowedSiweOrigins(): Promise<string[]> {
   const origins: string[] = [];
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  const appUrl = getAppUrl();
   if (appUrl && ORIGIN_RE.test(appUrl)) {
     origins.push(appUrl);
   }

--- a/app/api/kyc/signup-email/route.ts
+++ b/app/api/kyc/signup-email/route.ts
@@ -6,7 +6,7 @@ import {
   trackApiError,
 } from "@/app/lib/server-analytics";
 import { getEmailForMonitoredAddress } from "@/app/utils";
-import config from "@/app/lib/config";
+import { activepiecesConfig } from "@/app/lib/server-config";
 import { createKycReporter } from "@/app/lib/kyc-telemetry";
 
 /**
@@ -45,7 +45,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
       );
     }
 
-    const webhookUrl = config.activepiecesSignupVerifyWebhookUrl;
+    const webhookUrl = activepiecesConfig.signupVerifyWebhookUrl;
     if (!webhookUrl) {
       report.failed({
         walletAddress,

--- a/app/api/track-logout/route.ts
+++ b/app/api/track-logout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { trackServerEvent } from "@/app/lib/server-analytics";
+import { getAppUrl } from "@/app/lib/server-config";
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,7 +14,7 @@ export async function POST(request: NextRequest) {
 
     if (process.env.NODE_ENV === "production") {
       const origin = request.headers.get("origin");
-      const allowed = process.env.NEXT_PUBLIC_APP_URL;
+      const allowed = getAppUrl();
       if (
         origin &&
         allowed &&

--- a/app/api/webhooks/moralis/route.ts
+++ b/app/api/webhooks/moralis/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/app/lib/server-analytics";
 import { verifyMoralisSignature } from "@/app/utils";
 import { processMoralisDepositPayload } from "@/app/lib/moralis-deposit-processing";
-import config from "@/app/lib/config";
+import { moralisConfig } from "@/app/lib/server-config";
 import type { MoralisWebhookBody } from "@/app/types";
 
 /**
@@ -25,7 +25,7 @@ export const POST = withRateLimit(async (request: NextRequest) => {
     });
 
     const raw = await request.text();
-    const secret = config.moralisWebhookSecret;
+    const secret = moralisConfig.webhookSecret;
     const sig = request.headers.get("x-signature");
 
     if (secret) {

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -114,6 +114,13 @@ export function AddRefundAccountModal({
       setIsFetchingAccountName(false);
     };
 
+    // Bail before scheduling when the modal is closed so a late response cannot
+    // write a stale name that briefly shows on the next open.
+    if (!isOpen) {
+      stopWithoutLookup(null);
+      return;
+    }
+
     if (!selectedInstitution || !accountNumber) {
       setAccountNumberError(null);
       stopWithoutLookup(null);
@@ -186,7 +193,7 @@ export function AddRefundAccountModal({
     }, 800);
 
     return () => clearTimeout(timeoutId);
-  }, [selectedInstitution, accountNumber, currency, kycFullName]);
+  }, [isOpen, selectedInstitution, accountNumber, currency, kycFullName]);
 
   const filteredInstitutions = useMemo(
     () => filterAndSortInstitutions(institutions, bankSearchTerm),

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DialogTitle } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowDown01Icon, ArrowLeft02Icon, Tick02Icon } from "hugeicons-react";
+import {
+  ArrowDown01Icon,
+  ArrowLeft02Icon,
+  InformationSquareIcon,
+  Tick02Icon,
+} from "hugeicons-react";
 import { ImSpinner } from "react-icons/im";
 import { AnimatedModal, AnimatedFeedbackItem } from "@/app/components/AnimatedComponents";
 import { SearchInput } from "@/app/components/recipient/SearchInput";
 import { InputError } from "@/app/components/InputError";
 import type { InstitutionProps, RefundAccountDetails } from "@/app/types";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
+import {
+  classNames,
+  getOfframpAccountIdentifierPlaceholder,
+  filterAndSortInstitutions,
+  NGN_NUBAN_LENGTH,
+  isUnresolvedAccountName,
+} from "@/app/utils";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { primaryBtnClasses, secondaryBtnClasses } from "@/app/components/Styles";
 import { useKYC } from "@/app/context";
@@ -53,10 +64,12 @@ export function AddRefundAccountModal({
   const [accountName, setAccountName] = useState("");
   const [accountNumber, setAccountNumber] = useState("");
   const [isFetchingAccountName, setIsFetchingAccountName] = useState(false);
+  const [isAccountNameEditable, setIsAccountNameEditable] = useState(false);
   const [accountNumberError, setAccountNumberError] = useState<string | null>(null);
   const [accountNameError, setAccountNameError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const nameRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -65,6 +78,7 @@ export function AddRefundAccountModal({
     setFormError(null);
     setAccountNumberError(null);
     setAccountNameError(null);
+    setIsAccountNameEditable(false);
     if (initial) {
       const fromList = institutions.find(
         (i) => i.code === initial.institutionCode,
@@ -89,11 +103,20 @@ export function AddRefundAccountModal({
 
   // Auto-fetch account name when institution + account number are ready
   useEffect(() => {
-    setAccountName("");
-    setAccountNameError(null);
+    // Invalidate any in-flight lookup on every dependency change (including bail-outs).
+    const requestId = ++nameRequestIdRef.current;
+
+    const stopWithoutLookup = (message: string | null) => {
+      setIsAccountNameEditable(false);
+      setAccountName("");
+      setAccountNameError(message);
+      setFormError(null);
+      setIsFetchingAccountName(false);
+    };
 
     if (!selectedInstitution || !accountNumber) {
       setAccountNumberError(null);
+      stopWithoutLookup(null);
       return;
     }
 
@@ -102,17 +125,25 @@ export function AddRefundAccountModal({
     if (currency === "NGN") {
       if (digits.length === 0) {
         setAccountNumberError(null);
+        stopWithoutLookup(null);
         return;
       }
       if (digits.length !== NGN_NUBAN_LENGTH) {
         setAccountNumberError(
           `Please enter a valid 10-digit account number (${digits.length} entered).`,
         );
+        stopWithoutLookup(null);
         return;
       }
     }
 
+    // Drop any previously resolved/typed name so a stale success tick cannot
+    // suppress a later error, and so "OK" is never left visible while we re-verify.
+    setIsAccountNameEditable(false);
+    setAccountName("");
     setAccountNumberError(null);
+    setAccountNameError(null);
+    setFormError(null);
     setIsFetchingAccountName(true);
 
     const timeoutId = setTimeout(async () => {
@@ -121,27 +152,60 @@ export function AddRefundAccountModal({
           institution: selectedInstitution.code,
           accountIdentifier: digits || accountNumber,
         });
-        setAccountName(name);
-        if (kycFullName && !accountNameMatchesKyc(kycFullName, name)) {
-          setFormError(REFUND_NAME_MISMATCH_MESSAGE);
-        } else {
+        if (requestId !== nameRequestIdRef.current) return;
+
+        if (isUnresolvedAccountName(name)) {
+          // Same path as RecipientDetailsForm (#698): verification soft-failed with
+          // the "OK" sentinel. Ask for the account holder's name instead of showing
+          // "ok" with a green tick (and then failing KYC match against "OK").
+          setIsAccountNameEditable(true);
+          setAccountName("");
           setFormError(null);
+          setAccountNameError(null);
+        } else {
+          setIsAccountNameEditable(false);
+          setAccountName(name);
+          if (kycFullName && !accountNameMatchesKyc(kycFullName, name)) {
+            setFormError(REFUND_NAME_MISMATCH_MESSAGE);
+          } else {
+            setFormError(null);
+          }
+          setAccountNameError(null);
         }
-        setAccountNameError(null);
       } catch {
+        if (requestId !== nameRequestIdRef.current) return;
+        setIsAccountNameEditable(false);
+        setAccountName("");
         setAccountNameError("Account not found. Check the number and bank.");
+        setFormError(null);
       } finally {
-        setIsFetchingAccountName(false);
+        if (requestId === nameRequestIdRef.current) {
+          setIsFetchingAccountName(false);
+        }
       }
     }, 800);
 
     return () => clearTimeout(timeoutId);
-  }, [selectedInstitution, accountNumber, currency]);
+  }, [selectedInstitution, accountNumber, currency, kycFullName]);
 
   const filteredInstitutions = useMemo(
     () => filterAndSortInstitutions(institutions, bankSearchTerm),
     [institutions, bankSearchTerm],
   );
+
+  const applyManualAccountName = (value: string) => {
+    setAccountName(value);
+    const trimmed = value.trim();
+    if (!trimmed || isUnresolvedAccountName(trimmed)) {
+      setFormError(null);
+      return;
+    }
+    if (kycFullName && !accountNameMatchesKyc(kycFullName, trimmed)) {
+      setFormError(REFUND_NAME_MISMATCH_MESSAGE);
+    } else {
+      setFormError(null);
+    }
+  };
 
   const handleAddAccount = async () => {
     setFormError(null);
@@ -155,8 +219,12 @@ export function AddRefundAccountModal({
       return;
     }
     const name = accountName.trim();
-    if (!name) {
-      setFormError("Account name could not be verified. Check the account number.");
+    if (!name || isUnresolvedAccountName(name)) {
+      setFormError(
+        isAccountNameEditable
+          ? "Please enter the name on the account."
+          : "Account name could not be verified. Check the account number.",
+      );
       return;
     }
     // Must belong to the same person as the verified KYC profile. Only block here when we already
@@ -191,11 +259,14 @@ export function AddRefundAccountModal({
     }
   };
 
+  const resolvedNameReady =
+    accountName.trim().length > 0 && !isUnresolvedAccountName(accountName);
+
   const allFieldsFilled =
     selectedInstitution !== null &&
     accountNumber.trim().length > 0 &&
     !accountNumberError &&
-    accountName.trim().length > 0 &&
+    resolvedNameReady &&
     !isFetchingAccountName &&
     !accountNameError;
 
@@ -287,7 +358,7 @@ export function AddRefundAccountModal({
                 ) : null}
               </div>
 
-              {/* 3. Account name — auto-fetched */}
+              {/* 3. Account name — auto-fetched, or typed when verification returns OK */}
               <AnimatePresence mode="wait">
                 {isFetchingAccountName ? (
                   <div className="flex items-center gap-1 text-gray-400 dark:text-white/50">
@@ -295,6 +366,35 @@ export function AddRefundAccountModal({
                       <ImSpinner className="size-4 animate-spin" />
                       <p className="text-xs">Verifying account name...</p>
                     </AnimatedFeedbackItem>
+                  </div>
+                ) : isAccountNameEditable ? (
+                  <div className="w-full space-y-2">
+                    <label
+                      htmlFor="refund-account-name"
+                      className="mb-2 block text-sm font-semibold text-neutral-900 dark:text-white"
+                    >
+                      Account name
+                    </label>
+                    <input
+                      id="refund-account-name"
+                      type="text"
+                      autoComplete="off"
+                      value={accountName}
+                      onChange={(e) => applyManualAccountName(e.target.value)}
+                      placeholder="Enter your account name"
+                      className={classNames(
+                        "w-full rounded-xl border bg-white px-3.5 py-3 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/25 dark:bg-[#202020] dark:text-white dark:placeholder:text-white/40 dark:focus:border-blue-500 dark:focus:ring-blue-500/35",
+                        "border-neutral-200 dark:border-white/[0.12]",
+                      )}
+                    />
+                    <div className="flex w-full min-w-0 items-start gap-2 rounded-xl bg-warning-background/[8%] px-3 py-2">
+                      <InformationSquareIcon className="mt-0.5 size-5 shrink-0 text-warning-foreground dark:text-warning-text" />
+                      <p className="min-w-0 flex-1 break-words text-xs font-light leading-snug text-warning-foreground dark:text-warning-text">
+                        We couldn&apos;t confirm this account name. Enter the
+                        name on the account — it must match your verified
+                        identity.
+                      </p>
+                    </div>
                   </div>
                 ) : accountName ? (
                   <AnimatedFeedbackItem className="justify-between text-gray-400 dark:text-white/50">

--- a/app/components/recipient/RecipientDetailsForm.tsx
+++ b/app/components/recipient/RecipientDetailsForm.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDown01Icon,
   Tick02Icon,
   InformationCircleIcon,
+  InformationSquareIcon,
 } from "hugeicons-react";
 import Image from "next/image";
 
@@ -15,7 +16,7 @@ import { useOutsideClick } from "@/app/hooks";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { usePrivy } from "@privy-io/react-auth";
 import { InputError } from "@/app/components/InputError";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, isSameSavedRecipient, NGN_NUBAN_LENGTH } from "@/app/utils";
+import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, expandKesMpesaInstitutions, KES_MPESA_INSTITUTION_CODE, kesMpesaUiKey, getKesMpesaInstitutionLabel, isSameSavedRecipient, NGN_NUBAN_LENGTH, isUnresolvedAccountName } from "@/app/utils";
 import type { KesMpesaChannel } from "@/app/types";
 import {
   RecipientDetails,
@@ -32,6 +33,7 @@ import { validateWalletAddress } from "@/app/lib/validation";
 import { getNetworkImageUrl } from "@/app/utils";
 import { useActualTheme } from "@/app/hooks/useActualTheme";
 import { useNetwork } from "@/app/context";
+import { trackEvent } from "@/app/hooks/analytics/useMixpanel";
 import config from "@/app/lib/config";
 
 export const RecipientDetailsForm = ({
@@ -77,6 +79,15 @@ export const RecipientDetailsForm = ({
 
   const [isFetchingRecipientName, setIsFetchingRecipientName] = useState(false);
   const [recipientNameError, setRecipientNameError] = useState("");
+  /**
+   * The aggregator answers "OK" when no provider can resolve a name (Pretium fiats that
+   * soft-fail, and every currency with no verification at all). That is not a real account
+   * holder, so the user types one instead of being shown "ok" next to a success tick.
+   */
+  const [isRecipientNameEditable, setIsRecipientNameEditable] = useState(false);
+  const [alertViewed, setAlertViewed] = useState(false);
+  /** Guards against a slow verify overwriting a newer one (see getRecipientName). */
+  const nameRequestIdRef = useRef(0);
 
   const [savedRecipients, setSavedRecipients] = useState<
     RecipientDetailsWithId[]
@@ -125,8 +136,15 @@ export const RecipientDetailsForm = ({
         shouldValidate: true,
       });
     } else {
-      // Handle bank/mobile money selection for offramp
-      const channel = recipient.channel;
+      // Handle bank/mobile money selection for offramp.
+      // Send Money rows store channel as "" (the column default). The API omits an
+      // empty channel, but a cached or hand-built recipient can still carry the ""
+      // itself, and `??` would preserve it — so treat any falsy channel as Mobile.
+      // Only Till and Paybill are real business rails.
+      const channel: KesMpesaChannel | undefined =
+        recipient.institutionCode === KES_MPESA_INSTITUTION_CODE
+          ? (recipient.channel || "Mobile")
+          : recipient.channel;
       setSelectedInstitution({
         name:
           recipient.institutionCode === KES_MPESA_INSTITUTION_CODE && channel
@@ -147,6 +165,8 @@ export const RecipientDetailsForm = ({
       setValue("businessNumber", recipient.businessNumber ?? "", {
         shouldDirty: true,
       });
+      // Saved recipients carry a name already; never open the manual-entry input for them.
+      setIsRecipientNameEditable(false);
 
       // Remove extra spaces from recipient name
       recipient.name = recipient.name.replace(/\s+/g, " ").trim();
@@ -284,6 +304,7 @@ export const RecipientDetailsForm = ({
         setValue("accountIdentifier", "");
         setValue("businessNumber", "");
         setRecipientNameError("");
+        setIsRecipientNameEditable(false);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -291,50 +312,65 @@ export const RecipientDetailsForm = ({
 
   // Fetch recipient name based on institution and account identifier (only enforce digit-length for NGN)
   useEffect(() => {
+    // Bump synchronously on every dependency change, not just before a fetch: a
+    // lookup already in flight must be invalidated even when this run bails out in
+    // validation below, or its response would still be "current" and populate a
+    // name for an identifier the user has since replaced.
+    const requestId = ++nameRequestIdRef.current;
     let timeoutId: NodeJS.Timeout;
     const getRecipientName = async () => {
       if (!isManualEntry) return;
 
+      // Re-evaluating: drop the manual-name input and any name already resolved or
+      // typed for the previous identifier. Both matter — the validation branches
+      // below render their error in the input's else branch, so a surviving name
+      // would show with a success tick and suppress the error entirely.
+      setIsRecipientNameEditable(false);
+      setValue("recipientName", "");
+
       const isNGN = currency === "NGN";
       const digits = String(accountIdentifier ?? "").replace(/\D/g, "");
 
+      // Bail out without starting a lookup. Clears the spinner too: an earlier
+      // request may still be in flight, and its response now returns at the stale
+      // guard without touching state, which would leave the spinner up forever.
+      const stopWithoutLookup = (message: string) => {
+        setRecipientNameError(message);
+        setIsFetchingRecipientName(false);
+      };
+
       if (!institution || !accountIdentifier) {
-        setRecipientNameError("");
+        stopWithoutLookup("");
         return;
       }
 
       if (isKesPaybill && !(businessNumber ?? "").trim()) {
-        setRecipientNameError("");
+        stopWithoutLookup("");
         return;
       }
 
       if (isKesTill) {
         if (digits.length < 5 || digits.length > 7) {
-          if (digits.length > 0) {
-            setRecipientNameError(
-              "Please enter a valid till number (5–7 digits).",
-            );
-          } else {
-            setRecipientNameError("");
-          }
+          stopWithoutLookup(
+            digits.length > 0
+              ? "Please enter a valid till number (5–7 digits)."
+              : "",
+          );
           return;
         }
       }
 
       if (isNGN && digits.length !== NGN_NUBAN_LENGTH) {
-        if (digits.length > 0) {
-          setRecipientNameError(
-            "Please enter a valid 10-digit account number.",
-          );
-        } else {
-          setRecipientNameError("");
-        }
+        stopWithoutLookup(
+          digits.length > 0
+            ? "Please enter a valid 10-digit account number."
+            : "",
+        );
         return;
       }
 
       setRecipientNameError("");
       setIsFetchingRecipientName(true);
-      setValue("recipientName", "");
 
       try {
         const channel = (kesChannel || undefined) as
@@ -355,9 +391,22 @@ export const RecipientDetailsForm = ({
           accountIdentifier: accountIdentifier.toString(),
           ...(metadata ? { metadata } : {}),
         });
-        setValue("recipientName", accountName);
+        if (requestId !== nameRequestIdRef.current) return;
+
+        if (isUnresolvedAccountName(accountName)) {
+          // No provider could resolve a name. Ask for one instead of presenting
+          // the literal "OK" as a verified account holder.
+          setIsRecipientNameEditable(true);
+          setValue("recipientName", "");
+          setRecipientNameError("");
+        } else {
+          setIsRecipientNameEditable(false);
+          setValue("recipientName", accountName);
+        }
         setIsFetchingRecipientName(false);
       } catch (error) {
+        if (requestId !== nameRequestIdRef.current) return;
+        setIsRecipientNameEditable(false);
         setRecipientNameError("No recipient account found.");
         setIsFetchingRecipientName(false);
       }
@@ -423,6 +472,38 @@ export const RecipientDetailsForm = ({
     kesChannel,
   ]);
 
+  const handleLearnMore = () => {
+    trackEvent("recipient_alert_learn_more_clicked", {
+      currency,
+      institution: selectedInstitution?.name || "",
+    });
+    window.open(
+      "https://noblocks.xyz/blog/understanding-account-name-verification-on-noblocks",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  };
+
+  // Fire once per time the manual-name alert becomes visible, not on every render.
+  useEffect(() => {
+    if (isRecipientNameEditable && !alertViewed) {
+      trackEvent("recipient_alert_viewed", {
+        currency,
+        institution: selectedInstitution?.name || "",
+        kes_channel: kesChannel || "",
+      });
+      setAlertViewed(true);
+    } else if (!isRecipientNameEditable && alertViewed) {
+      setAlertViewed(false);
+    }
+  }, [
+    isRecipientNameEditable,
+    alertViewed,
+    currency,
+    selectedInstitution?.name,
+    kesChannel,
+  ]);
+
   // Simplified recipient details management
   const clearRecipientDetails = () => {
     setSelectedInstitution(null);
@@ -433,6 +514,7 @@ export const RecipientDetailsForm = ({
     setValue("kesChannel", "");
     setValue("businessNumber", "");
     setRecipientNameError("");
+    setIsRecipientNameEditable(false);
     setIsManualEntry(true);
   };
 
@@ -508,6 +590,21 @@ export const RecipientDetailsForm = ({
       const digits = String(value ?? "").replace(/\D/g, "");
       if (digits.length !== NGN_NUBAN_LENGTH) {
         return "Please enter a valid 10-digit account number.";
+      }
+      return true;
+    },
+  });
+
+  const recipientNameRegister = register("recipientName", {
+    validate: (value) => {
+      if (!isRecipientNameEditable) return true;
+      const name = String(value ?? "").replace(/\s+/g, " ").trim();
+      if (!name) return "Recipient name is required";
+      // Never let the sentinel through as if it were a real account holder.
+      // Any other non-empty name is accepted — no minimum length, since a short
+      // trading name is legitimate and there is no product rule requiring one.
+      if (isUnresolvedAccountName(name)) {
+        return "Enter the recipient's account name";
       }
       return true;
     },
@@ -740,6 +837,39 @@ export const RecipientDetailsForm = ({
                     <ImSpinner className="size-4 animate-spin" />
                     <p className="text-xs">Verifying account name...</p>
                   </AnimatedFeedbackItem>
+                </div>
+              ) : isRecipientNameEditable ? (
+                <div className="w-full space-y-2">
+                  <input
+                    type="text"
+                    autoComplete="off"
+                    placeholder="Enter recipient name"
+                    {...recipientNameRegister}
+                    className={classNames(
+                      "w-full rounded-xl border bg-transparent px-4 py-2.5 text-base outline-none transition-all duration-300 placeholder:text-text-placeholder focus:outline-none dark:text-white/80 dark:placeholder:text-white/30 sm:text-sm",
+                      errors.recipientName
+                        ? "border-input-destructive focus:border-gray-400 dark:border-input-destructive"
+                        : "border-border-input dark:border-white/20 dark:focus:border-white/40 dark:focus:ring-offset-neutral-900",
+                    )}
+                  />
+                  {errors.recipientName && (
+                    <InputError message={errors.recipientName.message} />
+                  )}
+                  <div className="flex w-full min-w-0 items-start gap-2 rounded-xl bg-warning-background/[8%] px-3 py-2">
+                    <InformationSquareIcon className="mt-0.5 size-5 shrink-0 text-warning-foreground dark:text-warning-text" />
+                    <p className="min-w-0 flex-1 break-words text-xs font-light leading-snug text-warning-foreground dark:text-warning-text">
+                      We couldn&apos;t confirm this account name. Make sure the
+                      recipient&apos;s account number is accurate before proceeding
+                      with your swap.{" "}
+                      <button
+                        type="button"
+                        onClick={handleLearnMore}
+                        className="font-semibold text-lavender-500"
+                      >
+                        Learn more.
+                      </button>
+                    </p>
+                  </div>
                 </div>
               ) : (
                 <>

--- a/app/hooks/useEIP7702Account.ts
+++ b/app/hooks/useEIP7702Account.ts
@@ -132,7 +132,7 @@ export function useDelegationContractAuth() {
             }
             const delegationAddress = getDelegationContractAddress(chainId);
             if (!delegationAddress || delegationAddress === "") {
-                throw new Error(`Delegation contract not configured for chain ${chainId}. Add the contract for this chain or set NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS.`);
+                throw new Error(`Delegation contract not configured for chain ${chainId}. Add it to DELEGATION_CONTRACT_BY_CHAIN in app/lib/config.ts.`);
             }
             const signed = await signAuthorization(
                 {

--- a/app/hooks/useEarnBridgeStatusTracker.ts
+++ b/app/hooks/useEarnBridgeStatusTracker.ts
@@ -7,7 +7,7 @@ import { useEarnHandler } from "./useEarnHandler";
 import {
   isLayerswapSuccessStatus,
   isLayerswapTerminalStatus,
-} from "../lib/layerswap";
+} from "../lib/layerswapStatus";
 import {
   addEarnSourcePosition,
   isStaleLiveFlowClaim,

--- a/app/hooks/useEvmEarnHandler.ts
+++ b/app/hooks/useEvmEarnHandler.ts
@@ -15,8 +15,11 @@ import {
 import {
   isLayerswapSuccessStatus,
   isLayerswapTerminalStatus,
-  type LayerswapDepositAction,
-  type LayerswapQuote,
+} from "../lib/layerswapStatus";
+// Type-only: layerswap.ts is server-only, so this import must stay erasable.
+import type {
+  LayerswapDepositAction,
+  LayerswapQuote,
 } from "../lib/layerswap";
 import { buildLayerswapDepositBatchCalls } from "../lib/layerswapExecute";
 import { executeBatchCalls } from "../lib/bridge";

--- a/app/hooks/useSmartWalletTransfer.ts
+++ b/app/hooks/useSmartWalletTransfer.ts
@@ -343,7 +343,7 @@ export function useSmartWalletTransfer({
           const chainName = selectedNetwork.chain.name;
           throw new Error(
             isNetworkErr
-              ? `Cannot reach the transaction server. Check that NEXT_PUBLIC_BUNDLER_SERVER_URL is set and the server is running. For ${chainName}, ensure the server has been restarted with support for this network.`
+              ? `Cannot reach the transaction service. Check your connection and try again. If this persists, ${chainName} may not be configured for sponsored transactions.`
               : (fetchErr as Error)?.message ?? "Network request failed",
           );
         }

--- a/app/lib/activepieces-deposit.ts
+++ b/app/lib/activepieces-deposit.ts
@@ -1,4 +1,4 @@
-import config from "./config";
+import { activepiecesConfig } from "./server-config";
 import type { ActivepiecesDepositPayload } from "../types";
 
 /**
@@ -7,7 +7,7 @@ import type { ActivepiecesDepositPayload } from "../types";
 export async function triggerActivepiecesDeposit(
   payload: ActivepiecesDepositPayload,
 ): Promise<void> {
-  const url = config.activepiecesWebhookUrl;
+  const url = activepiecesConfig.depositWebhookUrl;
   if (!url) {
     console.error(
       "[activepieces] ACTIVEPIECES_WEBHOOK_URL not set — skipping forward",

--- a/app/lib/activepieces-kyc-result.ts
+++ b/app/lib/activepieces-kyc-result.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { after } from "next/server";
-import config from "@/app/lib/config";
+import { activepiecesConfig } from "@/app/lib/server-config";
 import type { ActivepiecesKycResultPayload } from "@/app/types";
 import { getEmailForMonitoredAddress } from "@/app/utils";
 import {
@@ -33,7 +33,7 @@ export async function triggerActivepiecesKycResult(
   payload: ActivepiecesKycResultPayload,
   walletAddress?: string,
 ): Promise<void> {
-  const url = config.activepiecesKycResultWebhookUrl;
+  const url = activepiecesConfig.kycResultWebhookUrl;
   if (!url) {
     console.error(
       "[activepieces] ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL not set — skipping KYC result email",

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -1,5 +1,4 @@
 import { Config, JWTProviderConfig } from "@/app/types";
-import { resolveLayerswapApiBaseUrl } from "./layerswapConfig";
 
 /** EIP-7702 delegation contract (ProviderBatchCallAndSponsor) per chain. */
 export const DELEGATION_CONTRACT_BY_CHAIN: Record<number, string> = {
@@ -12,7 +11,7 @@ export const DELEGATION_CONTRACT_BY_CHAIN: Record<number, string> = {
   1: "0x25054a2b9D4544ed292DC1a74E8bF1f6F449d988",
 };
 
-/** Returns the delegation contract address for the given chainId. Uses NEXT_PUBLIC_DELEGATION_CONTRACT_ADDRESS if set, else DELEGATION_CONTRACT_BY_CHAIN, else "". */
+/** Returns the delegation contract address for the given chainId from DELEGATION_CONTRACT_BY_CHAIN, else "". */
 export function getDelegationContractAddress(chainId: number): string {
   return DELEGATION_CONTRACT_BY_CHAIN[chainId] ?? "";
 }
@@ -29,8 +28,6 @@ const config: Config = {
   rpcUrlKey: process.env.NEXT_PUBLIC_RPC_URL_KEY || "",
   mixpanelToken: process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || "",
   hotjarSiteId: Number(process.env.NEXT_PUBLIC_HOTJAR_SITE_ID || ""),
-  googleVerificationCode:
-    process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE || "",
   noticeBannerText: process.env.NEXT_PUBLIC_NOTICE_BANNER_TEXT || "",
   brevoConversationsId: process.env.NEXT_PUBLIC_BREVO_CONVERSATIONS_ID || "",
   brevoConversationsGroupId: process.env.NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID || "",
@@ -56,16 +53,6 @@ const config: Config = {
     );
     return Number.isFinite(parsed) ? parsed : 0;
   })(),
-  moralisWebhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
-  activepiecesWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
-  activepiecesSignupVerifyWebhookUrl:
-    process.env.ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL || "",
-  activepiecesKycResultWebhookUrl:
-    process.env.ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL || "",
-  moralisStreamId: process.env.MORALIS_STREAM_ID || "",
-  moralisApiKey: process.env.MORALIS_API_KEY || "",
-  moralisBaseUrl:
-    process.env.MORALIS_BASE_URL || "https://api.moralis-streams.com",
   earnEnabled: process.env.NEXT_PUBLIC_EARN_ENABLED === "true",
   evmEarnEnabled: process.env.NEXT_PUBLIC_EVM_EARN_ENABLED === "true",
   tronEnabled: process.env.NEXT_PUBLIC_TRON_ENABLED === "true",
@@ -83,11 +70,6 @@ const config: Config = {
   fantasyCampaignEnded:
     process.env.NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED === "true",
   embedEnabled: process.env.NEXT_PUBLIC_EMBED_ENABLED === "true",
-  /** Server-side LayerSwap API key (EVM earn bridge). */
-  layerswapApiKey: (process.env.LAYERSWAP_API_KEY || "").trim(),
-  layerswapApiBaseUrl: resolveLayerswapApiBaseUrl(
-    process.env.LAYERSWAP_API_BASE_URL,
-  ),
 };
 
 export default config;
@@ -98,14 +80,6 @@ export const DEFAULT_PRIVY_CONFIG: JWTProviderConfig = {
     jwksUrl: process.env.PRIVY_JWKS_URL || "",
     issuer: process.env.PRIVY_ISSUER || "",
     algorithms: ["ES256"],
-  },
-};
-
-export const DEFAULT_THIRDWEB_CONFIG: JWTProviderConfig = {
-  provider: "thirdweb",
-  thirdweb: {
-    clientId: process.env.THIRDWEB_CLIENT_ID || "",
-    domain: process.env.THIRDWEB_DOMAIN || "",
   },
 };
 

--- a/app/lib/hyperfx.ts
+++ b/app/lib/hyperfx.ts
@@ -40,13 +40,14 @@ import {
 } from "@/app/lib/hyperfxStatus";
 import type { HyperfxIntentQuote } from "./bridge";
 
+// This module runs in the browser, where only NEXT_PUBLIC_ vars are inlined —
+// the server-side HYPERBRIDGE_* names would always be undefined here. The
+// quote route reads those separately.
 const WS_URL =
   process.env.NEXT_PUBLIC_HYPERBRIDGE_WS_URL ||
-  process.env.HYPERBRIDGE_WS_URL ||
   "wss://nexus.rpc.polytope.technology";
 const INDEXER_URL =
   process.env.NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL ||
-  process.env.HYPERBRIDGE_INDEXER_URL ||
   "https://nexus.indexer.polytope.technology";
 
 const NOBLOCKS_GRAFFITI = padHex(stringToHex("noblocks.xyz"), {

--- a/app/lib/jwt.ts
+++ b/app/lib/jwt.ts
@@ -2,7 +2,7 @@ import { jwtVerify, createRemoteJWKSet } from 'jose';
 import { JWTPayload, JWTProviderConfig, VerifyJWTResult } from '@/app/types';
 
 /**
- * Verifies a JWT token for either Privy or Thirdweb provider
+ * Verifies a Privy-issued JWT token
  * @param token - The JWT token to verify
  * @param config - Configuration for the JWT provider
  * @returns The verified payload and provider
@@ -21,11 +21,6 @@ export async function verifyJWT(token: string, config: JWTProviderConfig): Promi
                 payload: payload as JWTPayload,
                 provider: config.provider,
             };
-        } else if (config.provider === 'thirdweb' && config.thirdweb) {
-            // Placeholder for thirdweb JWT verification
-            // TODO: Thirdweb verification will be implemented when ready to migrate
-            throw new Error('Thirdweb JWT verification not implemented yet');
-
         } else {
             throw new Error('Invalid JWT provider configuration');
         }

--- a/app/lib/layerswap.ts
+++ b/app/lib/layerswap.ts
@@ -1,33 +1,30 @@
 /**
  * LayerSwap API client (server-side). Proxied via /api/earn/layerswap/* routes.
+ *
+ * Status vocabulary and predicates live in ./layerswapStatus so client code can
+ * import them without dragging this module — and LAYERSWAP_API_KEY — into the
+ * browser bundle. They are re-exported here for server callers.
  */
 
+import "server-only";
 import axios from "axios";
 import type { Call } from "starknet";
-import config from "./config";
+import { getLayerswapApiBase, getLayerswapApiKey } from "./server-config";
 import {
   EARN_USDC_SYMBOL,
   LAYERSWAP_STARKNET_NETWORK,
   layerswapSourceNetwork,
 } from "./earnChains";
+import type { LayerswapSwapStatus } from "./layerswapStatus";
 
-export const LAYERSWAP_API_BASE = config.layerswapApiBaseUrl;
-
-/** LayerSwap API key from config (server routes only). */
-export function getLayerswapApiKey(): string {
-  return config.layerswapApiKey;
-}
+export {
+  isLayerswapSuccessStatus,
+  isLayerswapTerminalStatus,
+} from "./layerswapStatus";
+export type { LayerswapSwapStatus };
+export { getLayerswapApiKey };
 
 const UPSTREAM_TIMEOUT_MS = 30_000;
-
-export type LayerswapSwapStatus =
-  | "user_transfer_pending"
-  | "completed"
-  | "failed"
-  | "expired"
-  | "ls_transfer_pending"
-  | "pending_refund"
-  | "refunded";
 
 export interface LayerswapDepositAction {
   type: string;
@@ -80,7 +77,7 @@ export async function layerswapGetQuote(params: {
   destinationNetwork?: string;
 }): Promise<LayerswapQuote> {
   const { data } = await axios.get<LayerswapApiResponse<LayerswapQuote>>(
-    `${LAYERSWAP_API_BASE}/api/v2/quote`,
+    `${getLayerswapApiBase()}/api/v2/quote`,
     {
       headers: layerswapHeaders(params.apiKey),
       params: {
@@ -119,7 +116,7 @@ export async function layerswapCreateEarnSwap(params: {
   }
 
   const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
-    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    `${getLayerswapApiBase()}/api/v2/swaps`,
     {
       source_network: sourceNetwork,
       source_token: EARN_USDC_SYMBOL,
@@ -168,7 +165,7 @@ export async function layerswapCreateEarnWithdrawSwap(params: {
   }
 
   const { data } = await axios.post<LayerswapApiResponse<LayerswapPreparedSwap>>(
-    `${LAYERSWAP_API_BASE}/api/v2/swaps`,
+    `${getLayerswapApiBase()}/api/v2/swaps`,
     {
       source_network: LAYERSWAP_STARKNET_NETWORK,
       source_token: EARN_USDC_SYMBOL,
@@ -204,7 +201,7 @@ export async function layerswapGetSwap(params: {
 }): Promise<LayerswapPreparedSwap & { swap: NonNullable<LayerswapPreparedSwap["swap"]> }> {
   const { data } = await axios.get<
     LayerswapApiResponse<LayerswapPreparedSwap>
-  >(`${LAYERSWAP_API_BASE}/api/v2/swaps/${encodeURIComponent(params.swapId)}`, {
+  >(`${getLayerswapApiBase()}/api/v2/swaps/${encodeURIComponent(params.swapId)}`, {
     headers: layerswapHeaders(params.apiKey),
     timeout: UPSTREAM_TIMEOUT_MS,
     validateStatus: () => true,
@@ -218,21 +215,6 @@ export async function layerswapGetSwap(params: {
   return data.data as LayerswapPreparedSwap & {
     swap: NonNullable<LayerswapPreparedSwap["swap"]>;
   };
-}
-
-export function isLayerswapTerminalStatus(
-  status: LayerswapSwapStatus,
-): boolean {
-  return (
-    status === "completed" ||
-    status === "failed" ||
-    status === "expired" ||
-    status === "refunded"
-  );
-}
-
-export function isLayerswapSuccessStatus(status: LayerswapSwapStatus): boolean {
-  return status === "completed";
 }
 
 interface ParsedLayerswapCall {

--- a/app/lib/layerswapStatus.ts
+++ b/app/lib/layerswapStatus.ts
@@ -1,0 +1,31 @@
+/**
+ * LayerSwap swap status vocabulary and predicates.
+ *
+ * Split out of layerswap.ts so client components can poll swap status without
+ * pulling the API client — and its server-only credentials — into the browser
+ * bundle. Pure: no env access, no network, no imports.
+ */
+
+export type LayerswapSwapStatus =
+  | "user_transfer_pending"
+  | "completed"
+  | "failed"
+  | "expired"
+  | "ls_transfer_pending"
+  | "pending_refund"
+  | "refunded";
+
+export function isLayerswapTerminalStatus(
+  status: LayerswapSwapStatus,
+): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "expired" ||
+    status === "refunded"
+  );
+}
+
+export function isLayerswapSuccessStatus(status: LayerswapSwapStatus): boolean {
+  return status === "completed";
+}

--- a/app/lib/refund-account-api.ts
+++ b/app/lib/refund-account-api.ts
@@ -9,7 +9,10 @@ import {
   accountNameMatchesKyc,
   REFUND_NAME_MISMATCH_MESSAGE,
 } from "@/app/lib/name-matching";
-import { normalizeRefundAccountCurrency } from "@/app/utils";
+import {
+  isUnresolvedAccountName,
+  normalizeRefundAccountCurrency,
+} from "@/app/utils";
 import { resolveInstitutionForCurrency } from "@/app/lib/refund-account-institutions";
 
 type RefundAccountBody = {
@@ -178,6 +181,19 @@ export async function handlePutRefundAccount(
           success: false,
           error:
             "Missing required fields: currency, institution, institutionCode, accountIdentifier, accountName",
+        },
+      };
+    }
+
+    // Reject the verify-account "OK" sentinel. Clients must collect a real account
+    // name when verification cannot resolve one (same policy as recipient form #698).
+    if (isUnresolvedAccountName(accountName)) {
+      return {
+        status: 422,
+        body: {
+          success: false,
+          error:
+            "Account name could not be verified. Please enter the name on the account.",
         },
       };
     }

--- a/app/lib/register-moralis-stream-address.ts
+++ b/app/lib/register-moralis-stream-address.ts
@@ -1,4 +1,4 @@
-import config from "./config";
+import { moralisConfig } from "./server-config";
 /**
  * Add a wallet address to the configured Moralis EVM stream (e.g. after a new user gets a wallet).
  * Server-only; uses MORALIS_API_KEY, MORALIS_STREAM_ID, and MORALIS_BASE_URL.
@@ -7,9 +7,9 @@ export async function registerWalletForMoralisStream(
   walletAddress: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const address = walletAddress.trim().toLowerCase();
-  const streamId = config.moralisStreamId;
-  const apiKey = config.moralisApiKey;
-  const baseUrl = (config.moralisBaseUrl || "").trim();
+  const streamId = moralisConfig.streamId;
+  const apiKey = moralisConfig.apiKey;
+  const baseUrl = (moralisConfig.baseUrl || "").trim();
   if (!streamId || !apiKey || !baseUrl) {
     return {
       ok: false,

--- a/app/lib/server-config.ts
+++ b/app/lib/server-config.ts
@@ -8,6 +8,8 @@
  * Security is maintained because these env vars are not NEXT_PUBLIC_ prefixed.
  */
 
+import { resolveLayerswapApiBaseUrl } from "./layerswapConfig";
+
 /**
  * Validates environment variable and logs a warning or throws if missing
  * @param name - Environment variable name
@@ -50,13 +52,24 @@ export const cashbackConfig = {
   ),
 };
 
+/**
+ * Mixpanel project token for server-side tracking.
+ *
+ * Mixpanel's server token IS the project token, so NEXT_PUBLIC_MIXPANEL_TOKEN is
+ * a valid value here. It is accepted as a fallback because deployments have
+ * historically set only the public name, which left every event emitted by
+ * app/lib/server-analytics.ts silently dropped. Prefer MIXPANEL_SERVER_TOKEN so
+ * the two can be pointed at separate projects later.
+ */
 export function getServerMixpanelToken(): string {
   // Return empty string on client side
   if (typeof window !== "undefined") return "";
 
   return validateConfig(
     "MIXPANEL_SERVER_TOKEN",
-    process.env.MIXPANEL_SERVER_TOKEN || "",
+    process.env.MIXPANEL_SERVER_TOKEN ||
+      process.env.NEXT_PUBLIC_MIXPANEL_TOKEN ||
+      "",
     false, // Optional - analytics can fail gracefully
   );
 }
@@ -74,4 +87,61 @@ export function getServerMixpanelToken(): string {
 export function getAggregatorSenderApiKey(): string {
   if (typeof window !== "undefined") return "";
   return (process.env.AGGREGATOR_SENDER_API_KEY_ID || "").trim();
+}
+
+/**
+ * Canonical public origin of this deployment (e.g. https://noblocks.xyz).
+ *
+ * A security boundary, not a display value: it is the SIWE `domain` allowed to
+ * mint a session (app/api/auth/injected/verify) and the origin allowed to POST
+ * to /api/track-logout. Configured, never derived from the request Host header —
+ * a phisher could otherwise have a victim sign for their domain and replay it
+ * here behind a spoofed Host.
+ *
+ * NEXT_PUBLIC_APP_URL is the legacy name and still works. No client code reads
+ * it, so the prefix only ever misrepresented this as browser-facing config.
+ */
+export function getAppUrl(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "").trim();
+}
+
+/**
+ * Moralis stream credentials, used to register deposit-watch addresses and to
+ * verify the signature on incoming stream webhooks. SERVER-ONLY.
+ */
+export const moralisConfig = {
+  streamId: process.env.MORALIS_STREAM_ID || "",
+  apiKey: process.env.MORALIS_API_KEY || "",
+  baseUrl: process.env.MORALIS_BASE_URL || "https://api.moralis-streams.com",
+  webhookSecret: process.env.MORALIS_WEBHOOK_SECRET || "",
+};
+
+/**
+ * Activepieces webhook endpoints. Each is optional — an unset URL means that
+ * forward is skipped rather than failing the request. SERVER-ONLY.
+ */
+export const activepiecesConfig = {
+  /** Deposit forwarding, fired from the Moralis stream webhook. */
+  depositWebhookUrl: process.env.ACTIVEPIECES_WEBHOOK_URL || "",
+  /** Signup email verification flow. */
+  signupVerifyWebhookUrl:
+    process.env.ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL || "",
+  /** KYC decision notifications (SmileID callback, tier 3, phone OTP). */
+  kycResultWebhookUrl: process.env.ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL || "",
+};
+
+/** LayerSwap API key (EVM earn bridge). SERVER-ONLY. */
+export function getLayerswapApiKey(): string {
+  if (typeof window !== "undefined") return "";
+  return (process.env.LAYERSWAP_API_KEY || "").trim();
+}
+
+/**
+ * LayerSwap API base URL. Read lazily rather than at module scope so the
+ * validation warning in resolveLayerswapApiBaseUrl fires per call on the
+ * server instead of once during `next build`.
+ */
+export function getLayerswapApiBase(): string {
+  return resolveLayerswapApiBaseUrl(process.env.LAYERSWAP_API_BASE_URL);
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -479,7 +479,6 @@ export type Config = {
   rpcUrlKey: string;
   mixpanelToken: string;
   hotjarSiteId: number;
-  googleVerificationCode: string;
   noticeBannerText?: string; // Optional, for dynamic notice banner text
   brevoConversationsId: string; // Brevo chat widget ID
   brevoConversationsGroupId?: string; // Brevo chat widget group ID for routing
@@ -490,21 +489,6 @@ export type Config = {
   maintenanceSchedule: string; // e.g. "Friday, February 13th, from 7:00 PM to 11:00 PM WAT"
   referralMinQualifyingVolumeUsd: number;
   referralRewardAmountUsd: number;
-  moralisWebhookSecret: string;
-  activepiecesWebhookUrl: string;
-  /**
-   * Activepieces webhook for the Tier 1 "verify your phone" email (Brevo flow),
-   * triggered on new email signups. Payload `event`: "signup_verify_phone".
-   */
-  activepiecesSignupVerifyWebhookUrl: string;
-  /**
-   * Activepieces webhook for SmileID identity result emails (Brevo flow).
-   * Payload `event`: "kyc_result" with `status`: "success" | "failure".
-   */
-  activepiecesKycResultWebhookUrl: string;
-  moralisStreamId: string;
-  moralisApiKey: string;
-  moralisBaseUrl: string;
   /** Starknet Earn (Vesu via Starkzap). Requires Starknet wallet + API routes. */
   earnEnabled: boolean;
   /** EVM → Starknet Earn via LayerSwap (Phase 2). Requires LAYERSWAP_API_KEY server-side. */
@@ -534,9 +518,6 @@ export type Config = {
   fantasyCampaignEnded: boolean;
   /** Embeddable widget feature flag. Gates the /widget route (iframe embed for whitelisted partners). */
   embedEnabled: boolean;
-  /** LayerSwap API key (server-side only; used by /api/earn/layerswap/*). */
-  layerswapApiKey: string;
-  layerswapApiBaseUrl: string;
 };
 
 export type Network = {
@@ -646,7 +627,7 @@ export interface TransactionUpdateInput {
   txHash?: string;
 }
 
-export type JWTProvider = "privy" | "thirdweb";
+export type JWTProvider = "privy";
 
 export interface JWTProviderConfig {
   provider: JWTProvider;
@@ -654,10 +635,6 @@ export interface JWTProviderConfig {
     jwksUrl: string;
     issuer: string;
     algorithms: string[];
-  };
-  thirdweb?: {
-    clientId: string;
-    domain: string;
   };
 }
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -202,6 +202,25 @@ export function normalizeSavedRecipientChannel(
 }
 
 /**
+ * True when the aggregator could not resolve a real account holder.
+ *
+ * `/verify-account` answers the literal string "OK" in two cases: a Pretium fiat
+ * (KES, GHS, UGX, MWK) where every provider soft-failed, and any currency with no
+ * verification path at all, which returns "OK" unconditionally. KES M-Pesa Till and
+ * Paybill always land here — a Paybill lookup is structurally impossible because the
+ * identifier is only the reference and the business number never reaches the PSP.
+ *
+ * "OK" is a sentinel, not a name, so the UI must collect one from the user rather than
+ * display it. The aggregator keeps a client-supplied name in that case
+ * (ResolveAccountNameAfterValidation), and the on-chain path noblocks uses never
+ * re-validates it at all.
+ */
+export function isUnresolvedAccountName(name?: string | null): boolean {
+  const value = (name ?? "").trim();
+  return value === "" || value.toLowerCase() === "ok";
+}
+
+/**
  * True when two saved recipients are the same payout target.
  *
  * Mirrors the saved-recipient unique key exactly. Channel matters because Send

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -263,6 +263,11 @@ CREATE POLICY "Allow user registration"
 
 ### Client-Side Auth Setup
 
+> Illustrative only — Noblocks has no browser Supabase client today, and neither
+> `NEXT_PUBLIC_SUPABASE_URL` nor `NEXT_PUBLIC_SUPABASE_ANON_KEY` exists. Server
+> code reads `SUPABASE_URL` / `SUPABASE_SECRET_KEY`; see
+> [environment-variables.md](environment-variables.md).
+
 ```typescript
 import { createClient } from '@supabase/supabase-js';
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,6 +1,8 @@
 # Environment Variables
 
-This document lists all environment variables used by the Noblocks application. Most variables are optional; required ones depend on which features you want to enable locally.
+This document explains the environment variables used by the Noblocks application. Most variables are optional; required ones depend on which features you want to enable locally.
+
+[`.env.example`](../.env.example) is the canonical list — `__tests__/envDocumentation.test.ts` fails CI when it drifts from the variables the code reads. This document is the prose companion and is not machine-checked, so treat `.env.example` as the authority if the two ever disagree.
 
 ## Quick Start
 
@@ -15,6 +17,7 @@ This document lists all environment variables used by the Noblocks application. 
    - `NEXT_PUBLIC_PRIVY_APP_ID` – Your Privy app ID
    - `SUPABASE_URL` and `SUPABASE_SECRET_KEY` – From Supabase Dashboard
    - `INTERNAL_API_KEY` – Generate with `openssl rand -hex 32`
+   - `NEXT_PUBLIC_STARKNET_RPC_URL` – A Starknet JSON-RPC endpoint. `app/lib/starknet.ts` throws when it is missing, so any page that touches Starknet fails without it.
 
    `AGGREGATOR_SENDER_API_KEY_ID` (server-only — never `NEXT_PUBLIC_`) is optional for local UI exploration; set it when you need live order creation against the aggregator.
 
@@ -41,13 +44,21 @@ NEXT_PUBLIC_KYC_TIER_3_MONTHLY=2
 # Privy authentication app ID
 NEXT_PUBLIC_PRIVY_APP_ID=
 
-# RPC URL provider key
+# RPC URL provider key (Dwellir) — see "Keys that ship to the browser" below
 NEXT_PUBLIC_RPC_URL_KEY=
+
+# Starknet JSON-RPC endpoint. Required — app/lib/starknet.ts throws when unset
+NEXT_PUBLIC_STARKNET_RPC_URL=
 
 # Privy server-side secrets
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=https://auth.privy.io/api/v1/apps/<your-privy-app-id>/jwks.json
 PRIVY_ISSUER=privy.io
+# Optional: Privy wallet API base (defaults to https://api.privy.io)
+PRIVY_WALLET_API_URL=
+# Optional: authorization key for Privy wallet API calls (Starknet key export).
+# When unset, only the user signature is sent.
+PRIVY_WALLET_AUTH_PRIVATE_KEY=
 ```
 
 ### Database (Supabase)
@@ -61,9 +72,13 @@ SUPABASE_URL=https://your-project.supabase.co
 # Server admin secret key (sb_secret_...) — bypasses RLS, keep private!
 SUPABASE_SECRET_KEY=
 
-# Optional: Client-only publishable key if adding browser Supabase client later
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+# Passphrase for the encrypt_recipient_data / decrypt_recipient_data Postgres
+# functions protecting saved recipient details. Rotating it makes existing
+# encrypted rows unreadable.
+ENCRYPTION_KEY=
 ```
+
+There is no `NEXT_PUBLIC_SUPABASE_URL`: `app/lib/supabase.ts` reads `SUPABASE_URL` only, and the client never talks to Supabase directly.
 
 ### Client Analytics
 
@@ -120,12 +135,18 @@ Locally the tracer defaults to `localhost:8126` and is harmless with no agent ru
 
 ### Server-Side Analytics
 
+Powers `app/lib/server-analytics.ts`, which instruments every API route. With no token set, those events are dropped silently.
+
+Mixpanel's server token **is** the project token, so this is usually the same value as `NEXT_PUBLIC_MIXPANEL_TOKEN` — which is accepted as a fallback. Set `MIXPANEL_SERVER_TOKEN` explicitly if you want server events in a separate project.
+
 ```bash
-MIXPANEL_TOKEN=
+MIXPANEL_SERVER_TOKEN=              # Falls back to NEXT_PUBLIC_MIXPANEL_TOKEN
 MIXPANEL_PRIVACY_MODE=strict        # "strict" or "normal"
 MIXPANEL_INCLUDE_IP=false
 MIXPANEL_INCLUDE_ERROR_STACKS=false
 ```
+
+Defaults are privacy-safe when unset: wallet addresses and transaction IDs are always hashed, and IPs are hashed and error stacks dropped unless you opt in above.
 
 ### Client Error Reporting (Optional)
 
@@ -170,7 +191,10 @@ INJECTED_SESSION_SECRET=
 # SIWE messages must name this host (or an allowed embed origin) — configured,
 # never derived from the request Host header, so a signature phished on another
 # domain can't mint a session here.
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+#
+# Read on the server only (app/lib/server-config.ts → getAppUrl). The legacy
+# NEXT_PUBLIC_APP_URL still works as a fallback; prefer APP_URL.
+APP_URL=http://localhost:3000
 ```
 
 - **Minimum 32 characters.** The check runs lazily — when a token is actually
@@ -186,7 +210,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
   settings, not in a tracked file.
 - **Rotating it invalidates all live sessions.** Cost is low: users re-sign
   once, and tokens only last an hour anyway.
-- `NEXT_PUBLIC_APP_URL` must match the deployment's real public origin. If it
+- `APP_URL` must match the deployment's real public origin. If it
   still says `localhost:3000` in a deployed environment, sign-in fails with
   `401 Sign-in domain is not allowed` (embedded widgets additionally need the
   partner origin in `EMBED_ALLOWED_ORIGINS` or the `embed_allowed_origins`
@@ -200,6 +224,53 @@ ENABLE_WALLET_CONTEXT_SYNC=false
 
 # Starknet Earn (Vesu / Starkzap): wallet Earn CTA, deposit/withdraw, activity tab
 NEXT_PUBLIC_EARN_ENABLED=false
+# AVNU paymaster key — required whenever Starknet Earn is on, since the
+# paymaster runs in "sponsored" mode and throws without it
+STARKNET_PAYMASTER_API_KEY=
+# Gas token address; only used in non-sponsored mode (defaults to the first
+# token the paymaster reports as supported)
+STARKNET_GAS_TOKEN_ADDRESS=
+
+# EVM → Starknet Earn via LayerSwap. Needs NEXT_PUBLIC_EARN_ENABLED=true as
+# well — isEvmEarnEnabled() requires both flags.
+NEXT_PUBLIC_EVM_EARN_ENABLED=false
+LAYERSWAP_API_KEY=
+LAYERSWAP_API_BASE_URL=https://api.layerswap.io   # Optional; HTTPS only
+
+# Tron network + Privy Tron wallet
+NEXT_PUBLIC_TRON_ENABLED=false
+NEXT_PUBLIC_TRON_RPC_URL=                         # Optional; defaults to https://api.trongrid.io
+NEXT_PUBLIC_TRONGRID_API_KEY=                     # Optional; see the browser-exposed keys note below
+
+# HyperFX (Hyperbridge IntentGateway) USDC/USDT↔cNGN. Requires bridge enabled.
+NEXT_PUBLIC_HYPERFX_ENABLED=false
+ALCHEMY_API_KEY=                                  # Server-only ERC-4337 bundler
+# Hyperbridge Nexus endpoints; both optional, each falling back to the public
+# Polytope endpoint. The NEXT_PUBLIC_ pair is read by the browser swap client,
+# the unprefixed pair by the server quote route.
+NEXT_PUBLIC_HYPERBRIDGE_WS_URL=
+NEXT_PUBLIC_HYPERBRIDGE_INDEXER_URL=
+HYPERBRIDGE_WS_URL=
+HYPERBRIDGE_INDEXER_URL=
+
+# Textile FX v2 RFQ: USDT↔cNGN on BSC + Celo
+NEXT_PUBLIC_TEXTILE_ENABLED=false
+TEXTILE_API_KEY=
+
+# Noblocks Play (fantasy league)
+NEXT_PUBLIC_FANTASY_ENABLED=true
+# When true, public /play shows the campaign-ended announcement; /play/admin stays live
+NEXT_PUBLIC_FANTASY_CAMPAIGN_ENDED=true
+NEXT_PUBLIC_WORLDCUP_FOOTER_END_DATE=2026-07-19T23:59:59+01:00
+# Admin key for /api/play/admin/* (x-admin-key header). Unset = admin tooling OFF, never open
+FANTASY_ADMIN_KEY=
+# Shared secret for the Cloudflare worker POSTing /api/play/worker
+# (x-internal-auth header); falls back to INTERNAL_API_KEY
+FANTASY_WORKER_SECRET=
+# Dev-only: "true" compresses gameweek timing for local testing. Ignored in production
+FANTASY_LOCAL_TIMELAPSE=
+# API-Football key for fixtures, players and live scores
+API_FOOTBALL_KEY=
 
 # Referral program: show/hide UI and API routes
 NEXT_PUBLIC_REFERRAL_ENABLED=true
@@ -235,12 +306,15 @@ EMBED_ALLOWED_ORIGINS=
 INTERNAL_API_BASE_URL=
 ```
 
+#### Keys that ship to the browser
+
+`NEXT_PUBLIC_RPC_URL_KEY` (Dwellir) and `NEXT_PUBLIC_TRONGRID_API_KEY` are real provider credentials that are inlined into the client bundle by design — balance reads and RPC calls happen directly from the browser, so a server proxy would add a round trip to every one. Anyone can extract them from a deployed page.
+
+Treat them as public: restrict each key by origin in the provider's dashboard, and expect to rotate them like any published identifier. They protect quota, not access. `ALCHEMY_API_KEY` shows the alternative pattern — it stays server-side because `resolveHyperfxBundlerUrl` in `app/utils.ts` proxies through `/api/bridge/hyperfx/bundler` when called from the browser.
+
 ### External Services
 
 ```bash
-# SEO verification
-NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE=
-
 # Notice banner text (see docs/notice-banner.md)
 NEXT_PUBLIC_NOTICE_BANNER_TEXT=
 
@@ -260,10 +334,17 @@ SANITY_STUDIO_PROJECT_ID=your_project_id_here
 # Next.js App (client-side)
 NEXT_PUBLIC_SANITY_DATASET=production
 NEXT_PUBLIC_SANITY_PROJECT_ID=your_project_id_here
+```
 
-# Bundler / EIP-7702 sponsor
-NEXT_PUBLIC_BUNDLER_SERVER_URL=
+### Bundler / EIP-7702 Sponsor
+
+Sponsored batch calls are served by the in-process `/api/bundler` route; there is no external bundler URL to configure.
+
+```bash
+# Sponsor wallet that pays gas for batched EIP-7702 calls.
+# PRIVATE_KEY is a legacy alias, still accepted as a fallback.
 SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
+PRIVATE_KEY=
 ```
 
 ### Email & Communications
@@ -274,9 +355,28 @@ SPONSOR_EVM_WALLET_PRIVATE_KEY=0x...
 BREVO_API_KEY=
 # List ID from: Brevo Dashboard → Contacts → Lists (numeric)
 BREVO_LIST_ID=
+# From address on transactional email (defaults to no-reply@noblocks.xyz)
+BREVO_SENDER_EMAIL=
 # Brevo Conversations (chat widget)
 NEXT_PUBLIC_BREVO_CONVERSATIONS_ID=
 NEXT_PUBLIC_BREVO_CONVERSATIONS_GROUP_ID=
+
+# Activepieces webhooks. Each is optional — an unset URL skips that forward.
+ACTIVEPIECES_WEBHOOK_URL=                  # Deposit forwarding, from the Moralis stream webhook
+ACTIVEPIECES_SIGNUP_VERIFY_WEBHOOK_URL=    # Tier 1 "verify your phone" email
+ACTIVEPIECES_KYC_RESULT_WEBHOOK_URL=       # SmileID identity result emails
+```
+
+### Moralis EVM Streams (Deposit Watching)
+
+Server-only. Stream and key from the Moralis Dashboard → Streams.
+
+```bash
+MORALIS_STREAM_ID=
+MORALIS_API_KEY=
+MORALIS_BASE_URL=https://api.moralis-streams.com
+# Verifies the x-signature header on incoming stream webhooks
+MORALIS_WEBHOOK_SECRET=
 ```
 
 ### Phone Verification
@@ -288,12 +388,14 @@ KUDISMS_API_KEY=your_kudisms_api_key
 KUDISMS_APP_NAME_CODE=your_app_name_code
 KUDISMS_TEMPLATE_CODE=your_template_code
 KUDISMS_SENDER_ID=Noblocks
+KUDISMS_TIMEOUT_MS=                   # Optional; default 10000
 
 # Twilio (international via Verify API)
 # Get from: Twilio Console → Account Dashboard
 TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_VERIFY_TIMEOUT_MS=             # Optional; default 5000
 ```
 
 ### KYC Verification Services
@@ -301,13 +403,14 @@ TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #### SmileID (Identity Verification)
 
 ```bash
-# API base URL — sandbox ("0"), production ("1"), or full URL
-SMILE_IDENTITY_BASE_URL="XXXXXX"
 SMILE_IDENTITY_API_KEY="your_api_key_here"
 SMILE_IDENTITY_PARTNER_ID="your_partner_id_here"
 SMILE_ID_CALLBACK_URL=""              # Callback URL for async results
-SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production
+SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production, or a legacy full API URL
+SMILE_IDENTITY_SERVER_MODE=           # Optional override, checked first. "0" or "1" only
 ```
+
+`resolveSmileIdServerConfig` in `app/lib/smileID.ts` checks `SMILE_IDENTITY_SERVER_MODE` before `SMILE_IDENTITY_SERVER`. A legacy full URL in `SMILE_IDENTITY_SERVER` is accepted and its mode inferred from whether the host looks like sandbox. Anything unrecognized logs a warning and fails closed, so KYC requests error rather than hitting the wrong environment.
 
 #### Dojah (Tier 3 Address / Proof-of-Address)
 
@@ -315,15 +418,13 @@ SMILE_IDENTITY_SERVER="0"             # "0" = sandbox, "1" = production
 DOJAH_APP_ID=<YOUR_APP_ID>
 DOJAH_SECRET_KEY=<YOUR_SECRET_KEY>
 DOJAH_BASE_URL=https://api.dojah.io
-
-# Optional: Default false — send only input_type + input_value per Dojah docs
-# DOJAH_UTILITY_BILL_SEND_ADDRESS_FIELDS=true
-# Optional: Default true — retry base64 if URL submission fails (Dojah often can't fetch URLs)
-# DOJAH_UTILITY_BILL_BASE64_FALLBACK=false
+DOJAH_TIMEOUT_MS=                     # Optional; default 25000
 
 # Supabase Storage bucket for KYC documents (create in Supabase Dashboard → Storage)
 KYC_DOCUMENTS_BUCKET=kyc-documents
 ```
+
+Utility-bill submission has no toggles: `app/lib/dojah.ts` always sends the address fields alongside `input_type: "url"`, and submits the document URL with no base64 retry.
 
 ### Campaign Management
 

--- a/docs/kyc-aml-workflow.md
+++ b/docs/kyc-aml-workflow.md
@@ -119,6 +119,11 @@ Limited verification for very small transaction caps (primarily testing).
 
 ### SmileID Integration
 
+> Sketch, not the shipped code. The identifiers here are placeholders — the real
+> implementation lives in `app/lib/smileID.ts` and resolves its base URL from
+> `SMILE_IDENTITY_SERVER` / `SMILE_IDENTITY_SERVER_MODE`. There is no
+> `SMILE_IDENTITY_BASE_URL` or `SMILE_IDENTITY_PROJECT_ID` variable.
+
 ```typescript
 interface SmileIDRequest {
   url: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Jira Issue

Jira Issue: <!-- Atlassian MCP unavailable in this environment; ticket not filed -->

### Description

PR #698 taught the recipient form to treat the aggregator's `"OK"` verify-account sentinel as unresolved and collect a typed name. The **Add refund account** modal still treated `"OK"` as a real account name: it rendered `ok` next to the green tick, then blocked save with the KYC mismatch message ("doesn't match your verified identity") because `"OK"` never matches the user's verified name.

This change mirrors that recipient path for refund accounts:

- When verification returns an unresolved name (`OK` / empty), show an **Account name** input plus a warning that the name could not be confirmed.
- Keep the existing KYC name-match gate on the typed name (refund accounts must still belong to the verified identity).
- Invalidate in-flight lookups on dependency changes so a stale verify cannot repopulate `"OK"`.
- Reject saving the unresolved sentinel on `PUT /api/v1/refund-account` so a crafted client cannot persist `"OK"`.

Resolved bank names (and true KYC mismatches on resolved names) are unchanged.

### Self-review

- [x] Reviewed diff against acceptance criteria (including failure cases)
- [x] CodeRabbit / CI green


### References

- Follows https://github.com/paycrest/noblocks/pull/698 (recipient manual name when verify returns `"OK"`)


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

Automated:

```
pnpm exec jest __tests__/refundAccountRoute.test.ts __tests__/kes-mpesa-channel.test.ts --no-coverage
# 2 suites, 23 tests passed (includes new OK-sentinel 422 case + existing isUnresolvedAccountName coverage)
```

CI: all 3 checks passed on `cfe0d4d`.

Manual:

1. Onramp → Add refund account → KES M-PESA with an identifier that verifies as `"OK"` → name input + warning appear; no green `ok` tick; Add account stays disabled until a KYC-matching name is typed.
2. Same flow with a resolvable mobile number → resolved name + tick still shown; mismatch still blocks when the resolved name is not the user.
3. Cancel / change account number while a verify is in flight → no stale `"OK"` / name write.


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f25c202-d16d-45ff-8c96-3c2e54e442a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f25c202-d16d-45ff-8c96-3c2e54e442a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for manually entering a refund account holder name when automatic verification cannot resolve it.
  - Manual names are checked against KYC identity information before submission.
  - Added explanatory validation feedback for unresolved account names.

- **Bug Fixes**
  - Unresolved account-name results now block refund account submission with a clear verification error.
  - Improved handling of stale account-name lookups and reset account verification state more consistently, including when the modal closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->