### PR TITLE
fix(refund): ask for account name when verify returns OK

### DIFF
--- a/__tests__/kes-mpesa-channel.test.ts
+++ b/__tests__/kes-mpesa-channel.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeSavedRecipientChannel,
   getKesMpesaInstitutionLabel,
   KES_MPESA_INSTITUTION_CODE,
+  isUnresolvedAccountName,
 } from "../app/utils";
 import type { InstitutionProps } from "../app/types";
 
@@ -172,3 +173,28 @@ describe("KES M-Pesa virtual institution split", () => {
     ).toBe(true);
   });
 });
+
+describe("unresolved account names", () => {
+  it("treats the aggregator's OK sentinel as unresolved, in any casing", () => {
+    expect(isUnresolvedAccountName("OK")).toBe(true);
+    expect(isUnresolvedAccountName("ok")).toBe(true);
+    expect(isUnresolvedAccountName("Ok")).toBe(true);
+    expect(isUnresolvedAccountName("  OK  ")).toBe(true);
+  });
+
+  it("treats empty and missing names as unresolved", () => {
+    expect(isUnresolvedAccountName("")).toBe(true);
+    expect(isUnresolvedAccountName("   ")).toBe(true);
+    expect(isUnresolvedAccountName(undefined)).toBe(true);
+    expect(isUnresolvedAccountName(null)).toBe(true);
+  });
+
+  it("keeps real account names, including ones that merely contain 'ok'", () => {
+    expect(isUnresolvedAccountName("John Doe")).toBe(false);
+    expect(isUnresolvedAccountName("Okon Effiong")).toBe(false);
+    expect(isUnresolvedAccountName("Koko Stores")).toBe(false);
+    // A name that is only "ok" plus more text is a real name.
+    expect(isUnresolvedAccountName("OK Foods Ltd")).toBe(false);
+  });
+});
+

--- a/__tests__/refundAccountRoute.test.ts
+++ b/__tests__/refundAccountRoute.test.ts
@@ -169,6 +169,22 @@ describe("handlePutRefundAccount", () => {
     expect(mockedFrom).not.toHaveBeenCalled();
   });
 
