### PR TITLE
feat(bridge): enhance error handling in BridgeQuoteCard and Axios req…

### DIFF
--- a/app/components/bridge/BridgeForm.tsx
+++ b/app/components/bridge/BridgeForm.tsx
@@ -91,7 +91,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   const starknet = useStarknet();
   const { allTokens } = useTokens();
   const { signDelegationAuthorization } = useDelegationContractAuth();
-  const { refreshBalance } = useBalance();
+  const { refreshBalance, crossChainBalances } = useBalance();
   const { rate: cngnRate } = useCNGNRate({
     network: CNGN_CROSS_CHAIN_QUOTE_NETWORK,
   });
@@ -132,6 +132,21 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     10,
   );
 
+  const fromBalance = useMemo(() => {
+    if (!from) return 0;
+    const entry = crossChainBalances.find(
+      (b) => b.network.chain.name === from.network,
+    );
+    const key = from.token.toUpperCase();
+    return (
+      entry?.balances.rawBalances?.[key] ??
+      entry?.balances.rawBalances?.[from.token] ??
+      entry?.balances.balances[key] ??
+      entry?.balances.balances[from.token] ??
+      0
+    );
+  }, [from, crossChainBalances]);
+
   const parsedAmount = Number(amount);
   const minConvertResult = from
     ? minOffRampTokenAmount(from.token, cngnRate)
@@ -146,10 +161,16 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     Number.isFinite(parsedAmount) &&
     parsedAmount > 0 &&
     parsedAmount < minConvertAmount;
+  const hasInsufficientBalance =
+    !!from &&
+    Number.isFinite(parsedAmount) &&
+    parsedAmount > 0 &&
+    parsedAmount > fromBalance;
   const convertMinMessage =
     amountBelowMin && from && minConvertAmount !== null
       ? `Minimum amount is ${formatNumberWithCommas(minConvertAmount)} ${from.token}`
       : null;
+  const amountHasError = amountBelowMin || hasInsufficientBalance;
 
   const embeddedWallet = wallets.find((w) => w.walletClientType === "privy");
 
@@ -202,6 +223,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
       !routeUnsupported &&
       !!(evmAddress || starknetAddress) &&
       !cngnRateUnavailable &&
+      !hasInsufficientBalance &&
       (minConvertAmount === null || parsedAmount >= minConvertAmount),
     getAccessToken,
     getInjectedToken:
@@ -381,6 +403,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
   // treating that as a dead route showed this error to every user before they connected.
   const noRailAvailable =
     !cngnRateUnavailable &&
+    !hasInsufficientBalance &&
     (routeUnsupported ||
       (quoteFetched &&
         !quoteLoading &&
@@ -397,6 +420,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
     !noRailAvailable &&
     !isQuoteExpired &&
     !amountBelowMin &&
+    !hasInsufficientBalance &&
     !!quote &&
     !quoteLoading &&
     !quoteError &&
@@ -451,7 +475,7 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                 engine={engine}
                 timeEstimate={timeEstimate}
                 isQuoteLoading={quoteLoading}
-                amountHasError={amountBelowMin}
+                amountHasError={amountHasError}
               />
 
               {fromNetworkName !== toNetworkName && (
@@ -470,7 +494,13 @@ export const BridgeForm: React.FC<BridgeFormProps> = ({
                 </div>
               )}
 
-              {amountBelowMin && convertMinMessage && (
+              {hasInsufficientBalance && (
+                <div className="rounded-xl border border-red-100 bg-red-50 p-3 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
+                  Insufficient balance
+                </div>
+              )}
+
+              {!hasInsufficientBalance && amountBelowMin && convertMinMessage && (
                 <div className="rounded-xl border border-red-100 bg-red-50 p-3 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
                   {convertMinMessage}
                 </div>

--- a/app/components/bridge/BridgeQuoteCard.tsx
+++ b/app/components/bridge/BridgeQuoteCard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import type { BridgeQuote } from "@/app/lib/bridge";
+import { isSuppressed, mapToUserMessage } from "@/app/lib/errorMessages";
 import { formatTokenAmount } from "@/app/utils";
 
 interface BridgeQuoteCardProps {
@@ -54,9 +55,11 @@ export const BridgeQuoteCard: React.FC<BridgeQuoteCardProps> = ({
   }
 
   if (error) {
+    const userMsg = mapToUserMessage(error);
+    if (isSuppressed(userMsg)) return null;
     return (
       <div className="break-words rounded-xl bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-600 dark:text-red-400 border border-red-100 dark:border-red-900/30">
-        {error.message || "Failed to fetch quote. Please try again."}
+        {userMsg || "Unable to get a quote for this conversion. Please try again."}
       </div>
     );
   }

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -393,6 +393,26 @@ export function authHeaders(auth?: BridgeAuth | string | null): Record<string, s
   return a.token ? { Authorization: `Bearer ${a.token}` } : {};
 }
 
+/**
+ * Prefer the server's `error` / `message` over Axios's generic
+ * "Request failed with status code 4xx" so Convert can show a useful string.
+ */
+function extractAxiosServerMessage(err: unknown, fallback: string): string {
+  if (axios.isAxiosError(err)) {
+    const body = err.response?.data as { error?: unknown; message?: unknown } | undefined;
+    if (typeof body?.error === "string" && body.error.trim()) return body.error.trim();
+    if (typeof body?.message === "string" && body.message.trim()) return body.message.trim();
+  }
+  if (
+    err instanceof Error &&
+    err.message.trim() &&
+    !/^request failed with status code \d+$/i.test(err.message.trim())
+  ) {
+    return err.message.trim();
+  }
+  return fallback;
+}
+
 export class NearIntentsClient {
   /**
    * `withdrawFee` is already denominated in the destination asset — used as-is. `refundFee`
@@ -442,10 +462,19 @@ export class NearIntentsClient {
     auth: BridgeAuth | string | null | undefined,
     decimals: { origin: number; destination: number },
   ): Promise<BridgeQuote> {
-    const { data } = await axios.post("/api/bridge/near-intents/quote", params, {
-      headers: authHeaders(auth),
-    });
-    return this.normalizeQuote(data, params, decimals);
+    try {
+      const { data } = await axios.post("/api/bridge/near-intents/quote", params, {
+        headers: authHeaders(auth),
+      });
+      return this.normalizeQuote(data, params, decimals);
+    } catch (err) {
+      throw new Error(
+        extractAxiosServerMessage(
+          err,
+          "Unable to get a quote for this conversion. Please try again.",
+        ),
+      );
+    }
   }
 
   /** Re-requests with dry:false to get the real deposit address for execution. */
@@ -457,14 +486,26 @@ export class NearIntentsClient {
       dry: false,
       deadline: new Date(Date.now() + 600_000).toISOString(),
     };
-    const { data } = await axios.post("/api/bridge/near-intents/quote", freshParams, {
-      headers: authHeaders(auth),
-    });
-    // 1Click nests the address under data.quote.depositAddress (same shape normalizeQuote
-    // defends against) — reading only data.depositAddress misses it and throws spuriously.
-    const addr = data.quote?.depositAddress ?? data.depositAddress;
-    if (!addr) throw new Error("NEAR Intents did not return a deposit address");
-    return addr;
+    try {
+      const { data } = await axios.post("/api/bridge/near-intents/quote", freshParams, {
+        headers: authHeaders(auth),
+      });
+      // 1Click nests the address under data.quote.depositAddress (same shape normalizeQuote
+      // defends against) — reading only data.depositAddress misses it and throws spuriously.
+      const addr = data.quote?.depositAddress ?? data.depositAddress;
+      if (!addr) throw new Error("NEAR Intents did not return a deposit address");
+      return addr;
+    } catch (err) {
+      if (err instanceof Error && err.message === "NEAR Intents did not return a deposit address") {
+        throw err;
+      }
+      throw new Error(
+        extractAxiosServerMessage(
+          err,
+          "Unable to prepare this conversion. Please try again.",
+        ),
+      );
+    }
   }
 
   async getStatus(depositAddress: string, auth?: BridgeAuth | string | null): Promise<BridgeStatusResult> {

--- a/app/lib/bridge.ts
+++ b/app/lib/bridge.ts
@@ -400,15 +400,21 @@ export function authHeaders(auth?: BridgeAuth | string | null): Record<string, s
 function extractAxiosServerMessage(err: unknown, fallback: string): string {
   if (axios.isAxiosError(err)) {
     const body = err.response?.data as { error?: unknown; message?: unknown } | undefined;
-    if (typeof body?.error === "string" && body.error.trim()) return body.error.trim();
-    if (typeof body?.message === "string" && body.message.trim()) return body.message.trim();
+    // Same 120-char cap as pickServerMessage — keep Convert banners readable.
+    for (const value of [body?.error, body?.message]) {
+      const message = typeof value === "string" ? value.trim() : "";
+      if (message && message.length <= 120) return message;
+    }
   }
-  if (
-    err instanceof Error &&
-    err.message.trim() &&
-    !/^request failed with status code \d+$/i.test(err.message.trim())
-  ) {
-    return err.message.trim();
+  if (err instanceof Error) {
+    const message = err.message.trim();
+    if (
+      message &&
+      message.length <= 120 &&
+      !/^request failed with status code \d+$/i.test(message)
+    ) {
+      return message;
+    }
   }
   return fallback;
 }

--- a/app/lib/errorMessages.ts
+++ b/app/lib/errorMessages.ts
@@ -121,6 +121,23 @@ function isNetworkError(message: string, code: string): boolean {
   return matchesAny(message, NETWORK_ERROR_PATTERNS) || matchesAny(code, NETWORK_ERROR_PATTERNS);
 }
 
+/** Axios default copy like "Request failed with status code 400" — never show to users. */
+function isHttpStatusMessage(message: string): boolean {
+  return /^request failed with status code \d+$/i.test(message.trim());
+}
+
+function pickServerMessage(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null;
+  const body = data as Record<string, unknown>;
+  for (const key of ["error", "message"] as const) {
+    const value = body[key];
+    if (typeof value === "string" && value.trim().length > 0 && value.length <= 120) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
 /**
  * True when an error represents "aggregator could not match a liquidity provider"
  * for the requested corridor/amount. Matches on message OR error code.
@@ -163,10 +180,8 @@ export function mapToUserMessage(error: unknown): string {
       return ERROR_MESSAGES.SERVER;
     }
     if (status >= 400) {
-      const serverMsg = error.response.data?.message;
-      if (typeof serverMsg === "string" && serverMsg.length > 0 && serverMsg.length <= 120) {
-        return serverMsg;
-      }
+      const serverMsg = pickServerMessage(error.response.data);
+      if (serverMsg) return serverMsg;
       return ERROR_MESSAGES.CLIENT_REQUEST;
     }
   }
@@ -182,7 +197,8 @@ export function mapToUserMessage(error: unknown): string {
   }
 
   // 6. Prefer backend / library message when nothing else matched (e.g. aggregator rate errors)
-  if (message.trim()) {
+  // Skip Axios's generic status-code copy if it leaked through as a plain Error.
+  if (message.trim() && !isHttpStatusMessage(message)) {
     return message;
   }
 


### PR DESCRIPTION
### Jira Issue

Jira Issue: https://paycrest-io.atlassian.net/browse/KAN-801

### Description

Convert quote failures in the wallet showed Axios’s generic `Request failed with status code 400`, which hid the real upstream reason (e.g. missing `ONE_CLICK_JWT`, or NEAR’s temporary `$1,000` swap minimum). Confirm was also enabled when the entered amount exceeded wallet balance.

This PR:

- Surfaces human-readable quote errors instead of raw Axios status-code strings
- Blocks Confirm when the Convert amount is greater than the available from-token balance

Error messaging:

- Prefer server `error` / `message` from API responses when present (capped at 120 chars)
- Fall back to friendly copy when there is no usable server text
- Never show raw Axios status-code strings in the Convert quote banner

Balance guard:

- Hide Confirm and show **Insufficient balance** when amount > available balance
- Skip quote fetching while underfunded
- Style the amount field as an error (same pattern as below-min)

Implementation:

- `NearIntentsClient.getQuote` / `getDepositAddress` extract upstream messages before rethrowing (`app/lib/bridge.ts`)
- `mapToUserMessage` also reads `data.error`, and treats `Request failed with status code N` as non-user-facing (`app/lib/errorMessages.ts`)
- `BridgeQuoteCard` renders `mapToUserMessage(error)` for all Convert quote engines (`app/components/bridge/BridgeQuoteCard.tsx`)
- `BridgeForm` checks `crossChainBalances` against the entered amount before enabling Confirm / quoting (`app/components/bridge/BridgeForm.tsx`)

No API/contract changes. No breaking changes. Does not change routing, product mins, or liquidity. Execute-path error mapping is out of scope.

### Self-review

- [x] Reviewed diff against Jira acceptance criteria (including failure cases)
- [ ] CodeRabbit / CI green

### Testing

Manual (local noblocks, Convert in wallet):

1. Set `NEXT_PUBLIC_BRIDGE_ENABLED=true` and restart `pnpm dev`
2. Open wallet → Convert → Base USDC → BNB Smart Chain USDT
3. Without `ONE_CLICK_JWT`: banner shows `ONE_CLICK_JWT not configured` (not status 400)
4. With JWT and amount under NEAR’s temporary min: banner shows `Temporary swap limits: minimum swap amount is $1,000` (not status 400)
5. Enter an amount greater than wallet balance (e.g. 1001 with ~0.007 USDC): shows **Insufficient balance**, Confirm is hidden, no quote request
6. Enter an amount within balance (and above product min): Confirm appears when a quote is available; successful quotes still show amount out / fee as before

<img width="619" height="894" alt="Screenshot 2026-09-10 at 08 37 15" src="https://github.com/user-attachments/assets/fc9a33e1-1076-4a72-9b28-115eed50fe68" />

<img width="738" height="961" alt="Screenshot 2026-09-10 at 08 36 54" src="https://github.com/user-attachments/assets/ce3567e6-a108-4524-ae38-75a054d80803" />

<img width="583" height="863" alt="Screenshot 2026-09-10 at 09 10 19" src="https://github.com/user-attachments/assets/c2fb1d34-8a30-4e48-adb6-ed930d50fa7d" />


- [ ] This change adds test coverage for new/changed/fixed functionality

### Staging

- [ ] Staging noblocks checked (wallet and transaction flows)

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
- [x] If this PR adds a database migration, it follows expand/contract: the new code works against the **pre-migration** schema, the currently deployed code keeps working against the **post-migration** schema, and destructive changes (drops, renames, tightened constraints) are deferred until the old application version is no longer serving — migrations are applied around the deploy, not strictly before or after it


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bridge error messages by showing concise server-provided details when available.
  - Limited displayed server and native error messages to a readable length.
  - Replaced generic network or status text with clearer fallback messaging.
  - Suppressed errors that should not be displayed to users.
  - Preserved specific error handling for unavailable deposit addresses.
  - Improved consistency across quote and deposit-address request errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->