+  it("returns 422 when accountName is the unresolved OK sentinel", async () => {
+    const res = await handlePutRefundAccount(
+      putRequest({ ...validBody, accountName: "OK" }),
+    );
+    expect(res).toEqual({
+      status: 422,
+      body: {
+        success: false,
+        error:
+          "Account name could not be verified. Please enter the name on the account.",
+      },
+    });
+    expect(mockedResolveInstitution).not.toHaveBeenCalled();
+    expect(mockedFrom).not.toHaveBeenCalled();
+  });
+
   it("upserts with wallet+currency conflict target and aggregator institution name", async () => {
     mockedResolveInstitution.mockResolvedValue({
       ok: true,

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -114,6 +114,13 @@ export function AddRefundAccountModal({
       setIsFetchingAccountName(false);
     };
 
+    // Bail before scheduling when the modal is closed so a late response cannot
+    // write a stale name that briefly shows on the next open.
+    if (!isOpen) {
+      stopWithoutLookup(null);
+      return;
+    }
+
     if (!selectedInstitution || !accountNumber) {
       setAccountNumberError(null);
       stopWithoutLookup(null);
@@ -186,7 +193,7 @@ export function AddRefundAccountModal({
     }, 800);
 
     return () => clearTimeout(timeoutId);
-  }, [selectedInstitution, accountNumber, currency, kycFullName]);
+  }, [isOpen, selectedInstitution, accountNumber, currency, kycFullName]);
 
   const filteredInstitutions = useMemo(
     () => filterAndSortInstitutions(institutions, bankSearchTerm),

--- a/app/components/AddRefundAccountModal.tsx
+++ b/app/components/AddRefundAccountModal.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DialogTitle } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowDown01Icon, ArrowLeft02Icon, Tick02Icon } from "hugeicons-react";
+import {
+  ArrowDown01Icon,
+  ArrowLeft02Icon,
+  InformationSquareIcon,
+  Tick02Icon,
+} from "hugeicons-react";
 import { ImSpinner } from "react-icons/im";
 import { AnimatedModal, AnimatedFeedbackItem } from "@/app/components/AnimatedComponents";
 import { SearchInput } from "@/app/components/recipient/SearchInput";
 import { InputError } from "@/app/components/InputError";
 import type { InstitutionProps, RefundAccountDetails } from "@/app/types";
-import { classNames, getOfframpAccountIdentifierPlaceholder, filterAndSortInstitutions, NGN_NUBAN_LENGTH } from "@/app/utils";
+import {
+  classNames,
+  getOfframpAccountIdentifierPlaceholder,
+  filterAndSortInstitutions,
+  NGN_NUBAN_LENGTH,
+  isUnresolvedAccountName,
+} from "@/app/utils";
 import { fetchAccountName } from "@/app/api/aggregator";
 import { primaryBtnClasses, secondaryBtnClasses } from "@/app/components/Styles";
 import { useKYC } from "@/app/context";
@@ -53,10 +64,12 @@ export function AddRefundAccountModal({
   const [accountName, setAccountName] = useState("");
   const [accountNumber, setAccountNumber] = useState("");
   const [isFetchingAccountName, setIsFetchingAccountName] = useState(false);
+  const [isAccountNameEditable, setIsAccountNameEditable] = useState(false);
   const [accountNumberError, setAccountNumberError] = useState<string | null>(null);
   const [accountNameError, setAccountNameError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const nameRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -65,6 +78,7 @@ export function AddRefundAccountModal({
     setFormError(null);
     setAccountNumberError(null);
     setAccountNameError(null);
+    setIsAccountNameEditable(false);
     if (initial) {
       const fromList = institutions.find(
         (i) => i.code === initial.institutionCode,
@@ -89,11 +103,20 @@ export function AddRefundAccountModal({
 
   // Auto-fetch account name when institution + account number are ready
   useEffect(() => {
-    setAccountName("");
-    setAccountNameError(null);
+    // Invalidate any in-flight lookup on every dependency change (including bail-outs).
+    const requestId = ++nameRequestIdRef.current;
+
+    const stopWithoutLookup = (message: string | null) => {
+      setIsAccountNameEditable(false);
+      setAccountName("");
+      setAccountNameError(message);
+      setFormError(null);
+      setIsFetchingAccountName(false);
+    };
 
     if (!selectedInstitution || !accountNumber) {
       setAccountNumberError(null);
+      stopWithoutLookup(null);
       return;
     }
 
@@ -102,17 +125,25 @@ export function AddRefundAccountModal({
     if (currency === "NGN") {
       if (digits.length === 0) {
         setAccountNumberError(null);
+        stopWithoutLookup(null);
         return;
       }
       if (digits.length !== NGN_NUBAN_LENGTH) {
         setAccountNumberError(
           `Please enter a valid 10-digit account number (${digits.length} entered).`,
         );
+        stopWithoutLookup(null);
         return;
       }
     }
 
+    // Drop any previously resolved/typed name so a stale success tick cannot
+    // suppress a later error, and so "OK" is never left visible while we re-verify.
+    setIsAccountNameEditable(false);
+    setAccountName("");
     setAccountNumberError(null);
+    setAccountNameError(null);
+    setFormError(null);
     setIsFetchingAccountName(true);
 
     const timeoutId = setTimeout(async () => {
@@ -121,27 +152,60 @@ export function AddRefundAccountModal({
           institution: selectedInstitution.code,
           accountIdentifier: digits || accountNumber,
         });
-        setAccountName(name);
-        if (kycFullName && !accountNameMatchesKyc(kycFullName, name)) {
-          setFormError(REFUND_NAME_MISMATCH_MESSAGE);
-        } else {
+        if (requestId !== nameRequestIdRef.current) return;
+
+        if (isUnresolvedAccountName(name)) {
+          // Same path as RecipientDetailsForm (#698): verification soft-failed with
+          // the "OK" sentinel. Ask for the account holder's name instead of showing
+          // "ok" with a green tick (and then failing KYC match against "OK").
+          setIsAccountNameEditable(true);
+          setAccountName("");
           setFormError(null);
+          setAccountNameError(null);
+        } else {
+          setIsAccountNameEditable(false);
+          setAccountName(name);
+          if (kycFullName && !accountNameMatchesKyc(kycFullName, name)) {
+            setFormError(REFUND_NAME_MISMATCH_MESSAGE);
+          } else {
+            setFormError(null);
+          }
+          setAccountNameError(null);
         }
-        setAccountNameError(null);
       } catch {
+        if (requestId !== nameRequestIdRef.current) return;
+        setIsAccountNameEditable(false);
+        setAccountName("");
         setAccountNameError("Account not found. Check the number and bank.");
+        setFormError(null);
       } finally {
-        setIsFetchingAccountName(false);
+        if (requestId === nameRequestIdRef.current) {
+          setIsFetchingAccountName(false);
+        }
       }
     }, 800);
 
     return () => clearTimeout(timeoutId);
-  }, [selectedInstitution, accountNumber, currency]);
+  }, [selectedInstitution, accountNumber, currency, kycFullName]);
 
   const filteredInstitutions = useMemo(
     () => filterAndSortInstitutions(institutions, bankSearchTerm),
     [institutions, bankSearchTerm],
   );
+
+  const applyManualAccountName = (value: string) => {
+    setAccountName(value);
+    const trimmed = value.trim();
+    if (!trimmed || isUnresolvedAccountName(trimmed)) {
+      setFormError(null);
+      return;
+    }
+    if (kycFullName && !accountNameMatchesKyc(kycFullName, trimmed)) {
+      setFormError(REFUND_NAME_MISMATCH_MESSAGE);
+    } else {
+      setFormError(null);
+    }
+  };
 
   const handleAddAccount = async () => {
     setFormError(null);
@@ -155,8 +219,12 @@ export function AddRefundAccountModal({
       return;
     }
     const name = accountName.trim();
-    if (!name) {
-      setFormError("Account name could not be verified. Check the account number.");
+    if (!name || isUnresolvedAccountName(name)) {
+      setFormError(
+        isAccountNameEditable
+          ? "Please enter the name on the account."
+          : "Account name could not be verified. Check the account number.",
+      );
       return;
     }
     // Must belong to the same person as the verified KYC profile. Only block here when we already
@@ -191,11 +259,14 @@ export function AddRefundAccountModal({
     }
   };
 
+  const resolvedNameReady =
+    accountName.trim().length > 0 && !isUnresolvedAccountName(accountName);
+
   const allFieldsFilled =
     selectedInstitution !== null &&
     accountNumber.trim().length > 0 &&
     !accountNumberError &&
-    accountName.trim().length > 0 &&
+    resolvedNameReady &&
     !isFetchingAccountName &&
     !accountNameError;
 
@@ -287,7 +358,7 @@ export function AddRefundAccountModal({
                 ) : null}
               </div>
 
-              {/* 3. Account name — auto-fetched */}
+              {/* 3. Account name — auto-fetched, or typed when verification returns OK */}
               <AnimatePresence mode="wait">
                 {isFetchingAccountName ? (
                   <div className="flex items-center gap-1 text-gray-400 dark:text-white/50">
@@ -295,6 +366,35 @@ export function AddRefundAccountModal({
                       <ImSpinner className="size-4 animate-spin" />
                       <p className="text-xs">Verifying account name...</p>
                     </AnimatedFeedbackItem>
+                  </div>
+                ) : isAccountNameEditable ? (
+                  <div className="w-full space-y-2">
+                    <label
+                      htmlFor="refund-account-name"
+                      className="mb-2 block text-sm font-semibold text-neutral-900 dark:text-white"
+                    >
+                      Account name
+                    </label>
+                    <input
+                      id="refund-account-name"
+                      type="text"
+                      autoComplete="off"
+                      value={accountName}
+                      onChange={(e) => applyManualAccountName(e.target.value)}
+                      placeholder="Enter your account name"
+                      className={classNames(
+                        "w-full rounded-xl border bg-white px-3.5 py-3 text-sm text-neutral-900 outline-none transition-colors placeholder:text-neutral-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/25 dark:bg-[#202020] dark:text-white dark:placeholder:text-white/40 dark:focus:border-blue-500 dark:focus:ring-blue-500/35",
+                        "border-neutral-200 dark:border-white/[0.12]",
+                      )}
+                    />
+                    <div className="flex w-full min-w-0 items-start gap-2 rounded-xl bg-warning-background/[8%] px-3 py-2">
+                      <InformationSquareIcon className="mt-0.5 size-5 shrink-0 text-warning-foreground dark:text-warning-text" />
+                      <p className="min-w-0 flex-1 break-words text-xs font-light leading-snug text-warning-foreground dark:text-warning-text">
+                        We couldn&apos;t confirm this account name. Enter the
+                        name on the account — it must match your verified
+                        identity.
+                      </p>
+                    </div>
                   </div>
                 ) : accountName ? (
                   <AnimatedFeedbackItem className="justify-between text-gray-400 dark:text-white/50">

--- a/app/lib/refund-account-api.ts
+++ b/app/lib/refund-account-api.ts
@@ -9,7 +9,10 @@ import {
   accountNameMatchesKyc,
   REFUND_NAME_MISMATCH_MESSAGE,
 } from "@/app/lib/name-matching";
-import { normalizeRefundAccountCurrency } from "@/app/utils";
+import {
+  isUnresolvedAccountName,
+  normalizeRefundAccountCurrency,
+} from "@/app/utils";
 import { resolveInstitutionForCurrency } from "@/app/lib/refund-account-institutions";
 
 type RefundAccountBody = {
@@ -178,6 +181,19 @@ export async function handlePutRefundAccount(
           success: false,
           error:
             "Missing required fields: currency, institution, institutionCode, accountIdentifier, accountName",
+        },
+      };
+    }
+
+    // Reject the verify-account "OK" sentinel. Clients must collect a real account
+    // name when verification cannot resolve one (same policy as recipient form #698).
+    if (isUnresolvedAccountName(accountName)) {
+      return {
+        status: 422,
+        body: {
+          success: false,
+          error:
+            "Account name could not be verified. Please enter the name on the account.",
         },
       };
     }

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -202,6 +202,24 @@ export function normalizeSavedRecipientChannel(
 }
 
 /**
+ * True when /verify-account could not resolve a holder name.
+ *
+ * The aggregator answers the literal string `"OK"` when no provider can resolve
+ * an account holder. KES M-Pesa Till and Paybill hit this on every order — a
+ * Paybill lookup is structurally impossible, since the identifier is only the
+ * reference and the business number never reaches the PSP.
+ *
+ * `"OK"` is a sentinel, not a name, so the UI must collect one from the user rather than
+ * display it. The aggregator keeps a client-supplied name in that case
+ * (ResolveAccountNameAfterValidation), and the on-chain path noblocks uses never
+ * re-validates it at all.
+ */
+export function isUnresolvedAccountName(name?: string | null): boolean {
+  const value = (name ?? "").trim();
+  return value === "" || value.toLowerCase() === "ok";
+}
+
+/**
  * True when two saved recipients are the same payout target.
  *
  * Mirrors the saved-recipient unique key exactly. Channel matters because Send


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Jira Issue

Jira Issue: <!-- Atlassian MCP unavailable in this environment; ticket not filed -->

### Description

PR #698 taught the recipient form to treat the aggregator's `"OK"` verify-account sentinel as unresolved and collect a typed name. The **Add refund account** modal still treated `"OK"` as a real account name: it rendered `ok` next to the green tick, then blocked save with the KYC mismatch message ("doesn't match your verified identity") because `"OK"` never matches the user's verified name.

This change mirrors that recipient path for refund accounts (re-applied onto `stable` after #700 was reverted by #701):

- When verification returns an unresolved name (`OK` / empty), show an **Account name** input plus a warning that the name could not be confirmed.
- Keep the existing KYC name-match gate on the typed name (refund accounts must still belong to the verified identity).
- Invalidate in-flight lookups on dependency changes (and when the modal closes) so a stale verify cannot repopulate `"OK"`.
- Reject saving the unresolved sentinel on `PUT /api/v1/refund-account` so a crafted client cannot persist `"OK"`.
- Bring `isUnresolvedAccountName` onto `stable` (same helper as #698 on main, which has not been merged to `stable` yet).

Resolved bank names (and true KYC mismatches on resolved names) are unchanged.

### Self-review

- [x] Reviewed diff against acceptance criteria (including failure cases)
- [x] CI green (CodeRabbit auto-review skipped on `stable`; comment `@coderabbitai review` to run)


### References

- Follows https://github.com/paycrest/noblocks/pull/698 (recipient manual name when verify returns `"OK"`)
- Replaces reverted https://github.com/paycrest/noblocks/pull/700 (reverted in #701)


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

Automated:

```
pnpm exec jest __tests__/refundAccountRoute.test.ts __tests__/kes-mpesa-channel.test.ts --no-coverage
# 2 suites, 23 tests passed (OK-sentinel 422 + isUnresolvedAccountName coverage)
```

CI: all checks passed on `bd5ff15`.

Manual:

1. Onramp → Add refund account → KES M-PESA with an identifier that verifies as `"OK"` → name input + warning appear; no green `ok` tick; Add account stays disabled until a KYC-matching name is typed.
2. Same flow with a resolvable mobile number → resolved name + tick still shown; mismatch still blocks when the resolved name is not the user.
3. Cancel / change account number (or close the modal) while a verify is in flight → no stale `"OK"` / name write.


### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main` (`stable`)
- [ ] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f25c202-d16d-45ff-8c96-3c2e54e442a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f25c202-d16d-45ff-8c96-3c2e54e442a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

